### PR TITLE
Add possibiltiy to observe discrete state changes

### DIFF
--- a/src/modules/BaElement.js
+++ b/src/modules/BaElement.js
@@ -73,6 +73,8 @@ export class BaElement extends HTMLElement {
 		this._state = {};
 
 		this._rendered = false;
+
+		this._observer = [];
 	}
 
 	/**
@@ -142,6 +144,7 @@ export class BaElement extends HTMLElement {
 
 		if (!equals(this._state, extractedState)) {
 			this._state = extractedState;
+			this._observer.forEach(o => o());
 			this.onStateChanged();
 		}
 	}
@@ -252,4 +255,33 @@ export class BaElement extends HTMLElement {
 		}
 	}
 
+
+	/**
+	 * Registers an observer for a field / property of the state (see: {@link BaElement#extractState})
+	 * Observers are called right after {@link BaElement#extractState}
+	 * @protected
+	 * @param {string} name Name of the observed field
+	 * @param {function(changedState)} onChange A function that will be called when the observed field has changed
+	 */
+	_observe(name, onChange) {
+		const createObserver = (name, onChange) => {
+			let currentState = this._state[name];
+
+			return () => {
+				if (this._state[name]) {
+					const nextState = this._state[name];
+					if (!equals(nextState, currentState)) {
+						currentState = nextState;
+						onChange(currentState);
+					}
+				}
+				else {
+					console.warn('\'' + name + '\' is not a field in the state of this BaElement');
+				}
+			};
+
+		};
+
+		this._observer.push(createObserver(name, onChange));
+	}
 }

