### PR TITLE
add changeListeners for measurement-layer

### DIFF
--- a/src/modules/map/components/olMap/handler/measure/OlMeasurementHandler.js
+++ b/src/modules/map/components/olMap/handler/measure/OlMeasurementHandler.js
@@ -31,38 +31,51 @@ export class OlMeasurementHandler extends OlLayerHandler {
 		this._mapService = MapService;
 		this._environmentService = EnvironmentService;
 		this._vectorLayer = null;
-		this._draw = false;			
-		this._activeSketch = null;		
+		this._draw = false;
+		this._activeSketch = null;
 		this._helpTooltip;
 		this._isFinishOnFirstPoint = false;
 		this._isSnapOnLastPoint = false;
 		this._pointCount = 0;
 		this._overlays = [];
-		this._projectionHints = { fromProjection:'EPSG:' + this._mapService.getSrid(), toProjection:'EPSG:' + this._mapService.getDefaultGeodeticSrid() };		
+		this._projectionHints = { fromProjection: 'EPSG:' + this._mapService.getSrid(), toProjection: 'EPSG:' + this._mapService.getDefaultGeodeticSrid() };
 	}
 
 	/**
 	 * Activates the Handler.
 	 * @override
-	 */	
+	 */
 	activate(olMap) {
+		const visibleChangedHandler = (event) => {
+			const layer = event.target;
+			const isVisibleStyle = layer.getVisible() ? '' : 'none';
+			this._overlays.forEach(o => o.getElement().style.display = isVisibleStyle);
+		};
+
+		const opacityChangedHandler = (event) => {
+			const layer = event.target;
+			this._overlays.forEach(o => o.getElement().style.opacity = layer.getOpacity());
+		};
+
 		const prepareInteraction = () => {
-			const source = new VectorSource({ wrapX: false });	
+			const source = new VectorSource({ wrapX: false });
 			const layer = new VectorLayer({
 				source: source,
-				style: measureStyleFunction				
+				style: measureStyleFunction
 			});
+			this._layerVisibilityListener = layer.on('change:visible', visibleChangedHandler);
+			this._layerOpacityListener = layer.on('change:opacity', opacityChangedHandler);
 			return layer;
 		};
 
 		const pointerMoveHandler = (event) => {
 			const translate = (key) => this._translationService.translate(key);
-			
+
 			if (event.dragging) {
 				return;
 			}
 			/** @type {string} */
-			let helpMsg =  translate('map_olMap_handler_measure_start');
+			let helpMsg = translate('map_olMap_handler_measure_start');
 
 			if (this._activeSketch) {
 				this._activeSketch.getGeometry();
@@ -79,33 +92,33 @@ export class OlMeasurementHandler extends OlLayerHandler {
 					helpMsg += '<br/>' + translate('map_olMap_handler_delete_last_point');
 				}
 			}
-			
-			this._updateOverlay(this._helpTooltip, new Point(event.coordinate), helpMsg );
+
+			this._updateOverlay(this._helpTooltip, new Point(event.coordinate), helpMsg);
 		};
 
 		const removeLastPoint = (draw, event) => {
-			if ((event.which === 46 || event.keyCode === 46 ) && !/^(input|textarea)$/i.test(event.target.nodeName)) {
+			if ((event.which === 46 || event.keyCode === 46) && !/^(input|textarea)$/i.test(event.target.nodeName)) {
 				if (draw) {
 					draw.removeLastPoint();
-				}				
+				}
 			}
 		};
 
 		if (this._draw === false) {
-			this._vectorLayer = prepareInteraction();			
+			this._vectorLayer = prepareInteraction();
 			this._helpTooltip = this._createOverlay({ offset: [15, 0], positioning: 'center-left' }, MeasurementOverlayTypes.HELP);
-			const source = this._vectorLayer.getSource();			
-			this._draw = this._createInteraction(source);			
-			this._snap = new Snap({ source: source, pixelTolerance:this._getSnapTolerancePerDevice() });
-			this._addOverlayToMap(olMap, this._helpTooltip);			
+			const source = this._vectorLayer.getSource();
+			this._draw = this._createInteraction(source);
+			this._snap = new Snap({ source: source, pixelTolerance: this._getSnapTolerancePerDevice() });
+			this._addOverlayToMap(olMap, this._helpTooltip);
 			this._pointerMoveListener = olMap.on('pointermove', pointerMoveHandler);
 			this._keyboardListener = document.addEventListener('keyup', (e) => removeLastPoint(this._draw, e));
 
 			olMap.addInteraction(this._snap);
-			olMap.addInteraction(this._draw);	
-		}		
+			olMap.addInteraction(this._draw);
+		}
 		return this._vectorLayer;
