### PR TITLE
Improve documentation of action creators

### DIFF
--- a/src/modules/contextMenue/store/contextMenue.action.js
+++ b/src/modules/contextMenue/store/contextMenue.action.js
@@ -1,3 +1,7 @@
+/**
+ * Action creators to change/update the properties of contextMenue state.
+ * @module contextMenue/action
+ */
 import { CONTEXT_MENUE_CLICK } from './contextMenue.reducer';
 import { $injector } from '../../../injection';
 
@@ -6,6 +10,10 @@ const getStore = () => {
 	return StoreService.getStore();
 };
 
+/**
+ * Opens the contextMenue.
+ * @function
+ */
 export const contextMenueOpen = (contextMenuData) => {
 	getStore().dispatch({
 		type: CONTEXT_MENUE_CLICK,
@@ -13,6 +21,10 @@ export const contextMenueOpen = (contextMenuData) => {
 	});
 };
 
+/**
+ * Closes the contextMenue.
+ * @function
+ */
 export const contextMenueClose = () => {
 	getStore().dispatch({
 		type: CONTEXT_MENUE_CLICK,

--- a/src/modules/map/store/olMap.action.js
+++ b/src/modules/map/store/olMap.action.js
@@ -1,3 +1,7 @@
+/**
+ * Action creators to change/update the properties of map state.
+ * @module map/action
+ */
 import { ZOOM_CHANGED, POSITION_CHANGED, ZOOM_POSITION_CHANGED, POINTER_POSITION_CHANGED } from './olMap.reducer';
 import { $injector } from '../../../injection';
 
@@ -6,8 +10,10 @@ const getStore = () => {
 	return StoreService.getStore();
 };
 
-
-
+/**
+ * Changes zoom level and the position.
+ * @function
+ */
 export const changeZoomAndPosition = (zoomPosition) => {
 	getStore().dispatch({
 		type: ZOOM_POSITION_CHANGED,
@@ -15,7 +21,10 @@ export const changeZoomAndPosition = (zoomPosition) => {
 	});
 };
 
-
+/**
+ * Changes zoom level.
+ * @function
+ */
 export const changeZoom = (zoom) => {
 	getStore().dispatch({
 		type: ZOOM_CHANGED,
@@ -24,6 +33,11 @@ export const changeZoom = (zoom) => {
 	});
 };
 
+
+/**
+ * Increases zoom level by one.
+ * @function
+ */
 export const increaseZoom = () => {
 
 	const { map: { zoom } } = getStore().getState();
@@ -34,6 +48,10 @@ export const increaseZoom = () => {
 	});
 };
 
+/**
+ * Decreases zoom level by one.
+ * @function
+ */
 export const decreaseZoom = () => {
 
 	const { map: { zoom } } = getStore().getState();
@@ -44,6 +62,10 @@ export const decreaseZoom = () => {
 	});
 };
 
+/**
+ * Changes the position.
+ * @function
+ */
 export const changePosition = (position) => {
 	getStore().dispatch({
 		type: POSITION_CHANGED,
@@ -51,6 +73,10 @@ export const changePosition = (position) => {
 	});
 };
 
+/**
+ * Updates the pointer position.
+ * @function
+ */
 export const updatePointerPosition = (position) => {
 	getStore().dispatch({
 		type: POINTER_POSITION_CHANGED,

--- a/src/modules/menue/store/sidePanel.action.js
+++ b/src/modules/menue/store/sidePanel.action.js
@@ -1,3 +1,7 @@
+/**
+ * Action creators to change/update the properties of sidePanel state.
+ * @module menue/action
+ */
 import { OPEN_CLOSED_CHANGED } from './sidePanel.reducer';
 import { $injector } from '../../../injection';
 
@@ -7,6 +11,10 @@ const getStore = () => {
 };
 
 
+/**
+ * Opens the sidePanel.
+ * @function
+ */
 export const openSidePanel = () => {
 	getStore().dispatch({
 		type: OPEN_CLOSED_CHANGED,
@@ -14,6 +22,10 @@ export const openSidePanel = () => {
 	});
 };
 
+/**
+ * Closes the sidePanel.
+ * @function
+ */
 export const closeSidePanel = () => {
 	getStore().dispatch({
 		type: OPEN_CLOSED_CHANGED,
@@ -22,8 +34,12 @@ export const closeSidePanel = () => {
 	});
 };
 
+/**
+ * Toggles the sidePanel.
+ * @function
+ */
 export const toggleSidePanel = () => {
-	const { sidePanel: { open } }  = getStore().getState();
+	const { sidePanel: { open } } = getStore().getState();
 	getStore().dispatch({
 		type: OPEN_CLOSED_CHANGED,
 		payload: !open

--- a/src/modules/modal/store/modal.action.js
+++ b/src/modules/modal/store/modal.action.js
@@ -1,3 +1,7 @@
+/**
+ * Action creators to change/update the properties of modal state.
+ * @module modal/action
+ */
 import { MODAL_CHANGED } from './modal.reducer';
 import { $injector } from '../../../injection';
 
@@ -6,16 +10,24 @@ const getStore = () => {
 	return StoreService.getStore();
 };
 
-export const openModal = (payload) => {	
+/**
+ * Opens the modal.
+ * @function
+ */
+export const openModal = (payload) => {
 	getStore().dispatch({
 		type: MODAL_CHANGED,
 		payload: payload
 	});
 };
 
+/**
+ * Closes the modal.
+ * @function
+ */
 export const closeModal = () => {
 	getStore().dispatch({
 		type: MODAL_CHANGED,
-		payload: { title:false, content:false }
+		payload: { title: false, content: false }
 	});
 };

--- a/src/modules/uiTheme/store/uiTheme.action.js
+++ b/src/modules/uiTheme/store/uiTheme.action.js
@@ -1,3 +1,7 @@
+/**
+ * Action creators to change/update the properties of uiTheme state.
+ * @module uiTheme/action
+ */
 import { THEME_CHANGED } from './uiTheme.reducer';
 import { $injector } from '../../../injection';
 
@@ -6,6 +10,10 @@ const getStore = () => {
 	return StoreService.getStore();
 };
 
+/**
+ * Changes the theme.
+ * @function
+ */
 export const changeTheme = (theme) => {
 	getStore().dispatch({
 		type: THEME_CHANGED,
@@ -13,6 +21,10 @@ export const changeTheme = (theme) => {
 	});
 };
 
+/**
+ * Toggles the theme.
+ * @function
+ */
 export const toggleTheme = () => {
 	const { uiTheme: { theme } } = getStore().getState();
 	const newTheme = (theme === 'dark') ? 'light' : 'dark';


### PR DESCRIPTION
In order to have the action creators within the documentation, we use the `@module` annotation with a value conforming to the pattern `${moduleName}/action`.
Have a look @ the generated docs...