--- a/src/modules/BaElement.js
+++ b/src/modules/BaElement.js
@@ -257,13 +257,13 @@ export class BaElement extends HTMLElement {
 
 
 	/**
-	 * Registers an observer for a field / property of the state (see: {@link BaElement#extractState})
+	 * Registers an observer for a field / property of the state of this element (see: {@link BaElement#extractState}).
 	 * Observers are called right after {@link BaElement#extractState}
 	 * @protected
 	 * @param {string} name Name of the observed field
 	 * @param {function(changedState)} onChange A function that will be called when the observed field has changed
 	 */
-	_observe(name, onChange) {
+	observe(name, onChange) {
 		const createObserver = (name, onChange) => {
 			let currentState = this._state[name];
 

--- a/src/modules/BaElement.js
+++ b/src/modules/BaElement.js
@@ -1,5 +1,6 @@
 import { render as renderLitHtml } from 'lit-html';
 import { $injector } from '../injection';
+import { equals } from '../utils/storeUtils';
 
 /**
  * Abstract Base-Class for all BaElements.
@@ -139,8 +140,7 @@ export class BaElement extends HTMLElement {
 
 		const extractedState = this.extractState(this._storeService.getStore().getState());
 
-		// maybe we should use Lo.isEqual later, but for now it does the job
-		if (JSON.stringify(this._state) !== JSON.stringify(extractedState)) {
+		if (!equals(this._state, extractedState)) {
 			this._state = extractedState;
 			this.onStateChanged();
 		}

--- a/src/modules/map/components/olMap/handler/measure/OlMeasurementHandler.js
+++ b/src/modules/map/components/olMap/handler/measure/OlMeasurementHandler.js
@@ -10,7 +10,7 @@ import { MeasurementOverlayTypes } from './MeasurementOverlay';
 import { measureStyleFunction, generateSketchStyleFunction } from './StyleUtils';
 import { getPartitionDelta } from './GeometryUtils';
 import { MeasurementOverlay } from './MeasurementOverlay';
-import { MEASUREMENT_LAYER_ID } from '../../../../store/layers.action';
+import { MEASUREMENT_LAYER_ID } from '../../../../store/measurement.observer';
 
 if (!window.customElements.get(MeasurementOverlay.tag)) {
 	window.customElements.define(MeasurementOverlay.tag, MeasurementOverlay);

--- a/src/modules/map/store/layers.action.js
+++ b/src/modules/map/store/layers.action.js
@@ -5,10 +5,6 @@
 import { LAYER_MODIFIED, LAYER_ADDED, LAYER_REMOVED, BACKGROUND_CHANGED } from './layers.reducer';
 import { $injector } from '../../../injection';
 
-/**
- * Id of the layer used for measurement interaction
- */
-export const MEASUREMENT_LAYER_ID = 'measurement_layer';
 
 /**
  * Reflects the state of a layer.

--- a/src/modules/map/store/layers.reducer.js
+++ b/src/modules/map/store/layers.reducer.js
@@ -1,5 +1,3 @@
-import { ACTIVE_CHANGED as MEASUREMENT_ACTIVE_CHANGED } from './measurement.reducer';
-import { MEASUREMENT_LAYER_ID } from './layers.action';
 export const LAYER_ADDED = 'layer/added';
 export const LAYER_REMOVED = 'layer/removed';
 export const LAYER_MODIFIED = 'layer/modified';
@@ -132,15 +130,6 @@ export const layersReducer = (state = initialState, action) => {
 				background: payload
 			};
 		}
-		case MEASUREMENT_ACTIVE_CHANGED: {
-			if (payload) {
-				return addLayer(state, { id: MEASUREMENT_LAYER_ID, properties: { constraints: { hidden: true, alwaysTop: true } } });
-			}
-			else {
-				return removeLayer(state, MEASUREMENT_LAYER_ID);
-			}
-		}
-
 	}
 
 	return state;

--- a/src/modules/map/store/measurement.observer.js
+++ b/src/modules/map/store/measurement.observer.js
@@ -1,0 +1,25 @@
+import { observe } from '../../../utils/storeUtils';
+import { addLayer, removeLayer } from './layers.action';
+
+/**
+ * Id of the layer used for measurement interaction
+ */
+export const MEASUREMENT_LAYER_ID = 'measurement_layer';
+
+export const registerMeasurementObserver = (store) => {
+
+	const extract = (state) => {
+		return state.measurement.active;
+
+	};
+	const onChange = (changedState) => {
+		if (changedState) {
+			addLayer(MEASUREMENT_LAYER_ID, { constraints: { hidden: true, alwaysTop: true } });
+		}
+		else {
+			removeLayer(MEASUREMENT_LAYER_ID);
+		}
+	};
+
+	observe(store, extract, onChange);
+};

--- a/src/services/StoreService.js
+++ b/src/services/StoreService.js
@@ -8,6 +8,7 @@ import { layersReducer } from '../modules/map/store/layers.reducer';
 import { mapContextMenuReducer } from '../modules/map/store/mapContextMenu.reducer';
 import ReduxQuerySync from 'redux-query-sync';
 import { measurementReducer } from '../modules/map/store/measurement.reducer';
+import { registerMeasurementObserver as registerMeasurementObserver } from '../modules/map/store/measurement.observer';
 
 
 
@@ -71,21 +72,22 @@ export class StoreService {
 			position: positionReducer,
 			sidePanel: sidePanelReducer,
 			contextMenue: contextMenueReducer,
-			modal:modalReducer,
+			modal: modalReducer,
 			uiTheme: uiThemeReducer,
 			layers: layersReducer,
 			mapContextMenu: mapContextMenuReducer,
 			measurement: measurementReducer
 		});
 
-		this.store = createStore(rootReducer, storeEnhancer);
+		this._store = createStore(rootReducer, storeEnhancer);
+
+		registerMeasurementObserver(this._store);
 	}
 
 	/**
 	 * Returns the store.
 	 */
 	getStore() {
-		return this.store;
-
+		return this._store;
 	}
 }

--- a/src/utils/storeUtils.js
+++ b/src/utils/storeUtils.js
@@ -28,7 +28,7 @@ export const observe = (store, extract, onChange, ignoreInitialState = true) => 
 };
 
 /**
- * Returns the result of a comparision. If both values are objects,
+ * Returns the result of a comparision between two values. If both values are objects,
  * a deep comparision is done, otherwise a shallow one.
  * @function
  * @param {object|string|number} value0 

--- a/src/utils/storeUtils.js
+++ b/src/utils/storeUtils.js
@@ -1,0 +1,44 @@
+/**
+ * Registers an observer for state changes of the store.
+ * @function
+ * @param {object} store The redux store
+ * @param {function(state)} extract A function that extract a portion (single value or a object) from the current state which will be observed for comparision
+ * @param {function(changedState)} onChange A function that will be called when the extracted state has changed
+ * @param {boolean|true} ignoreInitialState A boolean which indicate, if the callback should be initially called with the current state immediately after the observer has been registered
+ * @returns  A function that unsubscribes the observer
+ */
+export const observe = (store, extract, onChange, ignoreInitialState = true) => {
+	const initialFlag = Object.freeze({});
+	let currentState = initialFlag;
+
+	const handleChange = () => {
+		const nextState = extract(store.getState());
+		if (!equals(nextState, currentState)) {
+			const callCallback = (currentState !== initialFlag || !ignoreInitialState);
+			currentState = nextState;
+			if (callCallback) {
+				onChange(currentState);
+			}
+		}
+	};
+
+	const unsubscribe = store.subscribe(handleChange);
+	handleChange();
+	return unsubscribe;
+};
+
+/**
+ * Returns the result of a comparision. If both values are objects,
+ * a deep comparision is done, otherwise a shallow one.
+ * @function
+ * @param {object|string|number} value0 
+ * @param {object|string|number} value1 
+ * @returns {boolean} true if both values are equal
+ */
+export const equals = (value0, value1) => {
+	if (typeof value0 === 'object' && typeof value1 === 'object') {
+		// maybe we should use Lo.isEqual later, but for now it does the job
+		return JSON.stringify(value0) === JSON.stringify(value1);
+	}
+	return value0 === value1;
+};

