### PR TITLE
add a switch for device related snapTolerance

### DIFF
--- a/src/modules/map/components/olMap/handler/measure/OlMeasurementHandler.js
+++ b/src/modules/map/components/olMap/handler/measure/OlMeasurementHandler.js
@@ -26,9 +26,10 @@ export class OlMeasurementHandler extends OlLayerHandler {
 	//this handler could be statefull
 	constructor() {
 		super(MEASUREMENT_LAYER_ID);
-		const { TranslationService, MapService } = $injector.inject('TranslationService', 'MapService');
+		const { TranslationService, MapService, EnvironmentService } = $injector.inject('TranslationService', 'MapService', 'EnvironmentService');
 		this._translationService = TranslationService;
 		this._mapService = MapService;
+		this._environmentService = EnvironmentService;
 		this._vectorLayer = null;
 		this._draw = false;			
 		this._activeSketch = null;		
@@ -95,7 +96,7 @@ export class OlMeasurementHandler extends OlLayerHandler {
 			this._helpTooltip = this._createOverlay({ offset: [15, 0], positioning: 'center-left' }, MeasurementOverlayTypes.HELP);
 			const source = this._vectorLayer.getSource();			
 			this._draw = this._createInteraction(source);			
-			this._snap = new Snap({ source: source, pixelTolerance:4 });
+			this._snap = new Snap({ source: source, pixelTolerance:this._getSnapTolerancePerDevice() });
 			this._addOverlayToMap(olMap, this._helpTooltip);			
 			this._pointerMoveListener = olMap.on('pointermove', pointerMoveHandler);
 			this._keyboardListener = document.addEventListener('keyup', (e) => removeLastPoint(this._draw, e));
@@ -263,5 +264,12 @@ export class OlMeasurementHandler extends OlLayerHandler {
 		measurementOverlay.value = value;
 		measurementOverlay.geometry = geometry;
 		overlay.setPosition(measurementOverlay.position);							
+	}
+
+	_getSnapTolerancePerDevice() {
+		if (this._environmentService.isTouch()) {
+			return 12;
+		}
+		return 4;
 	}
 }

--- a/test/modules/map/components/olMap/handler/measure/OlMeasurementHandler.test.js
+++ b/test/modules/map/components/olMap/handler/measure/OlMeasurementHandler.test.js
@@ -106,52 +106,26 @@ describe('OlMeasurementHandler', () => {
 		
 	});
 
-	describe('when activated over olMap', () => {
-		
-		const initialCenter = fromLonLat([11.57245, 48.14021]);
-
-		const setupMap =  () => {
-			return new Map({
-				layers: [
-					new TileLayer({
-						source: new OSM(),
-					}),
-					new TileLayer({
-						source: new TileDebug(),
-					})],
-				target: 'map',
-				view: new View({
-					center: initialCenter,
-					zoom: 1,
-				}),
-			});
+	describe('when using EnvironmentService for snapTolerance', () => {
 			
-		};
-
-		it('uses EnvironmentService for snapTolerance', () => {
-			const classUnderTest = new OlMeasurementHandler();			
-			const environmentSpy = spyOn(environmentServiceMock, 'isTouch');
-			const map =  setupMap();
-
-			classUnderTest.activate(map);
-			expect(environmentSpy).toHaveBeenCalled();			
-		});
-
 		it('isTouch() resolves in higher snapTolerance', () => {
 			const classUnderTest = new OlMeasurementHandler();
-			environmentServiceMock.isTouch = () => true;
-			
+			const environmentSpy = spyOn(environmentServiceMock, 'isTouch').and.returnValue(true);
+								
 			expect(classUnderTest._getSnapTolerancePerDevice()).toBe(12);			
+			expect(environmentSpy).toHaveBeenCalled();	
 		});
 
 		it('isTouch() resolves in lower snapTolerance', () => {
 			const classUnderTest = new OlMeasurementHandler();
-			environmentServiceMock.isTouch = () => false;
-			
+			const environmentSpy = spyOn(environmentServiceMock, 'isTouch').and.returnValue(false);
+								
 			expect(classUnderTest._getSnapTolerancePerDevice()).toBe(4);			
+			expect(environmentSpy).toHaveBeenCalled();	
 		});
 
 	});
+
 	describe('when draw a line', () => {
 		const initialCenter = fromLonLat([11.57245, 48.14021]);
 

--- a/test/modules/map/components/olMap/handler/measure/OlMeasurementHandler.test.js
+++ b/test/modules/map/components/olMap/handler/measure/OlMeasurementHandler.test.js
@@ -16,9 +16,12 @@ import { register } from 'ol/proj/proj4';
 import { MEASUREMENT_LAYER_ID } from '../../../../../../../src/modules/map/store/layers.action';
 
 
+const environmentServiceMock = { isTouch: () => false };
+
 TestUtils.setupStoreAndDi({ }, );
 $injector.registerSingleton('TranslationService', { translate: (key) => key });
 $injector.registerSingleton('MapService', { getSrid: () => 3857, getDefaultGeodeticSrid: () => 25832 });
+$injector.registerSingleton('EnvironmentService', environmentServiceMock);
 
 proj4.defs('EPSG:25832', '+proj=utm +zone=32 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +axis=neu');
 register(proj4);
@@ -99,9 +102,56 @@ describe('OlMeasurementHandler', () => {
 			expect(map.removeOverlay).toHaveBeenCalledTimes(4);
 			expect(classUnderTest._overlays.length).toBe(0);
 		});	
+
+		
 	});
 
+	describe('when activated over olMap', () => {
+		
+		const initialCenter = fromLonLat([11.57245, 48.14021]);
 
+		const setupMap =  () => {
+			return new Map({
+				layers: [
+					new TileLayer({
+						source: new OSM(),
+					}),
+					new TileLayer({
+						source: new TileDebug(),
+					})],
+				target: 'map',
+				view: new View({
+					center: initialCenter,
+					zoom: 1,
+				}),
+			});
+			
+		};
+
+		it('uses EnvironmentService for snapTolerance', () => {
+			const classUnderTest = new OlMeasurementHandler();			
+			const environmentSpy = spyOn(environmentServiceMock, 'isTouch');
+			const map =  setupMap();
+
+			classUnderTest.activate(map);
+			expect(environmentSpy).toHaveBeenCalled();			
+		});
+
+		it('isTouch() resolves in higher snapTolerance', () => {
+			const classUnderTest = new OlMeasurementHandler();
+			environmentServiceMock.isTouch = () => true;
+			
+			expect(classUnderTest._getSnapTolerancePerDevice()).toBe(12);			
+		});
+
+		it('isTouch() resolves in lower snapTolerance', () => {
+			const classUnderTest = new OlMeasurementHandler();
+			environmentServiceMock.isTouch = () => false;
+			
+			expect(classUnderTest._getSnapTolerancePerDevice()).toBe(4);			
+		});
+
+	});
 	describe('when draw a line', () => {
 		const initialCenter = fromLonLat([11.57245, 48.14021]);
 


### PR DESCRIPTION
adding a private getter-method for snaptolerance depending on
environment information (isTouch) to deliver a better draw-behavior in
small areas on Desktop-Environments on the one hand and
better first-point or last-point snaps on Touch-Environments