### PR TITLE
add share-function in ShareService

### DIFF
--- a/src/modules/map/components/olMap/OlMap.js
+++ b/src/modules/map/components/olMap/OlMap.js
@@ -116,12 +116,18 @@ export class OlMap extends BaElement {
 
 	_buildContextMenueData(evt) {
 		const coord = this._map.getEventCoordinate(evt.originalEvent);
+
+		const shareUrl = window.location.href;
 		const copyToClipboard = () => this._shareService.copyToClipboard(coord).catch(() => this.log('Cannot copy the coordinate to clipboard.'));
+		// todo: implement (and use) permalink-service, shortener-service to get a usable URL
+		// todo: add translation-service with i18n-olMap-provider
+		const shareWith = () => this._shareService.share('BA4', 'Use the platform', shareUrl);
 		const firstCommand = { label: 'Copy Coordinates', shortCut: '[CTRL] + C', action: copyToClipboard };
 		const secondCommand = { label: 'Hello', action: () => this.log('Hello World!') };
+		const thirdCommand = { label: 'Share', action: shareWith };
 		return {
 			pointer: { x: evt.originalEvent.pageX, y: evt.originalEvent.pageY },
-			commands: [firstCommand, secondCommand]
+			commands: [firstCommand, secondCommand, thirdCommand]
 		};
 	}
 

--- a/src/services/ShareService.js
+++ b/src/services/ShareService.js
@@ -1,9 +1,38 @@
+import { html } from 'lit-html';
+import { openModal } from './../modules/modal/store/modal.action';
+import { $injector } from '../injection';
 export class ShareService {
 	constructor(_navigator = navigator) {
+		const { TranslationService } = $injector.inject('TranslationService');
+		this._translationService = TranslationService;
 		this._navigator = _navigator;
 	}
 
 	copyToClipboard(textToCopy) {
 		return this._navigator.clipboard.writeText(textToCopy);
+	}
+
+	async share(title = '', text = '', urlToShare) {
+
+		const shareData = {
+			title:title,
+			text:text,
+			url:urlToShare
+		};
+
+		try {
+			await this._navigator.share(shareData);			
+		}
+		catch(err) {			
+			const translate = (key) => this._translationService.translate(key);
+			// todo: move alternativeShare-Content to new ba-element component
+			const alternativeShare = html`<div>
+				<label>${translate('share_link_to_share')}:</label>
+				<input type="text" value=${urlToShare} readonly></input>
+				<ba-button title=${translate('share_copy_to_clipboard')} label=${translate('share_copy_to_clipboard')}></ba-button>
+			</div>`;
+			const payload = { title: 'Showcase', content:alternativeShare };
+			openModal(payload);
+		}
 	}
 } 

--- a/test/modules/map/components/olMap/OlMap.test.js
+++ b/test/modules/map/components/olMap/OlMap.test.js
@@ -178,7 +178,7 @@ describe('OlMap', () => {
 			const actualPointer = store.getState().contextMenue.data.pointer;
 
 			expect(actualPointer).toEqual({ x: 10, y: 0 });
-			expect(actualCommands.length).toBe(2);
+			expect(actualCommands.length).toBe(3);
 			expect(actualCommands[0].label).toBe('Copy Coordinates');
 			expect(actualCommands[0].action).not.toBeUndefined();
 			expect(actualCommands[0].shortCut).toBe('[CTRL] + C');

--- a/test/service/ShareService.test.js
+++ b/test/service/ShareService.test.js
@@ -1,9 +1,13 @@
 import { ShareService } from '../../src/services/ShareService';
+import { $injector } from '../../src/injection';
 
 describe('ShareService', () => {
 
 	describe('copy to clipboard', () => {
 		it('calls clipboard api', () => {
+			$injector
+				.registerSingleton('TranslationService', { translate: (key) => key });
+
 			const mockNavigator = { clipboard: {} };
 			mockNavigator.clipboard.writeText = jasmine.createSpy();
 


### PR DESCRIPTION
Adding a share-function to ShareService for application-wide usage.

First implementation is - as a starting point - the map context-menu.