### PR TITLE
Custom SRS management

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6103,6 +6103,11 @@
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
       "dev": true
     },
+    "mgrs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mgrs/-/mgrs-1.0.0.tgz",
+      "integrity": "sha1-+5FYjnjJACVnI5XLQLJffNatGCk="
+    },
     "micromatch": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -7333,6 +7338,15 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
+    },
+    "proj4": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.7.0.tgz",
+      "integrity": "sha512-UVhulf8m70/dREOBrJagWq8cDYUgjQUWILRqys/gqo/+ZLeNB/04zbtPhJbz8+cCPzZNQMychfBaWUCP60U9mQ==",
+      "requires": {
+        "mgrs": "1.0.0",
+        "wkt-parser": "^1.2.4"
+      }
     },
     "promise-inflight": {
       "version": "1.0.1",
@@ -9907,7 +9921,6 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -9951,7 +9964,6 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2"
           }
@@ -9961,7 +9973,6 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -10628,6 +10639,11 @@
           "dev": true
         }
       }
+    },
+    "wkt-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.2.4.tgz",
+      "integrity": "sha512-ZzKnc7ml/91fOPh5bANBL4vUlWPIYYv11waCtWTkl2TRN+LEmBg60Q1MA8gqV4hEp4MGfSj9JiHz91zw/gTDXg=="
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "dependencies": {
     "lit-html": "^1.3.0",
     "ol": "^6.5.0",
+    "proj4": "^2.7.0",
     "redux": "^4.0.5",
     "redux-query-sync": "^0.1.10"
   },

--- a/src/injection/config.js
+++ b/src/injection/config.js
@@ -19,7 +19,7 @@ $injector
 	.register('HttpService', HttpService)
 	.registerSingleton('ConfigService', new ProcessEnvConfigService())
 	.registerSingleton('TranslationService', new TranslationService)
-	.register('CoordinateService', OlCoordinateService)
+	.registerSingleton('CoordinateService', new OlCoordinateService())
 	.registerSingleton('EnvironmentService', new EnvironmentService(window))
 	.registerSingleton('StoreService', new StoreService())
 	.registerSingleton('GeoResourceService', new GeoResourceService(loadBvvGeoResources))