-	}	
+	}
 
 	/**
 	 *  @override
@@ -120,9 +133,11 @@ export class OlMeasurementHandler extends OlLayerHandler {
 		this._overlays = [];
 		unByKey(this._pointerMoveListener);
 		unByKey(this._keyboardListener);
+		unByKey(this._layerVisibilityListener);
+		unByKey(this._layerOpacityListener);
 		this._helpTooltip = null;
 		this._draw = false;
-	}	
+	}
 
 	_addOverlayToMap(map, overlay) {
 		this._overlays.push(overlay);
@@ -134,23 +149,23 @@ export class OlMeasurementHandler extends OlLayerHandler {
 		map.removeOverlay(overlay);
 	}
 
-	_createInteraction(source) {		
+	_createInteraction(source) {
 		const draw = new Draw({
 			source: source,
-			type:'Polygon',
-			minPoints:2,
-			snapTolerance:4,
+			type: 'Polygon',
+			minPoints: 2,
+			snapTolerance: 4,
 			style: generateSketchStyleFunction(measureStyleFunction)
-		});						
-		
+		});
+
 		const updateMeasureTooltips = (geometry) => {
 			let measureGeometry = geometry;
 			const map = draw.getMap();
-			const measureTooltip = this._activeSketch.get('measurement');		
-			
+			const measureTooltip = this._activeSketch.get('measurement');
+
 			if (geometry instanceof Polygon) {
 				const lineCoordinates = geometry.getCoordinates()[0].slice(0, -1);
-				
+
 
 				if (this._pointCount !== lineCoordinates.length) {
 					// a point is added or removed
@@ -166,84 +181,84 @@ export class OlMeasurementHandler extends OlLayerHandler {
 
 					this._isSnapOnLastPoint = (lastPoint[0] === lastPoint2[0] && lastPoint[1] === lastPoint2[1]);
 				}
-				
+
 				if (!this._isFinishOnFirstPoint) {
 					measureGeometry = new LineString(lineCoordinates);
-				}					
+				}
 
 				if (geometry.getArea()) {
-					let areaOverlay = this._activeSketch.get('area') || this._createOverlay( { positioning: 'top-center' }, MeasurementOverlayTypes.AREA, this._projectionHints );				 
+					let areaOverlay = this._activeSketch.get('area') || this._createOverlay({ positioning: 'top-center' }, MeasurementOverlayTypes.AREA, this._projectionHints);
 					this._addOverlayToMap(map, areaOverlay);
 					this._updateOverlay(areaOverlay, geometry);
 					this._activeSketch.set('area', areaOverlay);
 				}
 			}
 
-			this._updateOverlay(measureTooltip, measureGeometry, '');		
-						
+			this._updateOverlay(measureTooltip, measureGeometry, '');
+
 			// add partition tooltips on the line
 			const partitions = this._activeSketch.get('partitions') || [];
-		
-			
-			let delta = getPartitionDelta(measureGeometry, this._projectionHints);			
+
+
+			let delta = getPartitionDelta(measureGeometry, this._projectionHints);
 			let partitionIndex = 0;
-			for (let i = delta;i < 1;i += delta, partitionIndex++) {
-				let partition = partitions[partitionIndex] || false; 
-				if (partition === false) {			
-					partition = this._createOverlay( { offset: [0, -25], positioning: 'top-center' }, MeasurementOverlayTypes.DISTANCE_PARTITION, this._projectionHints );
-					
-					this._addOverlayToMap(map, partition);									
+			for (let i = delta; i < 1; i += delta, partitionIndex++) {
+				let partition = partitions[partitionIndex] || false;
+				if (partition === false) {
+					partition = this._createOverlay({ offset: [0, -25], positioning: 'top-center' }, MeasurementOverlayTypes.DISTANCE_PARTITION, this._projectionHints);
+
+					this._addOverlayToMap(map, partition);
 					partitions.push(partition);
 				}
-				this._updateOverlay(partition, measureGeometry, i );
+				this._updateOverlay(partition, measureGeometry, i);
 			}
 
 			if (partitionIndex < partitions.length) {
-				for (let j = partitions.length - 1;j >= partitionIndex;j--) {
+				for (let j = partitions.length - 1; j >= partitionIndex; j--) {
 					const removablePartition = partitions[j];
 					if (map) {
-						this._removeOverlayFromMap(map, removablePartition);				
-					}	
+						this._removeOverlayFromMap(map, removablePartition);
+					}
 					partitions.pop();
 				}
 			}
-			this._activeSketch.set('partitions', partitions);		
+			this._activeSketch.set('partitions', partitions);
 		};
 		let listener;
-		
-		const finishMeasurementTooltip = (event) => {			
+
+		const finishMeasurementTooltip = (event) => {
 
 			const geometry = event.feature.getGeometry();
 			const measureTooltip = event.feature.get('measurement');
 			measureTooltip.getElement().static = true;
-			measureTooltip.setOffset([0, -7]);				
+			measureTooltip.setOffset([0, -7]);
 			if (geometry instanceof Polygon && !this._isFinishOnFirstPoint) {
 				const lineCoordinates = geometry.getCoordinates()[0].slice(0, -1);
-				event.feature.setGeometry(new LineString(lineCoordinates));		
-				this._removeOverlayFromMap(draw.getMap(),	this._activeSketch.get('area')	);
+				event.feature.setGeometry(new LineString(lineCoordinates));
+				this._removeOverlayFromMap(draw.getMap(), this._activeSketch.get('area'));
 			}
 			else {
 				this._updateOverlay(measureTooltip, geometry);
 			}
-			this._activeSketch = null;						
+			this._activeSketch = null;
 			unByKey(listener);
 		};
-		
-		draw.on('drawstart', event =>  {	
-			
-			const measureTooltip = this._createOverlay({ offset: [0, -15], positioning: 'bottom-center' }, MeasurementOverlayTypes.DISTANCE, this._projectionHints);	
+
+		draw.on('drawstart', event => {
+
+			const measureTooltip = this._createOverlay({ offset: [0, -15], positioning: 'bottom-center' }, MeasurementOverlayTypes.DISTANCE, this._projectionHints);
 			this._activeSketch = event.feature;
 			this._activeSketch.set('measurement', measureTooltip);
 
-			this._pointCount = 1;		
+			this._pointCount = 1;
 			this._isSnapOnLastPoint = false;
 			listener = event.feature.getGeometry().on('change', event => {
 				updateMeasureTooltips(event.target);
 			});
 			const map = draw.getMap();
 			if (map) {
-				this._addOverlayToMap(map, measureTooltip);				
-			}			
+				this._addOverlayToMap(map, measureTooltip);
+			}
 		});
 
 		draw.on('drawend', finishMeasurementTooltip);
@@ -253,9 +268,9 @@ export class OlMeasurementHandler extends OlLayerHandler {
 
 	_createOverlay(overlayOptions = {}, type, projectionHints = {}) {
 		const measurementOverlay = document.createElement(MeasurementOverlay.tag);
-		measurementOverlay.type = type;		
+		measurementOverlay.type = type;
 		measurementOverlay.projectionHints = projectionHints;
-		const overlay = new Overlay({ ...overlayOptions, element:measurementOverlay });
+		const overlay = new Overlay({ ...overlayOptions, element: measurementOverlay });
 		return overlay;
 	}
 
@@ -263,7 +278,7 @@ export class OlMeasurementHandler extends OlLayerHandler {
 		const measurementOverlay = overlay.getElement();
 		measurementOverlay.value = value;
 		measurementOverlay.geometry = geometry;
-		overlay.setPosition(measurementOverlay.position);							
+		overlay.setPosition(measurementOverlay.position);
 	}
 
 	_getSnapTolerancePerDevice() {

--- a/test/modules/map/components/olMap/handler/measure/OlMeasurementHandler.test.js
+++ b/test/modules/map/components/olMap/handler/measure/OlMeasurementHandler.test.js
@@ -18,7 +18,7 @@ import { MEASUREMENT_LAYER_ID } from '../../../../../../../src/modules/map/store
 
 const environmentServiceMock = { isTouch: () => false };
 
-TestUtils.setupStoreAndDi({ }, );
+TestUtils.setupStoreAndDi({},);
 $injector.registerSingleton('TranslationService', { translate: (key) => key });
 $injector.registerSingleton('MapService', { getSrid: () => 3857, getDefaultGeodeticSrid: () => 25832 });
 $injector.registerSingleton('EnvironmentService', environmentServiceMock);
@@ -41,13 +41,13 @@ describe('OlMeasurementHandler', () => {
 	const simulateDrawEvent = (type, draw, feature) => {
 		const eventType = type;
 		const drawEvent = new DrawEvent(eventType, feature);
-		
+
 		draw.dispatchEvent(drawEvent);
-	};		
+	};
 
 	const simulateKeyEvent = (keyCode) => {
-		const keyEvent = new KeyboardEvent('keyup', { keyCode:keyCode, which:keyCode });
-		
+		const keyEvent = new KeyboardEvent('keyup', { keyCode: keyCode, which: keyCode });
+
 		document.dispatchEvent(keyEvent);
 	};
 
@@ -55,7 +55,7 @@ describe('OlMeasurementHandler', () => {
 		const classUnderTest = new OlMeasurementHandler();
 		const initialCenter = fromLonLat([11.57245, 48.14021]);
 
-		const setupMap =  () => {
+		const setupMap = () => {
 			return new Map({
 				layers: [
 					new TileLayer({
@@ -70,58 +70,58 @@ describe('OlMeasurementHandler', () => {
 					zoom: 1,
 				}),
 			});
-			
+
 		};
 
 		it('adds a Interaction', () => {
-			const map =  setupMap();
+			const map = setupMap();
 			map.addInteraction = jasmine.createSpy();
 			classUnderTest.activate(map);
-			
+
 			expect(map.addInteraction).toHaveBeenCalled();
 		});
 
 		it('removes a Interaction', () => {
-			const map =  setupMap();
-			const layerStub = {}; 
+			const map = setupMap();
+			const layerStub = {};
 			map.removeInteraction = jasmine.createSpy();
 
 			classUnderTest.deactivate(map, layerStub);
-			
+
 			expect(map.removeInteraction).toHaveBeenCalled();
-		});	
-		
+		});
+
 
 		it('removes all registered mapOverlays', () => {
-			const map =  setupMap();			
+			const map = setupMap();
 			map.removeOverlay = jasmine.createSpy();
 			const overlayStub = {};
 			classUnderTest._overlays = [overlayStub, overlayStub, overlayStub, overlayStub];
 			classUnderTest.deactivate(map);
-			
+
 			expect(map.removeOverlay).toHaveBeenCalledTimes(4);
 			expect(classUnderTest._overlays.length).toBe(0);
-		});	
+		});
 
-		
+
 	});
 
 	describe('when using EnvironmentService for snapTolerance', () => {
-			
+
 		it('isTouch() resolves in higher snapTolerance', () => {
 			const classUnderTest = new OlMeasurementHandler();
 			const environmentSpy = spyOn(environmentServiceMock, 'isTouch').and.returnValue(true);
-								
-			expect(classUnderTest._getSnapTolerancePerDevice()).toBe(12);			
-			expect(environmentSpy).toHaveBeenCalled();	
+
+			expect(classUnderTest._getSnapTolerancePerDevice()).toBe(12);
+			expect(environmentSpy).toHaveBeenCalled();
 		});
 
 		it('isTouch() resolves in lower snapTolerance', () => {
 			const classUnderTest = new OlMeasurementHandler();
 			const environmentSpy = spyOn(environmentServiceMock, 'isTouch').and.returnValue(false);
-								
-			expect(classUnderTest._getSnapTolerancePerDevice()).toBe(4);			
-			expect(environmentSpy).toHaveBeenCalled();	
+
+			expect(classUnderTest._getSnapTolerancePerDevice()).toBe(4);
+			expect(environmentSpy).toHaveBeenCalled();
 		});
 
 	});
@@ -129,7 +129,7 @@ describe('OlMeasurementHandler', () => {
 	describe('when draw a line', () => {
 		const initialCenter = fromLonLat([11.57245, 48.14021]);
 
-		const setupMap =   () => {
+		const setupMap = () => {
 
 			return new Map({
 				layers: [
@@ -145,15 +145,15 @@ describe('OlMeasurementHandler', () => {
 					zoom: 1,
 				}),
 			});
-			
-		};	
+
+		};
 
 		it('creates tooltip content for line', () => {
 			const classUnderTest = new OlMeasurementHandler();
-			const map =  setupMap();
-			const geometry  = new LineString([[0, 0], [1, 0]]);
-			const feature = new Feature({ geometry:geometry });
-		
+			const map = setupMap();
+			const geometry = new LineString([[0, 0], [1, 0]]);
+			const feature = new Feature({ geometry: geometry });
+
 			classUnderTest.activate(map);
 			simulateDrawEvent('drawstart', classUnderTest._draw, feature);
 			feature.getGeometry().dispatchEvent('change');
@@ -161,92 +161,92 @@ describe('OlMeasurementHandler', () => {
 			const baOverlay = feature.get('measurement').getElement();
 
 			expect(baOverlay.outerHTML).toBe('<ba-measure-overlay></ba-measure-overlay>');
-		});	
+		});
 
 		it('creates partition tooltips for long line', () => {
 			const classUnderTest = new OlMeasurementHandler();
-			const map =  setupMap();
-			const geometry  = new LineString([[0, 0], [1234, 0]]);
-			const feature = new Feature({ geometry:geometry });
-		
+			const map = setupMap();
+			const geometry = new LineString([[0, 0], [1234, 0]]);
+			const feature = new Feature({ geometry: geometry });
+
 			classUnderTest.activate(map);
 			simulateDrawEvent('drawstart', classUnderTest._draw, feature);
 			feature.getGeometry().dispatchEvent('change');
 
-			expect(feature.get('partitions').length).toBe(1);			
-		});	
+			expect(feature.get('partitions').length).toBe(1);
+		});
 
 		it('creates partition tooltips for longer line', () => {
 			const classUnderTest = new OlMeasurementHandler();
-			const map =  setupMap();
-			const geometry  = new LineString([[0, 0], [12345, 0]]);
-			const feature = new Feature({ geometry:geometry });
-		
+			const map = setupMap();
+			const geometry = new LineString([[0, 0], [12345, 0]]);
+			const feature = new Feature({ geometry: geometry });
+
 			classUnderTest.activate(map);
 			simulateDrawEvent('drawstart', classUnderTest._draw, feature);
 			feature.getGeometry().dispatchEvent('change');
 
-			expect(feature.get('partitions').length).toBe(12);			
-		});	
+			expect(feature.get('partitions').length).toBe(12);
+		});
 
 		it('creates partition tooltips very long line', () => {
 			const classUnderTest = new OlMeasurementHandler();
-			const map =  setupMap();
-			const geometry  = new LineString([[0, 0], [123456, 0]]);
-			const feature = new Feature({ geometry:geometry });
-		
+			const map = setupMap();
+			const geometry = new LineString([[0, 0], [123456, 0]]);
+			const feature = new Feature({ geometry: geometry });
+
 			classUnderTest.activate(map);
 			simulateDrawEvent('drawstart', classUnderTest._draw, feature);
 			feature.getGeometry().dispatchEvent('change');
 
-			expect(feature.get('partitions').length).toBe(12);			
-		});	
-		
+			expect(feature.get('partitions').length).toBe(12);
+		});
+
 		it('creates partition tooltips for longest line', () => {
 			const classUnderTest = new OlMeasurementHandler();
-			const map =  setupMap();
-			const geometry  = new LineString([[0, 0], [1234567, 0]]);
-			const feature = new Feature({ geometry:geometry });
-		
+			const map = setupMap();
+			const geometry = new LineString([[0, 0], [1234567, 0]]);
+			const feature = new Feature({ geometry: geometry });
+
 			classUnderTest.activate(map);
 			simulateDrawEvent('drawstart', classUnderTest._draw, feature);
 			feature.getGeometry().dispatchEvent('change');
 
-			expect(feature.get('partitions').length).toBe(12);			
-		});	
+			expect(feature.get('partitions').length).toBe(12);
+		});
 
 		it('creates partition tooltips for not closed polygon', () => {
 			const classUnderTest = new OlMeasurementHandler();
-			const map =  setupMap();
-			const geometry  = new Polygon([[[0, 0], [500, 0], [550, 550], [0, 500]]]);
-			const feature = new Feature({ geometry:geometry });
-		
+			const map = setupMap();
+			const geometry = new Polygon([[[0, 0], [500, 0], [550, 550], [0, 500]]]);
+			const feature = new Feature({ geometry: geometry });
+
 			classUnderTest.activate(map);
 			simulateDrawEvent('drawstart', classUnderTest._draw, feature);
 			feature.getGeometry().dispatchEvent('change');
 
-			expect(feature.get('partitions').length).toBe(1);			
-		});	
+			expect(feature.get('partitions').length).toBe(1);
+		});
 
 		it('creates partition tooltips for not closed large polygon', () => {
 			const classUnderTest = new OlMeasurementHandler();
-			const map =  setupMap();
-			const geometry  = new Polygon([[[0, 0], [5000, 0], [5500, 5500], [0, 5000]]]);
-			const feature = new Feature({ geometry:geometry });
-		
+			const map = setupMap();
+			const geometry = new Polygon([[[0, 0], [5000, 0], [5500, 5500], [0, 5000]]]);
+			const feature = new Feature({ geometry: geometry });
+
 			classUnderTest.activate(map);
 			simulateDrawEvent('drawstart', classUnderTest._draw, feature);
 			feature.getGeometry().dispatchEvent('change');
 
-			expect(feature.get('partitions').length).toBe(10);			
-		});	
+			expect(feature.get('partitions').length).toBe(10);
+		});
 
 		it('removes partition tooltips after shrinking very long line', () => {
 			const classUnderTest = new OlMeasurementHandler();
-			const map =  setupMap();
-			const geometry  = new LineString([[0, 0], [12345, 0]]);
-			const feature = new Feature({ geometry:geometry });
-		
+			const map = setupMap();
+			const geometry = new LineString([[0, 0], [12345, 0]]);
+			const feature = new Feature({ geometry: geometry });
+
 			classUnderTest.activate(map);
 			simulateDrawEvent('drawstart', classUnderTest._draw, feature);
 			feature.getGeometry().dispatchEvent('change');
@@ -255,18 +255,18 @@ describe('OlMeasurementHandler', () => {
 
 			geometry.setCoordinates([[0, 0], [1234, 0]]);
 			feature.getGeometry().dispatchEvent('change');
-			
-			expect(feature.get('partitions').length).toBe(1);			
-		});	
+
+			expect(feature.get('partitions').length).toBe(1);
+		});
 
 		it('unregister tooltip-listener after finish drawing', () => {
 			const classUnderTest = new OlMeasurementHandler();
-			const map =  setupMap();
-			const geometry  = new LineString([[0, 0], [1, 0]]);
-			const feature = new Feature({ geometry:geometry });	
-		
+			const map = setupMap();
+			const geometry = new LineString([[0, 0], [1, 0]]);
+			const feature = new Feature({ geometry: geometry });
+
 			classUnderTest.activate(map);
-					
+
 			simulateDrawEvent('drawstart', classUnderTest._draw, feature);
 			feature.getGeometry().dispatchEvent('change');
 			simulateDrawEvent('drawend', classUnderTest._draw, feature);
@@ -275,32 +275,32 @@ describe('OlMeasurementHandler', () => {
 
 			expect(baOverlay.static).toBeTrue();
 			expect(feature.get('measurement').getOffset()).toEqual([0, -7]);
-		});		
-		
-		
+		});
+
+
 		it('positions tooltip content on the end of not closed Polygon', () => {
 			const classUnderTest = new OlMeasurementHandler();
-			const map =  setupMap();
-			const snappedGeometry  =  new Polygon([[[0, 0], [500, 0], [550, 550], [0, 500], [0, 0]]]);
-			const feature = new Feature({ geometry:snappedGeometry });
-		
+			const map = setupMap();
+			const snappedGeometry = new Polygon([[[0, 0], [500, 0], [550, 550], [0, 500], [0, 0]]]);
+			const feature = new Feature({ geometry: snappedGeometry });
+
 			classUnderTest.activate(map);
 			simulateDrawEvent('drawstart', classUnderTest._draw, feature);
 			feature.getGeometry().dispatchEvent('change');
 
 			const overlay = feature.get('measurement');
 
-			
+
 			expect(overlay.getPosition()[0]).toBe(0);
 			expect(overlay.getPosition()[1]).toBe(500);
-		});	
+		});
 
 		it('positions tooltip content on the end of a updated not closed Polygon', () => {
 			const classUnderTest = new OlMeasurementHandler();
-			const map =  setupMap();
-			const snappedGeometry  =  new Polygon([[[0, 0], [500, 0], [550, 550], [0, 500], [0, 500]]]);			  
-			const feature = new Feature({ geometry:snappedGeometry });
-		
+			const map = setupMap();
+			const snappedGeometry = new Polygon([[[0, 0], [500, 0], [550, 550], [0, 500], [0, 500]]]);
+			const feature = new Feature({ geometry: snappedGeometry });
+
 			classUnderTest.activate(map);
 			simulateDrawEvent('drawstart', classUnderTest._draw, feature);
 			feature.getGeometry().dispatchEvent('change');
@@ -314,21 +314,21 @@ describe('OlMeasurementHandler', () => {
 
 			expect(overlay.getPosition()[0]).toBe(0);
 			expect(overlay.getPosition()[1]).toBe(250);
-		});	
-		
+		});
+
 
 		it('removes last point if keypressed', () => {
 			const classUnderTest = new OlMeasurementHandler();
-			const map =  setupMap();
-			const geometry  =  new Polygon([[[0, 0], [500, 0], [550, 550], [0, 500], [0, 500]]]);			  
-			const feature = new Feature({ geometry:geometry });
+			const map = setupMap();
+			const geometry = new Polygon([[[0, 0], [500, 0], [550, 550], [0, 500], [0, 500]]]);
+			const feature = new Feature({ geometry: geometry });
 			const deleteKeyCode = 46;
-		
-			classUnderTest.activate(map);			
+
+			classUnderTest.activate(map);
 			simulateDrawEvent('drawstart', classUnderTest._draw, feature);
 			classUnderTest._draw.removeLastPoint = jasmine.createSpy();
 			feature.getGeometry().dispatchEvent('change');
-			
+
 			simulateKeyEvent(deleteKeyCode);
 			expect(classUnderTest._draw.removeLastPoint).toHaveBeenCalled();
 		});
@@ -337,7 +337,7 @@ describe('OlMeasurementHandler', () => {
 	describe('when pointer move', () => {
 		const initialCenter = fromLonLat([11.57245, 48.14021]);
 
-		const setupMap =  () => {
+		const setupMap = () => {
 
 			return new Map({
 				layers: [
@@ -353,24 +353,24 @@ describe('OlMeasurementHandler', () => {
 					zoom: 1,
 				}),
 			});
-			
+
 		};
 
 		const simulateMouseEvent = (map, type, x, y, dragging) => {
 			const eventType = type;
-	
+
 			const event = new Event(eventType);
 			//event.target = map.getViewport().firstChild;
 			event.clientX = x;
 			event.clientY = y;
 			event.pageX = x;
-			event.pageY = y;			
+			event.pageY = y;
 			event.shiftKey = false;
 			event.preventDefault = function () { };
-	
-			
-			let mapEvent = new MapBrowserEvent(eventType, map, event);		
-			mapEvent.coordinate = [x, y];	
+
+
+			let mapEvent = new MapBrowserEvent(eventType, map, event);
+			mapEvent.coordinate = [x, y];
 			mapEvent.dragging = dragging ? dragging : false;
 			map.dispatchEvent(mapEvent);
 		};
@@ -378,84 +378,166 @@ describe('OlMeasurementHandler', () => {
 		it('creates and move helpTooltip', () => {
 			const classUnderTest = new OlMeasurementHandler();
 			const map = setupMap();
-			
-			classUnderTest.activate(map);			
-			simulateMouseEvent(map, MapBrowserEventType.POINTERMOVE, 10, 0);			
+
+			classUnderTest.activate(map);
+			simulateMouseEvent(map, MapBrowserEventType.POINTERMOVE, 10, 0);
 			const baOverlay = classUnderTest._helpTooltip.getElement();
-			expect(baOverlay.value).toBe('map_olMap_handler_measure_start');			
-			expect(classUnderTest._helpTooltip.getPosition()).toEqual([10, 0]);	
-		});	
+			expect(baOverlay.value).toBe('map_olMap_handler_measure_start');
+			expect(classUnderTest._helpTooltip.getPosition()).toEqual([10, 0]);
+		});
 
 		it('no move when dragging', () => {
 			const classUnderTest = new OlMeasurementHandler();
 			const map = setupMap();
-			
-			classUnderTest.activate(map);			
-			simulateMouseEvent(map, MapBrowserEventType.POINTERMOVE, 10, 0, true);			
-					
+
+			classUnderTest.activate(map);
+			simulateMouseEvent(map, MapBrowserEventType.POINTERMOVE, 10, 0, true);
+
 			expect(classUnderTest._helpTooltip.getPosition()).toBeFalsy();
-		});	
+		});
 
 		it('change message in helpTooltip, when sketch is changing', () => {
 			const classUnderTest = new OlMeasurementHandler();
 			const map = setupMap();
-			
-			classUnderTest.activate(map);			
-			simulateMouseEvent(map, MapBrowserEventType.POINTERMOVE, 10, 0);		
-			
+
+			classUnderTest.activate(map);
+			simulateMouseEvent(map, MapBrowserEventType.POINTERMOVE, 10, 0);
+
 			const baOverlay = classUnderTest._helpTooltip.getElement();
-			expect(baOverlay.value).toBe('map_olMap_handler_measure_start');			
-			classUnderTest._activeSketch = new Feature({ geometry:new LineString([[0, 0], [1, 0]]) });	
-			simulateMouseEvent(map, MapBrowserEventType.POINTERMOVE, 20, 0);						
-			expect(baOverlay.value).toBe('map_olMap_handler_measure_continue_line');	
-		});	
+			expect(baOverlay.value).toBe('map_olMap_handler_measure_start');
+			classUnderTest._activeSketch = new Feature({ geometry: new LineString([[0, 0], [1, 0]]) });
+			simulateMouseEvent(map, MapBrowserEventType.POINTERMOVE, 20, 0);
+			expect(baOverlay.value).toBe('map_olMap_handler_measure_continue_line');
+		});
 
 		it('change message in helpTooltip, when sketch is snapping to first point', () => {
 			const classUnderTest = new OlMeasurementHandler();
 			const map = setupMap();
-			
-			classUnderTest.activate(map);	
+
+			classUnderTest.activate(map);
 			const baOverlay = classUnderTest._helpTooltip.getElement();
-			
+
 			simulateMouseEvent(map, MapBrowserEventType.POINTERMOVE, 10, 0);
-			expect(baOverlay.value).toBe('map_olMap_handler_measure_start');			
-			const snappedGeometry  =  new Polygon([[[0, 0], [500, 0], [550, 550], [0, 500], [0, 500]]]);			  
-			const feature = new Feature({ geometry:snappedGeometry });
-			simulateDrawEvent('drawstart', classUnderTest._draw, feature);		
-			feature.getGeometry().dispatchEvent('change');		
+			expect(baOverlay.value).toBe('map_olMap_handler_measure_start');
+			const snappedGeometry = new Polygon([[[0, 0], [500, 0], [550, 550], [0, 500], [0, 500]]]);
+			const feature = new Feature({ geometry: snappedGeometry });
+			simulateDrawEvent('drawstart', classUnderTest._draw, feature);
+			feature.getGeometry().dispatchEvent('change');
 			expect(classUnderTest._pointCount).toBe(4);
-			
-			
+
+
 			snappedGeometry.setCoordinates([[[0, 0], [500, 0], [550, 550], [0, 500], [0, 0], [0, 0]]]);
 			feature.getGeometry().dispatchEvent('change');
 			expect(classUnderTest._pointCount).toBe(5);
-			simulateMouseEvent(map, MapBrowserEventType.POINTERMOVE, 0, 0);									
-			expect(baOverlay.value).toBe('map_olMap_handler_measure_snap_first_point<br/>map_olMap_handler_delete_last_point');	
-		});	
+			simulateMouseEvent(map, MapBrowserEventType.POINTERMOVE, 0, 0);
+			expect(baOverlay.value).toBe('map_olMap_handler_measure_snap_first_point<br/>map_olMap_handler_delete_last_point');
+		});
 
 		it('change message in helpTooltip, when sketch is snapping to last point', () => {
 			const classUnderTest = new OlMeasurementHandler();
 			const map = setupMap();
-			
-			classUnderTest.activate(map);	
+
+			classUnderTest.activate(map);
 			const baOverlay = classUnderTest._helpTooltip.getElement();
-			
+
 			simulateMouseEvent(map, MapBrowserEventType.POINTERMOVE, 10, 0);
-			expect(baOverlay.value).toBe('map_olMap_handler_measure_start');			
-			const snappedGeometry  =  new Polygon([[[0, 0], [500, 0], [550, 550], [0, 500], [0, 500]]]);			  
-			const feature = new Feature({ geometry:snappedGeometry });
-			simulateDrawEvent('drawstart', classUnderTest._draw, feature);		
-			feature.getGeometry().dispatchEvent('change');		
+			expect(baOverlay.value).toBe('map_olMap_handler_measure_start');
+			const snappedGeometry = new Polygon([[[0, 0], [500, 0], [550, 550], [0, 500], [0, 500]]]);
+			const feature = new Feature({ geometry: snappedGeometry });
+			simulateDrawEvent('drawstart', classUnderTest._draw, feature);
+			feature.getGeometry().dispatchEvent('change');
 			expect(classUnderTest._pointCount).toBe(4);
-			
-			
+
+
 			snappedGeometry.setCoordinates([[[0, 0], [500, 0], [550, 550], [0, 500], [0, 500], [0, 500]]]);
 			feature.getGeometry().dispatchEvent('change');
 			expect(classUnderTest._pointCount).toBe(5);
-			simulateMouseEvent(map, MapBrowserEventType.POINTERMOVE, 0, 0);									
-			expect(baOverlay.value).toBe('map_olMap_handler_measure_snap_last_point<br/>map_olMap_handler_delete_last_point');	
-		});	
-		
+			simulateMouseEvent(map, MapBrowserEventType.POINTERMOVE, 0, 0);
+			expect(baOverlay.value).toBe('map_olMap_handler_measure_snap_last_point<br/>map_olMap_handler_delete_last_point');
+		});
+
+	});
+
+	describe('when measurement-layer changes', () => {
+		const initialCenter = fromLonLat([11.57245, 48.14021]);
+
+		const setupMap = () => {
+
+			return new Map({
+				layers: [
+					new TileLayer({
+						source: new OSM(),
+					}),
+					new TileLayer({
+						source: new TileDebug(),
+					})],
+				target: 'map',
+				view: new View({
+					center: initialCenter,
+					zoom: 1,
+				}),
+			});
+
+		};
+
+		it('layer visibility, then overlay visibility changes', () => {
+			const classUnderTest = new OlMeasurementHandler();
+			const geometry = new Polygon([[[0, 0], [500, 0], [550, 550], [0, 500], [0, 500]]]);
+			const feature = new Feature({ geometry: geometry });
+			const map = setupMap();
+
+			// create a measurement with overlays
+			const measurementLayer = classUnderTest.activate(map);
+			simulateDrawEvent('drawstart', classUnderTest._draw, feature);
+			feature.getGeometry().dispatchEvent('change');
+			geometry.setCoordinates([[[0, 0], [500, 0], [550, 550], [0, 500], [0, 0], [0, 0]]]);
+			feature.getGeometry().dispatchEvent('change');
+			simulateDrawEvent('drawend', classUnderTest._draw, feature);
+
+			// some overlays exists
+			const overlay = feature.get('measurement');
+			const overlayElement = overlay.getElement();
+			expect(overlay).toBeTruthy();
+			expect(overlayElement).toBeTruthy();
+
+			// layers visibility changed
+			measurementLayer.setVisible(false);
+
+			expect(overlayElement.style.display).toBeDefined();
+			expect(overlayElement.style.display).toBe('none');
+
+
+			measurementLayer.setVisible(true);
+			expect(overlayElement.style.display).toBe('');
+		});
+
+		it('layer opacity, then overlay opacity changes', () => {
+			const classUnderTest = new OlMeasurementHandler();
+			const geometry = new Polygon([[[0, 0], [500, 0], [550, 550], [0, 500], [0, 500]]]);
+			const feature = new Feature({ geometry: geometry });
+			const map = setupMap();
+
+			// create a measurement with overlays
+			const measurementLayer = classUnderTest.activate(map);
+			simulateDrawEvent('drawstart', classUnderTest._draw, feature);
+			feature.getGeometry().dispatchEvent('change');
+			geometry.setCoordinates([[[0, 0], [500, 0], [550, 550], [0, 500], [0, 0], [0, 0]]]);
+			feature.getGeometry().dispatchEvent('change');
+			simulateDrawEvent('drawend', classUnderTest._draw, feature);
+
+			// some overlays exists
+			const overlay = feature.get('measurement');
+			const overlayElement = overlay.getElement();
+			expect(overlay).toBeTruthy();
+			expect(overlayElement).toBeTruthy();
+
+			// layers opacity changed
+			measurementLayer.setOpacity(0.3);
+
+			expect(overlayElement.style.opacity).toBeDefined();
+			expect(overlayElement.style.opacity).toBe('0.3');
+
+		});
 	});
 });
 


### PR DESCRIPTION
add changeListener for measurement-layer to bind layer-visibility and opacity to overlay-visibility/opacity 

fix for #110

the current fix interpretes the measurement-layer as internal object (OlMeasurementHandler is stateful) and therefore using listeners to react on changes of the layer.

But... it breaks the design (use the StateStore as the single point of truth)...so a implementaion with a observer is more appropriate. 