--- a/test/modules/BaElement.test.js
+++ b/test/modules/BaElement.test.js
@@ -128,7 +128,7 @@ describe('BaElement', () => {
 	});
 
 	describe('when initialized', () => {
-		
+
 		it('renders the view', async () => {
 			const element = await TestUtils.render(BaElementImpl.tag);
 
@@ -159,14 +159,14 @@ describe('BaElement', () => {
 		it('does not call render() as long as not initialized', async () => {
 			const instance = new BaElementImpl();
 			spyOn(instance, 'onBeforeRender');
-			
+
 			instance.render();
-			
+
 			expect(instance.onBeforeRender).not.toHaveBeenCalled();
-			
+
 			//let's initialize the component
 			instance.connectedCallback();
-			
+
 			expect(instance.onBeforeRender).toHaveBeenCalledTimes(1);
 		});
 
@@ -174,11 +174,11 @@ describe('BaElement', () => {
 			const instance = new BaElementImpl();
 			const onBeforeRenderSpy = spyOn(instance, 'onBeforeRender');
 			const onAfterRenderSpy = spyOn(instance, 'onAfterRender');
-			
+
 			//let's initialize the component
 			instance.connectedCallback();
 			instance.render();
-			
+
 			expect(instance.onBeforeRender).toHaveBeenCalledWith(true);
 			expect(instance.onAfterRender).toHaveBeenCalledWith(true);
 
@@ -208,6 +208,24 @@ describe('BaElement', () => {
 			expect(element.onRenderCalled).toBe(8);
 			expect(element.onAfterRenderCalled).toBe(9);
 			expect(element.shadowRoot.innerHTML.includes('42')).toBeTrue();
+		});
+
+		it('calls registered observer', async () => {
+			const element = await TestUtils.render(BaElementImpl.tag);
+			const elementStateIndexCallback = jasmine.createSpy();
+			const someUnknownFieldCallback = jasmine.createSpy();
+			const warnSpy = spyOn(console, 'warn');
+			element._observe('elementStateIndex', elementStateIndexCallback);
+			element._observe('someUnknowField', someUnknownFieldCallback);
+
+
+			store.dispatch({
+				type: INDEX_CHANGED,
+				payload: 42
+			});
+
+			expect(elementStateIndexCallback).toHaveBeenCalledOnceWith(42);
+			expect(warnSpy).toHaveBeenCalledOnceWith('\'someUnknowField\' is not a field in the state of this BaElement');
 		});
 	});
 });

--- a/test/modules/BaElement.test.js
+++ b/test/modules/BaElement.test.js
@@ -215,8 +215,8 @@ describe('BaElement', () => {
 			const elementStateIndexCallback = jasmine.createSpy();
 			const someUnknownFieldCallback = jasmine.createSpy();
 			const warnSpy = spyOn(console, 'warn');
-			element._observe('elementStateIndex', elementStateIndexCallback);
-			element._observe('someUnknowField', someUnknownFieldCallback);
+			element.observe('elementStateIndex', elementStateIndexCallback);
+			element.observe('someUnknowField', someUnknownFieldCallback);
 
 
 			store.dispatch({

--- a/test/modules/map/components/olMap/OlMap.test.js
+++ b/test/modules/map/components/olMap/OlMap.test.js
@@ -8,11 +8,13 @@ import MapEventType from 'ol/MapEventType';
 import { $injector } from '../../../../../src/injection';
 import { layersReducer } from '../../../../../src/modules/map/store/layers.reducer';
 import { WmsGeoResource } from '../../../../../src/services/domain/geoResources';
-import { addLayer, modifyLayer, removeLayer, MEASUREMENT_LAYER_ID } from '../../../../../src/modules/map/store/layers.action';
+import { addLayer, modifyLayer, removeLayer } from '../../../../../src/modules/map/store/layers.action';
 import { activate as activateMeasurement, deactivate as deactivateMeasurement } from '../../../../../src/modules/map/store/measurement.action';
 import { changeZoomAndCenter, fit } from '../../../../../src/modules/map/store/position.action';
 import { simulateMapEvent, simulateMouseEvent } from './mapTestUtils';
 import VectorLayer from 'ol/layer/Vector';
+import { MEASUREMENT_LAYER_ID, registerMeasurementObserver } from '../../../../../src/modules/map/store/measurement.observer';
+import { measurementReducer } from '../../../../../src/modules/map/store/measurement.reducer';
 
 window.customElements.define(OlMap.tag, OlMap);
 
@@ -61,6 +63,9 @@ describe('OlMap', () => {
 				active: [],
 				background: null
 			},
+			measurement:{
+				active:false
+			}
 		};
 		const combinedState = {
 			...defaultState,
@@ -70,6 +75,7 @@ describe('OlMap', () => {
 		store = TestUtils.setupStoreAndDi(combinedState, {
 			position: positionReducer,
 			layers: layersReducer,
+			measurement: measurementReducer
 		});
 
 
@@ -319,6 +325,8 @@ describe('OlMap', () => {
 			const activateSpy = spyOn(measurementHandlerMock, 'activate').and.returnValue(olLayer);
 			const deactivateSpy = spyOn(measurementHandlerMock, 'deactivate').and.returnValue(olLayer);
 			const element = await setup();
+			//in this case we need the measurement oberver, because it adds the measurement layer to the store
+			registerMeasurementObserver(store);
 			const map = element._map;
 
 			activateMeasurement();

--- a/test/modules/map/components/olMap/handler/measure/OlMeasurementHandler.test.js
+++ b/test/modules/map/components/olMap/handler/measure/OlMeasurementHandler.test.js
@@ -13,7 +13,7 @@ import { $injector } from '../../../../../../../src/injection';
 import { TestUtils } from '../../../../../../test-utils.js';
 import proj4 from 'proj4';
 import { register } from 'ol/proj/proj4';
-import { MEASUREMENT_LAYER_ID } from '../../../../../../../src/modules/map/store/layers.action';
+import { MEASUREMENT_LAYER_ID } from '../../../../../../../src/modules/map/store/measurement.observer';
 
 
 const environmentServiceMock = { isTouch: () => false };

--- a/test/modules/map/store/layers.reducer.test.js
+++ b/test/modules/map/store/layers.reducer.test.js
@@ -1,6 +1,5 @@
 import { layersReducer, index, sort, defaultLayerProperties } from '../../../../src/modules/map/store/layers.reducer';
-import { addLayer, removeLayer, modifyLayer, changeBackground, MEASUREMENT_LAYER_ID } from '../../../../src/modules/map/store/layers.action';
-import { activate as activateMeasurement, deactivate as deactivateMeasurement } from '../../../../src/modules/map/store/measurement.action';
+import { addLayer, removeLayer, modifyLayer, changeBackground } from '../../../../src/modules/map/store/layers.action';
 import { TestUtils } from '../../../test-utils.js';
 
 describe('defaultLayerProperties', () => {
@@ -329,20 +328,5 @@ describe('layersReducer', () => {
 		changeBackground('bg0');
 
 		expect(store.getState().layers.background).toBe('bg0');
-	});
-
-	it('adds and removes a layer for the measurement tool', () => {
-		const store = setup();
-
-		activateMeasurement();
-
-		expect(store.getState().layers.active.length).toBe(1);
-		const measurementLayer = store.getState().layers.active[0];
-		expect(measurementLayer.id).toBe(MEASUREMENT_LAYER_ID);
-		expect(measurementLayer.constraints).toEqual({ hidden:true, alwaysTop: true });
-
-		deactivateMeasurement();
-
-		expect(store.getState().layers.active.length).toBe(0);
 	});
 });

--- a/test/modules/map/store/measurement.observer.test.js
+++ b/test/modules/map/store/measurement.observer.test.js
@@ -1,0 +1,34 @@
+import { measurementReducer } from '../../../../src/modules/map/store/measurement.reducer';
+import { MEASUREMENT_LAYER_ID, registerMeasurementObserver } from '../../../../src/modules/map/store/measurement.observer';
+
+import { activate, deactivate } from '../../../../src/modules/map/store/measurement.action';
+import { TestUtils } from '../../../test-utils.js';
+import { layersReducer } from '../../../../src/modules/map/store/layers.reducer';
+
+
+
+describe('measurementObserver', () => {
+
+	const setup = (state) => {
+		const store = TestUtils.setupStoreAndDi(state, {
+			measurement: measurementReducer,
+			layers: layersReducer,
+		});
+		registerMeasurementObserver(store);
+		return store;
+	};
+
+
+	it('adds ore remove the measuremt layer', () => {
+		const store = setup();
+		
+		activate();
+
+		expect(store.getState().layers.active.length).toBe(1);
+		expect(store.getState().layers.active[0].id).toBe(MEASUREMENT_LAYER_ID);
+		
+		deactivate();
+		
+		expect(store.getState().layers.active.length).toBe(0);
+	});
+});

--- a/test/utils/storeUtils.test.js
+++ b/test/utils/storeUtils.test.js
@@ -1,0 +1,136 @@
+/* eslint-disable no-undef */
+import { observe, equals } from '../../src/utils/storeUtils.js';
+import { createStore } from 'redux';
+
+// onChangeSpy.calls.reset();
+describe('store utils', () => {
+
+	describe('observe', () => {
+
+		it('observes a property', () => {
+			//arrange
+			const reducer = (state = { active: false }, action) => {
+				switch (action.type) {
+					case 'SOMETHING':
+						return { ...state, active: action.payload };
+					default:
+						return state;
+				}
+			};
+			const store = createStore(reducer);
+			const extract = (state) => {
+				return state.active;
+			};
+			const onChangeSpy = jasmine.createSpy();
+
+			//act
+			observe(store, extract, onChangeSpy);
+			//no initial call after observer registration
+			expect(onChangeSpy).not.toHaveBeenCalled();
+			
+
+			//act
+			store.dispatch({
+				type: 'SOMETHING',
+				payload: false
+			});
+			//no call cause state was not changed
+			expect(onChangeSpy).not.toHaveBeenCalled();
+
+			//act
+			store.dispatch({
+				type: 'SOMETHING',
+				payload: true
+			});
+			expect(onChangeSpy).toHaveBeenCalledOnceWith(true);
+		});
+
+		it('initially calls the callback when ignoreInitialState is set to false', () => {
+			//arrange
+			const reducer = (state = { active: false }, action) => {
+				switch (action.type) {
+					case 'SOMETHING':
+						return { ...state, active: action.payload };
+					default:
+						return state;
+				}
+			};
+			const store = createStore(reducer);
+			const extract = (state) => {
+				return state.active;
+			};
+			const onChangeSpy = jasmine.createSpy();
+
+			//act
+			observe(store, extract, onChangeSpy, false);
+
+			expect(onChangeSpy).toHaveBeenCalledOnceWith(false);
+		});
+
+
+		it('observes an object', () => {
+			//arrange
+			const reducer = (state = { some: { active: false } }, action) => {
+				switch (action.type) {
+					case 'SOMETHING':
+						return { ...state, some: action.payload };
+
+					default:
+						return state;
+				}
+			};
+			const store = createStore(reducer);
+			const extract = (state) => {
+				return state.some;
+			};
+			const onChangeSpy = jasmine.createSpy();
+
+			//act
+			observe(store, extract, onChangeSpy);
+
+			//no initial call after observer registration
+			expect(onChangeSpy).not.toHaveBeenCalled();
+
+			//act
+			store.dispatch({
+				type: 'SOMETHING',
+				payload: { active: false }
+			});
+			//no call cause state was not changed
+			expect(onChangeSpy).not.toHaveBeenCalled();
+
+			//act
+			store.dispatch({
+				type: 'SOMETHING',
+				payload: { active: true }
+			});
+			expect(onChangeSpy).toHaveBeenCalledOnceWith({ active: true });
+		});
+	});
+	describe('equals', () => {
+
+		it('compares values shallowly', () => {
+			expect(equals(1, 1)).toBeTrue();
+			expect(equals(true, true)).toBeTrue();
+			expect(equals('some', 'some')).toBeTrue();
+			const sym = Symbol('foo');
+			expect(equals(sym, sym)).toBeTrue();
+			const someF = () => { };
+			expect(equals(someF, someF)).toBeTrue();
+
+			expect(equals(1, 2)).toBeFalse();
+			expect(equals(true, false)).toBeFalse();
+			expect(equals('some', 'Some')).toBeFalse();
+			expect(equals(Symbol('foo'), Symbol('foo'))).toBeFalse();
+			expect(equals(() => { }, () => { })).toBeFalse();
+		});
+
+		it('compares objects deeply', () => {
+			expect(equals({ some: 42 }, { some: 42 })).toBeTrue();
+			expect(equals([42, { value: 42 }, 'some'], [42, { value: 42 }, 'some'])).toBeTrue();
+
+			expect(equals({ some: 42 }, { some: 21 })).toBeFalse();
+			expect(equals([42, { value: 42 }, 'some'], [42, { value: 21 }, 'some'])).toBeFalse();
+		});
+	});
+});


### PR DESCRIPTION
... within a BaElement.

Example:

If the state of an element extracted from die global store looks like: 

`{ foo:bar, some:42 }`

...and we want to be notified about changes individually, we can now register an observer:
```
observe('foo', (value) => { console.log('foo changed: ' value) });
observe('some', (value) => { console.log('some changed: ' value)});
```