### PR TITLE
Rename mapservice method and include a "label" property

### DIFF
--- a/src/services/MapService.js
+++ b/src/services/MapService.js
@@ -42,10 +42,10 @@ export class MapService {
 
 	/**
 	 *All availavle SRIDs for use within the UI.
-	 @returns {Array<number>} srids
+	 @returns {Array<SridDefinition>} srids
 	 */
-	getSridsForView() {
-		return this._definitions.sridsForView;
+	getSridDefinitionsForView() {
+		return this._definitions.sridDefinitionsForView;
 	}
 
 	/**

--- a/src/services/provider/mapDefinitions.provider.js
+++ b/src/services/provider/mapDefinitions.provider.js
@@ -6,15 +6,22 @@
  */
 
 /**
+ * Meta data for a srid
+ * @typedef {Object} SridDefinition
+ * @property {string} label label
+ * @property {number} code srid
+ */
+
+/**
  * Provider for map releated meta data
  * @returns {MapDefinitions} meta data 
  */
 export const getBvvMapDefinitions = () => {
 	return {
-		defaultExtent : [995772.9694449581, 5982715.763684852, 1548341.2904285304, 6544564.28740462],
+		defaultExtent: [995772.9694449581, 5982715.763684852, 1548341.2904285304, 6544564.28740462],
 		srid: 3857,
-		defaultSridForView:  25832,
-		sridsForView :[25832, 4326],
+		defaultSridForView: 25832,
+		sridDefinitionsForView: [{ label: 'UTM', code: 25832 }, { label: 'WGS84', code: 4326 }],
 		defaultGeodeticSrid: 25832
 	};
 };

--- a/test/service/MapService.test.js
+++ b/test/service/MapService.test.js
@@ -19,8 +19,8 @@ describe('MapService', () => {
 			return {
 				defaultExtent: [0, 1, 2, 3],
 				srid: 3857,
-				defaultSridForView:  4326,
-				sridsForView :[4326, 9999],
+				defaultSridForView: 4326,
+				sridDefinitionsForView: [{ label: 'WGS88', code: 4326 }, { label: 'Something', code: 9999 }],
 				defaultGeodeticSrid: 9999
 			};
 		};
@@ -62,7 +62,7 @@ describe('MapService', () => {
 	it('provides an array of srids for the view', () => {
 		const instanceUnderTest = setup();
 
-		expect(instanceUnderTest.getSridsForView()).toEqual([4326, 9999]);
+		expect(instanceUnderTest.getSridDefinitionsForView()).toEqual([{ label: 'WGS88', code: 4326 }, { label: 'Something', code: 9999 }]);
 	});
 
 	it('provides the internal srid of the map', () => {

--- a/test/service/provider/mapDefinitions.provider.test.js
+++ b/test/service/provider/mapDefinitions.provider.test.js
@@ -5,12 +5,12 @@ describe('MapDefinitions provider', () => {
 	describe('Bvv mapDefinitions provider', () => {
 
 		it('provides map related meta data', () => {
-			const { defaultExtent, srid, defaultSridForView, sridsForView, defaultGeodeticSrid } = getBvvMapDefinitions();
+			const { defaultExtent, srid, defaultSridForView, sridDefinitionsForView, defaultGeodeticSrid } = getBvvMapDefinitions();
 
 			expect(defaultExtent).toEqual([995772.9694449581, 5982715.763684852, 1548341.2904285304, 6544564.28740462]);
 			expect(srid).toBe(3857);
 			expect(defaultSridForView).toBe(25832);
-			expect(sridsForView).toEqual([25832, 4326]);
+			expect(sridDefinitionsForView).toEqual([{ label: 'UTM', code: 25832 }, { label: 'WGS84', code: 4326 }]);
 			expect(defaultGeodeticSrid).toEqual(25832);
 		});
 	});


### PR DESCRIPTION
`MapService#getSridDefinitionsForView` returns  `SridDefinition` objects, which contain a label