--- a/src/modules/footer/components/mapInfo/MapInfo.js
+++ b/src/modules/footer/components/mapInfo/MapInfo.js
@@ -24,7 +24,7 @@ export class MapInfo extends BaElement {
 	initialize() {
 		// let's listen for map_clicked -events
 		window.addEventListener('map_clicked', (evt) => {
-			alert('click @ ' + this._coordinateService.stringifyYX(
+			alert('click @ ' + this._coordinateService.stringify(
 				this._coordinateService.toLonLat(evt.detail), 3));
 		});
 
@@ -38,7 +38,7 @@ export class MapInfo extends BaElement {
 
 
 		const pointerPosition4326 = pointerPosition
-			? this._coordinateService.stringifyYX(
+			? this._coordinateService.stringify(
 				this._coordinateService.toLonLat(pointerPosition), 3)
 			: '';
 

--- a/src/services/OlCoordinateService.js
+++ b/src/services/OlCoordinateService.js
@@ -68,7 +68,7 @@ export class OlCoordinateService {
 	/**
 	 * Transforms a coordinate in the source srid to a coordinate in the target srid
 	 * @param {Coordinate}  [coordinate] 
-	 * @param {numbet} sourceSrid srid of the current coordinate
+	 * @param {number} sourceSrid srid of the current coordinate
 	 * @param {number} targetSrid srid of the transformed coordinate
 	 * @returns {Coordinate} transformed coordinate
 	 */

--- a/src/services/provider/proj4.provider.js
+++ b/src/services/provider/proj4.provider.js
@@ -1,0 +1,8 @@
+import proj4 from 'proj4';
+import { register } from 'ol/proj/proj4';
+
+export const loadBvvDefinitions = () => {
+	proj4.defs('EPSG:25832', '+proj=utm +zone=32 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +axis=neu');
+	proj4.defs('EPSG:25833', '+proj=utm +zone=33 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +axis=neu');
+	register(proj4);
+};

--- a/src/services/provider/stringifyCoords.provider.js
+++ b/src/services/provider/stringifyCoords.provider.js
@@ -1,0 +1,12 @@
+import { createStringXY } from 'ol/coordinate';
+
+/**
+ * A function that returns a function which itsself takes a coordinate and returns a string representation.
+ *
+ * @typedef {function():(function(Coordinate) : (string) stringifyCoordProvider
+ */
+
+
+export const defaultStringifyFunction = (srid, options = { digits: 3 }) => {
+	return createStringXY(options.digits);
+};

--- a/test/service/OlCoordinateService.test.js
+++ b/test/service/OlCoordinateService.test.js
@@ -1,47 +1,73 @@
 /* eslint-disable no-undef */
 import { OlCoordinateService } from '../../src/services/OlCoordinateService';
 import { fromLonLat, toLonLat, transformExtent } from 'ol/proj';
+import proj4 from 'proj4';
+import { register } from 'ol/proj/proj4';
 
 describe('OlCoordinateService', () => {
 
 	let instanceUnderTest;
 	beforeEach(() => {
-		instanceUnderTest = new OlCoordinateService();
+		const proj4Provider = () => {
+			proj4.defs('EPSG:25832', '+proj=utm +zone=32 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +axis=neu');
+			proj4.defs('EPSG:25833', '+proj=utm +zone=33 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +axis=neu');
+			register(proj4);
+		};
+
+		const stringifyCoordsProvider = () => {
+			return coordinate => coordinate[0] + ', ' + coordinate[1];
+		};
+
+		instanceUnderTest = new OlCoordinateService(proj4Provider, stringifyCoordsProvider);
 	});
 
 	describe('transforms coordinates', () => {
+		describe('with default projection', () => {
 
-		it('from EPSG:4326 to EPSG:3857', () => {
-			const initialCooord4326 = [11.57245, 48.14021];
-			const coord3857 = fromLonLat(initialCooord4326);
+			it('from EPSG:4326 to EPSG:3857', () => {
+				const initialCooord4326 = [11.57245, 48.14021];
+				const coord3857 = fromLonLat(initialCooord4326);
 
-			const coord4326 = instanceUnderTest.toLonLat(coord3857);
+				const coord4326 = instanceUnderTest.toLonLat(coord3857);
 
-			expect(coord4326[0]).toBeCloseTo(initialCooord4326[0], 3);
-			expect(coord4326[1]).toBeCloseTo(initialCooord4326[1], 3);
+				expect(coord4326[0]).toBeCloseTo(initialCooord4326[0], 3);
+				expect(coord4326[1]).toBeCloseTo(initialCooord4326[1], 3);
+			});
+
+			it('from EPSG:3857 to EPSG:4326', () => {
+				const initialCooord3857 = [1288239.2412306187, 6130212.561641981];
+				const coord4326 = toLonLat(initialCooord3857);
+
+				const coord3857 = instanceUnderTest.fromLonLat(coord4326);
+
+				expect(coord3857[0]).toBeCloseTo(initialCooord3857[0], 3);
+				expect(coord3857[1]).toBeCloseTo(initialCooord3857[1], 3);
+			});
 		});
 
-		it('from EPSG:3857 to EPSG:4326', () => {
-			const initialCooord3857 = [1288239.2412306187, 6130212.561641981];
-			const coord4326 = toLonLat(initialCooord3857);
+		describe('with custom projection', () => {
+		
 
-			const coord3857 = instanceUnderTest.fromLonLat(coord4326);
+			it('from custom EPSG (here 25823) to custom EPSG (here 25833)', () => {
+				const coord25832 = [1288239.2412306187, 6130212.561641981];
+				const coord25833 = instanceUnderTest.transform(coord25832, 25832, 25833);
 
-			expect(coord3857[0]).toBeCloseTo(initialCooord3857[0], 3);
-			expect(coord3857[1]).toBeCloseTo(initialCooord3857[1], 3);
+				expect(coord25833.length).toBe(2);
+				expect(coord25833).not.toEqual(coord25832);
+			});
+
+
+			it('throws an error when srid is not supported', () => {
+				const coord25832 = [1288239.2412306187, 6130212.561641981];
+				
+				expect(() => {
+					instanceUnderTest.transform(coord25832, 25832, 25834);
+				})
+					.toThrowError(/Unsupported SRID: 25834/);
+			});
 		});
-
-		it('from EPSG:3857 to EPSG:25832', () => {
-
-			expect(() => instanceUnderTest.to25832([1288239.2412306187, 6130212.561641981])).toThrowError(/Not yet implemented/);
-		});
-
-		it('from EPSG:25832 to EPSG:3857', () => {
-
-			expect(() => instanceUnderTest.from25832([676696, 5367913])).toThrowError(/Not yet implemented/);
-		});
-
 	});
+
 
 	describe('transforms extents', () => {
 
@@ -58,7 +84,7 @@ describe('OlCoordinateService', () => {
 		});
 
 		it('transforms from EPSG:3857 to EPSG:4326', () => {
-			const initialExtent3857 =  [1288239.2412306187, 6130212.561641981, 1299371.190309946, 6146910.663709761];
+			const initialExtent3857 = [1288239.2412306187, 6130212.561641981, 1299371.190309946, 6146910.663709761];
 			const extent4326 = transformExtent(initialExtent3857, 'EPSG:3857', 'EPSG:4326');
 
 			const extent3857 = instanceUnderTest.fromLonLatExtent(extent4326);
@@ -70,14 +96,14 @@ describe('OlCoordinateService', () => {
 		});
 	});
 
-	describe('stringifies', () => {
+	describe('stringifiy', () => {
 
-		it('lon/lat coordinates', () => {
+		it('stringifies with the default provider lon/lat coordinates', () => {
 			const initialCooord4326 = [11.57245, 48.14021];
 
-			const string = instanceUnderTest.stringifyYX(initialCooord4326, 3);
+			const string = instanceUnderTest.stringify(initialCooord4326, 3);
 
-			expect(string).toBe('11.572, 48.140');
+			expect(string).toBe('11.57245, 48.14021');
 		});
 	});
 });

--- a/test/service/provider/proj4.provider.test.js
+++ b/test/service/provider/proj4.provider.test.js
@@ -1,0 +1,15 @@
+import { loadBvvDefinitions } from '../../../src/services/provider/proj4.provider';
+import { get } from 'ol/proj';
+
+describe('Proj4 provider', () => {
+
+	describe('Bvv specific provider', () => {
+
+		it('it registers BVV specific definitions', () => {
+			loadBvvDefinitions();
+
+			expect(get('EPSG:25832').getCode()).toBe('EPSG:25832');
+			expect(get('EPSG:25833').getCode()).toBe('EPSG:25833');
+		});
+	});
+});

--- a/test/service/provider/stringifyCoords.provider.test.js
+++ b/test/service/provider/stringifyCoords.provider.test.js
@@ -1,0 +1,16 @@
+import { defaultStringifyFunction } from '../../../src/services/provider/stringifyCoords.provider';
+
+describe('StringifyCoord provider', () => {
+
+	describe('default provider', () => {
+
+		it('it registers Bvv specific definitions', () => {
+
+			const initialCooord4326 = [11.57245, 48.14021];
+
+			const string = defaultStringifyFunction()(initialCooord4326, { digits: 3 });
+
+			expect(string).toBe('11.572, 48.140');
+		});
+	});
+});


### PR DESCRIPTION
Added custom SRS support.

The BvvProvider registers definitions for 25823 and 25833.

Example for using it in ol:

```
import { get } from 'ol/proj';


get('EPSG:25832') //just an example, later we will use the MapService to get the wanted id of the srs


```

Example of transforming a coordinate:

```
coordinateService.transform(coord25832, 25832, 25833);

```