### PR TITLE
Toggle element: make it possible to register the callback within the markup

### DIFF
--- a/src/modules/commons/components/toggle/Toggle.js
+++ b/src/modules/commons/components/toggle/Toggle.js
@@ -21,6 +21,11 @@ export class Toggle extends BaElement {
 		this._checked = this.getAttribute('checked') === 'true';
 		this._disabled = this.getAttribute('disabled') === 'true';
 		this.title = this.getAttribute('title') || '';
+		
+		// we pass the click event
+		this.addEventListener('click', () =>{
+			this._root.querySelector('label').click();
+		});
 	}
 
 

--- a/src/modules/commons/components/toggle/Toggle.js
+++ b/src/modules/commons/components/toggle/Toggle.js
@@ -16,8 +16,8 @@ export class Toggle extends BaElement {
 	 * @override
 	 */
 	initialize() {
-		//properties 'onChange', 'checked', 'disabled', 'title' are exposed via getter and setter
-		this._onChange = () => { };
+		//properties 'onToggle', 'checked', 'disabled', 'title' are exposed via getter and setter
+		this._onToggle = () => { };
 		this._checked = this.getAttribute('checked') === 'true';
 		this._disabled = this.getAttribute('disabled') === 'true';
 		this.title = this.getAttribute('title') || '';
@@ -30,9 +30,12 @@ export class Toggle extends BaElement {
 	createView() {
 
 		const onChange = (event) => {
-			this._onChange(event);
+			this.dispatchEvent(new CustomEvent('toggle', {
+				detail: { checked: event.target.checked }
+			}));
+			
+			this._onToggle(event);
 		};
-
 		const classes = {
 			disabled: this._disabled,
 			active: this._checked,
@@ -99,11 +102,11 @@ export class Toggle extends BaElement {
 		return this._checked;
 	}
 
-	set onChange(callback) {
-		this._onChange = callback;
+	set onToggle(callback) {
+		this._onToggle = callback;
 	}
 
-	get onChange() {
-		return this._onChange;
+	get onToggle() {
+		return this._onToggle;
 	}
 }

--- a/src/modules/header/components/Header.js
+++ b/src/modules/header/components/Header.js
@@ -28,21 +28,25 @@ export class Header extends BaElement {
 	}
 
 	createShowCase() {
-		const onClick0 = ()=> {
+		const onClick0 = () => {
 			changeZoomAndPosition({
 				zoom: 13,
 				position: this._coordinateService.fromLonLat([11.57245, 48.14021])
 			});
 		};
 
-		const onClick1 = ()  => {
+		const onClick1 = () => {
 			changeZoomAndPosition({
 				zoom: 11,
 				position: this._coordinateService.fromLonLat([11.081, 49.449])
 			});
 		};
+		const onToggle = (event) => {
+			// eslint-disable-next-line no-console
+			console.log('toggled ' + event.detail.checked);
+		};
 
-		return html `<p>Here we present components in random order that:</p>
+		return html`<p>Here we present components in random order that:</p>
 		<ul>
 		<li>are <i>common and reusable</i> components or <i>functional behaviors</i>, who can be added to or extend other components</li>
 		<li><i>feature</i> components, which have already been implemented, but have not yet been given the most suitable place...</li>
@@ -57,7 +61,7 @@ export class Header extends BaElement {
 					<ba-button id='button3' label='disabled' disabled=true></ba-button>
 		</div>
 		<p>Toggle-Button</p>
-		<div class='toggle' style="display: flex;justify-content: flex-start;"><ba-toggle title="Toggle"><span>Toggle me!</span></ba-toggle></div>
+		<div class='toggle' style="display: flex;justify-content: flex-start;"><ba-toggle title="Toggle" @toggle=${onToggle}><span>Toggle me!</span></ba-toggle></div>
 		<hr>
 		<h3>Specific components</h3>
 		<p>Theme-Toggle</p>
@@ -82,8 +86,8 @@ export class Header extends BaElement {
 			}
 		};
 
-		const showModalInfo = ()=> {
-			const payload = { title:'Showcase', content: this.createShowCase() };
+		const showModalInfo = () => {
+			const payload = { title: 'Showcase', content: this.createShowCase() };
 			openModal(payload);
 		};
 

--- a/src/modules/uiTheme/components/toggle/ThemeToggle.js
+++ b/src/modules/uiTheme/components/toggle/ThemeToggle.js
@@ -27,7 +27,7 @@ export class ThemeToggle extends BaElement {
 	onAfterRender(firsttime) {
 		if (firsttime) {
 			// register callback on toggle
-			this._root.querySelector('ba-toggle').onChange = () => {
+			this._root.querySelector('ba-toggle').onToggle = () => {
 				toggleTheme();
 			};
 		}

--- a/test/modules/commons/components/Toggle.test.js
+++ b/test/modules/commons/components/Toggle.test.js
@@ -156,16 +156,29 @@ describe('Toggle', () => {
 	});
 	describe('when clicked', () => {
 
-		it('calls the onChange callback', async () => {
+		it('calls the onToggle callback via property callback', async () => {
 
 			const element = await TestUtils.render(Toggle.tag);
-			element.onChange = jasmine.createSpy();
+			element.onToggle = jasmine.createSpy();
 
 
 			const label = element.shadowRoot.querySelector('label');
 			label.click();
 
-			expect(element.onChange).toHaveBeenCalled();
+			expect(element.onToggle).toHaveBeenCalled();
+		});
+
+		it('calls the onToggle callback via attribute callback', async () => {
+
+			spyOn(window, 'alert');
+			const element = await TestUtils.render(Toggle.tag, { onToggle: 'alert(\'called\')' });
+			element.onToggle = jasmine.createSpy();
+
+
+			const label = element.shadowRoot.querySelector('label');
+			label.click();
+
+			expect(window.alert).toHaveBeenCalledWith('called');
 		});
 
 		it('does nothing when disabled', async () => {

--- a/test/modules/commons/components/Toggle.test.js
+++ b/test/modules/commons/components/Toggle.test.js
@@ -161,9 +161,7 @@ describe('Toggle', () => {
 			const element = await TestUtils.render(Toggle.tag);
 			element.onToggle = jasmine.createSpy();
 
-
-			const label = element.shadowRoot.querySelector('label');
-			label.click();
+			element.click();
 
 			expect(element.onToggle).toHaveBeenCalled();
 		});
@@ -174,20 +172,16 @@ describe('Toggle', () => {
 			const element = await TestUtils.render(Toggle.tag, { onToggle: 'alert(\'called\')' });
 			element.onToggle = jasmine.createSpy();
 
-
-			const label = element.shadowRoot.querySelector('label');
-			label.click();
+			element.click();
 
 			expect(window.alert).toHaveBeenCalledWith('called');
 		});
 
 		it('does nothing when disabled', async () => {
 			const element = await TestUtils.render(Toggle.tag, { disabled: true });
-
 			element.onClick = jasmine.createSpy();
 
-			const label = element.shadowRoot.querySelector('label');
-			label.click();
+			element.click();
 
 			expect(element.onClick).not.toHaveBeenCalled();
 		});

--- a/test/modules/uiTheme/components/toggle/ThemeToggle.test.js
+++ b/test/modules/uiTheme/components/toggle/ThemeToggle.test.js
@@ -43,7 +43,7 @@ describe('ThemeToggle', () => {
 		it('changes the theme', async () => {
 			const element = await setup();
 			
-			element.shadowRoot.querySelector('ba-toggle').shadowRoot.querySelector('input').click();
+			element.shadowRoot.querySelector('ba-toggle').click();
 
 			expect(store.getState().uiTheme.theme).toBe('light');
 			expect(element.shadowRoot.querySelector('ba-toggle').getAttribute('checked')).toBe('false');


### PR DESCRIPTION
It's now possible to register the callback by an event listener within the markup:
`<ba-toggle  @toggle=${onToggle}><span>Toggle me!</span></ba-toggle>`

Have also a look at our showroom...