### PR TITLE
Prevent unnecessary re-rendering

### DIFF
--- a/src/modules/commons/components/button/Button.js
+++ b/src/modules/commons/components/button/Button.js
@@ -59,8 +59,10 @@ export class Button extends BaElement {
 	}
 
 	set disabled(value) {
-		this._disabled = value;
-		this.render();
+		if(value !== this.disabled){
+			this._disabled = value;
+			this.render();
+		}
 	}
 
 	get disabled() {


### PR DESCRIPTION
In order to re-render the view only when the state has actually changed, we have to compare new values with existing values
before we call `render()`.

This is a generic  recipe and valid for all components, which expose internal state via a setter method.