### PR TITLE
Prevent rendering before initialization is done

### DIFF
--- a/src/modules/BaElement.js
+++ b/src/modules/BaElement.js
@@ -91,6 +91,7 @@ export class BaElement extends HTMLElement {
 		});
 
 		this.initialize();
+		this._initialized = true;
 
 		this.render();
 	}
@@ -154,7 +155,7 @@ export class BaElement extends HTMLElement {
 	 * @protected
 	 */
 	render() {
-		if (!this.isRenderingSkipped()) {
+		if (this._initialized && !this.isRenderingSkipped()) {
 			this.onBeforeRender();
 			const template = this.createView();
 			renderLitHtml(template, this.getRenderTarget());

--- a/test/modules/BaElement.test.js
+++ b/test/modules/BaElement.test.js
@@ -155,6 +155,21 @@ describe('BaElement', () => {
 			expect(element.initializeCalled).toBe(1);
 			expect(element.onWindowLoadCalled).toBe(2);
 		});
+
+		it('does not call render() as long as not initialized', async () => {
+			const instance = new BaElementImpl();
+			spyOn(instance, 'onBeforeRender');
+			
+			instance.render();
+			
+			expect(instance.onBeforeRender).not.toHaveBeenCalled();
+			
+			//let's initialize the component
+			instance.connectedCallback();
+			
+			expect(instance.onBeforeRender).toHaveBeenCalledTimes(1);
+		});
+
 	});
 
 	describe('when state changed', () => {


### PR DESCRIPTION
Call of `render() ` should be skipped  as long as element/component not is initialized