### PR TITLE
Pointer and map reducer

### DIFF
--- a/src/modules/footer/components/coordinateSelect/CoordinateSelect.js
+++ b/src/modules/footer/components/coordinateSelect/CoordinateSelect.js
@@ -79,7 +79,11 @@ export class CoordinateSelect extends BaElement {
      * @override 
      */
 	extractState(store) {
-		const { position: { pointerPosition } } = store;
+		let pointerPosition = undefined;
+		const { map: { pointer } } = store;
+		if (pointer) {
+			pointerPosition = pointer.payload.coordinate;
+		}
 		return { pointerPosition };
 	}
 

--- a/src/modules/footer/components/coordinateSelect/CoordinateSelect.js
+++ b/src/modules/footer/components/coordinateSelect/CoordinateSelect.js
@@ -80,9 +80,9 @@ export class CoordinateSelect extends BaElement {
      */
 	extractState(store) {
 		let pointerPosition = undefined;
-		const { map: { pointer } } = store;
-		if (pointer) {
-			pointerPosition = pointer.payload.coordinate;
+		const { pointer: { move } } = store;
+		if (move) {
+			pointerPosition = move.payload.coordinate;
 		}
 		return { pointerPosition };
 	}

--- a/src/modules/map/components/olMap/OlMap.js
+++ b/src/modules/map/components/olMap/OlMap.js
@@ -10,7 +10,7 @@ import { removeLayer } from '../../store/layers.action';
 import { changeZoomAndCenter } from '../../store/position.action';
 import { $injector } from '../../../../injection';
 import { toOlLayer, updateOlLayer, toOlLayerFromHandler } from './olMapUtils';
-import { setBeingDragged, setPointerMove } from '../../store/pointer.action';
+import { setBeingDragged, setContextClick, setPointerMove } from '../../store/pointer.action';
 
 
 /**
@@ -91,6 +91,11 @@ export class OlMap extends BaElement {
 			setBeingDragged(false);
 		});
 
+		this._map.addEventListener('contextmenu', (evt) => {
+			evt.preventDefault();
+			const coord = this._map.getEventCoordinate(evt.originalEvent);
+			setContextClick({ coordinate: coord, screenCoordinate: [evt.originalEvent.clientX, evt.originalEvent.clientY] });
+		});
 
 		this._map.on('pointermove', (evt) => {
 			if (evt.dragging) {

--- a/src/modules/map/components/olMap/OlMap.js
+++ b/src/modules/map/components/olMap/OlMap.js
@@ -10,7 +10,7 @@ import { removeLayer } from '../../store/layers.action';
 import { changeZoomAndCenter } from '../../store/position.action';
 import { $injector } from '../../../../injection';
 import { toOlLayer, updateOlLayer, toOlLayerFromHandler } from './olMapUtils';
-import { setBeingDragged, setPointer } from '../../store/map.action';
+import { setBeingDragged, setPointerMove } from '../../store/pointer.action';
 
 
 /**
@@ -98,7 +98,7 @@ export class OlMap extends BaElement {
 				return;
 			}
 			const coord = this._map.getEventCoordinate(evt.originalEvent);
-			setPointer({ coordinate: coord, screenCoordinate: [evt.originalEvent.clientX, evt.originalEvent.clientY] });
+			setPointerMove({ coordinate: coord, screenCoordinate: [evt.originalEvent.clientX, evt.originalEvent.clientY] });
 		});
 
 		this._map.on('pointerdrag', () => {

--- a/src/modules/map/components/olMap/OlMap.js
+++ b/src/modules/map/components/olMap/OlMap.js
@@ -7,9 +7,10 @@ import TileLayer from 'ol/layer/Tile';
 import XYZ from 'ol/source/XYZ';
 import { defaults as defaultControls } from 'ol/control';
 import { removeLayer } from '../../store/layers.action';
-import { changeZoomAndCenter, updatePointerPosition } from '../../store/position.action';
+import { changeZoomAndCenter } from '../../store/position.action';
 import { $injector } from '../../../../injection';
 import { toOlLayer, updateOlLayer, toOlLayerFromHandler } from './olMapUtils';
+import { setPointer } from '../../store/map.action';
 
 
 /**
@@ -27,7 +28,7 @@ export class OlMap extends BaElement {
 			OlMeasurementHandler: measurementHandler,
 			OlContextMenueMapEventHandler: contextMenueHandler
 		} = $injector.inject('GeoResourceService', 'OlMeasurementHandler', 'OlContextMenueMapEventHandler');
-		
+
 		this._geoResourceService = georesourceService;
 		this._geoResourceService = georesourceService;
 		this._layerHandler = new Map([[measurementHandler.id, measurementHandler]]);
@@ -96,7 +97,7 @@ export class OlMap extends BaElement {
 				return;
 			}
 			const coord = this._map.getEventCoordinate(evt.originalEvent);
-			updatePointerPosition(coord);
+			setPointer({ coordinate: coord, screenCoordinate: [evt.originalEvent.clientX, evt.originalEvent.clientY] });
 		});
 
 		this._eventHandler.forEach(handler => {

--- a/src/modules/map/components/olMap/OlMap.js
+++ b/src/modules/map/components/olMap/OlMap.js
@@ -11,6 +11,7 @@ import { changeZoomAndCenter } from '../../store/position.action';
 import { $injector } from '../../../../injection';
 import { toOlLayer, updateOlLayer, toOlLayerFromHandler } from './olMapUtils';
 import { setBeingDragged, setContextClick, setPointerMove } from '../../store/pointer.action';
+import { setBeingMoved, setMoveEnd, setMoveStart } from '../../store/map.action';
 
 
 /**
@@ -84,11 +85,18 @@ export class OlMap extends BaElement {
 			}),
 		});
 
+		this._map.on('movestart', () => {
+			setMoveStart();
+			setBeingMoved(true);
+		});
+
 		this._map.on('moveend', () => {
 			if (this._view) {
 				this._syncStore();
 			}
 			setBeingDragged(false);
+			setMoveEnd();
+			setBeingMoved(false);
 		});
 
 		this._map.addEventListener('contextmenu', (evt) => {
@@ -99,7 +107,7 @@ export class OlMap extends BaElement {
 
 		this._map.on('pointermove', (evt) => {
 			if (evt.dragging) {
-				// the event is a drag gesture, twe handle it in 'pointerdrag'
+				// the event is a drag gesture, so we handle it in 'pointerdrag'
 				return;
 			}
 			const coord = this._map.getEventCoordinate(evt.originalEvent);

--- a/src/modules/map/components/olMap/OlMap.js
+++ b/src/modules/map/components/olMap/OlMap.js
@@ -10,7 +10,7 @@ import { removeLayer } from '../../store/layers.action';
 import { changeZoomAndCenter } from '../../store/position.action';
 import { $injector } from '../../../../injection';
 import { toOlLayer, updateOlLayer, toOlLayerFromHandler } from './olMapUtils';
-import { setPointer } from '../../store/map.action';
+import { setBeingDragged, setPointer } from '../../store/map.action';
 
 
 /**
@@ -88,16 +88,21 @@ export class OlMap extends BaElement {
 			if (this._view) {
 				this._syncStore();
 			}
+			setBeingDragged(false);
 		});
 
 
 		this._map.on('pointermove', (evt) => {
 			if (evt.dragging) {
-				// the event is a drag gesture, this is handled by openlayers (map move)
+				// the event is a drag gesture, twe handle it in 'pointerdrag'
 				return;
 			}
 			const coord = this._map.getEventCoordinate(evt.originalEvent);
 			setPointer({ coordinate: coord, screenCoordinate: [evt.originalEvent.clientX, evt.originalEvent.clientY] });
+		});
+
+		this._map.on('pointerdrag', () => {
+			setBeingDragged(true);
 		});
 
 		this._eventHandler.forEach(handler => {

--- a/src/modules/map/components/olMap/OlMap.js
+++ b/src/modules/map/components/olMap/OlMap.js
@@ -100,7 +100,7 @@ export class OlMap extends BaElement {
 		});
 
 		this._map.addEventListener('contextmenu', (evt) => {
-			evt.preventDefault();
+			// evt.preventDefault();
 			const coord = this._map.getEventCoordinate(evt.originalEvent);
 			setContextClick({ coordinate: coord, screenCoordinate: [evt.originalEvent.clientX, evt.originalEvent.clientY] });
 		});

--- a/src/modules/map/store/map.action.js
+++ b/src/modules/map/store/map.action.js
@@ -5,10 +5,10 @@
 
 import { $injector } from '../../../injection';
 import { EventLike } from '../../../utils/storeUtils';
-import { BEING_DRAGGED_CHANGED, CLICK_CHANGED, CONTEXT_CLICK_CHANGED } from './map.reducer';
+import { BEING_DRAGGED_CHANGED, CLICK_CHANGED, CONTEXT_CLICK_CHANGED, POINTER_CHANGED } from './map.reducer';
 
 /**
-* @typedef {Object} Click
+* @typedef {Object} PointerEvent
 * @param {number[]} coordinate Of the last click expressed in EPSG:3857
 * @param {number[]} screenCoordinate Of the last click expressed pixel
 */
@@ -22,24 +22,36 @@ const getStore = () => {
 /**
  * Sets information about the last click that occurred on the map.
  * @function
- * @param {Click} click 
+ * @param {PointerEvent} pointerEvent 
  */
-export const setClick = (click) => {
+export const setClick = (pointerEvent) => {
 	getStore().dispatch({
 		type: CLICK_CHANGED,
-		payload: new EventLike(click)
+		payload: new EventLike(pointerEvent)
 	});
 };
 
 /**
  * Sets information about the last context click that occurred on the map.
  * @function
- * @param {Click} click 
+ * @param {PointerEvent} pointerEvent 
  */
-export const setContextClick = (click) => {
+export const setContextClick = (pointerEvent) => {
 	getStore().dispatch({
 		type: CONTEXT_CLICK_CHANGED,
-		payload: new EventLike(click)
+		payload: new EventLike(pointerEvent)
+	});
+};
+
+/**
+ * Sets information about the last pointer move occurred on the map.
+ * @function
+ * @param {PointerEvent} pointerEvent 
+ */
+export const setPointer = (pointerEvent) => {
+	getStore().dispatch({
+		type: POINTER_CHANGED,
+		payload: new EventLike(pointerEvent)
 	});
 };
 
@@ -54,3 +66,4 @@ export const setBeingDragged = (dragged) => {
 		payload: dragged
 	});
 };
+

--- a/src/modules/map/store/map.action.js
+++ b/src/modules/map/store/map.action.js
@@ -1,0 +1,56 @@
+/**
+ * Action creators to update state concerning map related information
+ * @module map/action
+ */
+
+import { $injector } from '../../../injection';
+import { EventLike } from '../../../utils/storeUtils';
+import { BEING_DRAGGED_CHANGED, CLICK_CHANGED, CONTEXT_CLICK_CHANGED } from './map.reducer';
+
+/**
+* @typedef {Object} Click
+* @param {number[]} coordinate Of the last click expressed in EPSG:3857
+* @param {number[]} screenCoordinate Of the last click expressed pixel
+*/
+
+
+const getStore = () => {
+	const { StoreService: storeService } = $injector.inject('StoreService');
+	return storeService.getStore();
+};
+
+/**
+ * Sets information about the last click that occurred on the map.
+ * @function
+ * @param {Click} click 
+ */
+export const setClick = (click) => {
+	getStore().dispatch({
+		type: CLICK_CHANGED,
+		payload: new EventLike(click)
+	});
+};
+
+/**
+ * Sets information about the last context click that occurred on the map.
+ * @function
+ * @param {Click} click 
+ */
+export const setContextClick = (click) => {
+	getStore().dispatch({
+		type: CONTEXT_CLICK_CHANGED,
+		payload: new EventLike(click)
+	});
+};
+
+/**
+ * Sets information wether map is being dragged.
+ * @function
+ * @param {boolean} dragged 
+ */
+export const setBeingDragged = (dragged) => {
+	getStore().dispatch({
+		type: BEING_DRAGGED_CHANGED,
+		payload: dragged
+	});
+};

--- a/src/modules/map/store/map.action.js
+++ b/src/modules/map/store/map.action.js
@@ -1,0 +1,54 @@
+/**
+ * Action creators concerning interactions of a user with the map
+ * @module map/action
+ */
+
+import { $injector } from '../../../injection';
+import { EventLike } from '../../../utils/storeUtils';
+import { BEING_MOVED_CHANGED, MOVE_START_CHANGED, MOVE_END_CHANGED } from './map.reducer';
+
+/**
+* @typedef {Object} PointerEvent
+* @param {number[]} coordinate Of the last click expressed in EPSG:3857
+* @param {number[]} screenCoordinate Of the last click expressed pixel
+*/
+
+
+const getStore = () => {
+	const { StoreService: storeService } = $injector.inject('StoreService');
+	return storeService.getStore();
+};
+
+/**
+ * Sets information wether moving the map starts
+ * @function
+ */
+export const setMoveStart = () => {
+	getStore().dispatch({
+		type: MOVE_START_CHANGED,
+		payload: new EventLike('movestart')
+	});
+};
+
+/**
+ * Sets information wether moving the map ends
+ * @function
+ */
+export const setMoveEnd = () => {
+	getStore().dispatch({
+		type: MOVE_END_CHANGED,
+		payload: new EventLike('moveend')
+	});
+};
+
+/**
+ * Sets information wether map is being moved
+ * @function
+ * @param {boolean} moved 
+ */
+export const setBeingMoved = (moved) => {
+	getStore().dispatch({
+		type: BEING_MOVED_CHANGED,
+		payload: moved
+	});
+};

--- a/src/modules/map/store/map.reducer.js
+++ b/src/modules/map/store/map.reducer.js
@@ -1,0 +1,53 @@
+
+export const BEING_MOVED_CHANGED = 'pointer/beingMoved';
+export const MOVE_START_CHANGED = 'pointer/moveStart';
+export const MOVE_END_CHANGED = 'pointer/moveEnd';
+
+export const initialState = {
+
+	/**
+	 * @type EventLike
+	 */
+	moveStart: null,
+
+	/**
+	 * @type EventLike
+	 */
+	moveEnd: null,
+
+	/**
+	 * @type {boolean}
+	 */
+	beingMoved: false,
+};
+
+
+export const mapReducer = (state = initialState, action) => {
+
+	const { type, payload } = action;
+	switch (type) {
+		case BEING_MOVED_CHANGED: {
+
+			return {
+				...state,
+				beingMoved: payload
+			};
+		}
+		case MOVE_START_CHANGED: {
+
+			return {
+				...state,
+				moveStart: payload
+			};
+		}
+		case MOVE_END_CHANGED: {
+
+			return {
+				...state,
+				moveEnd: payload
+			};
+		}
+	}
+
+	return state;
+};

--- a/src/modules/map/store/map.reducer.js
+++ b/src/modules/map/store/map.reducer.js
@@ -1,0 +1,53 @@
+export const CLICK_CHANGED = 'map/click';
+export const CONTEXT_CLICK_CHANGED = 'map/contextClick';
+export const BEING_DRAGGED_CHANGED = 'map/beingDragged';
+
+export const initialState = {
+
+    /**
+     * @type {EventLike<Click>}
+     */
+    click: null,
+
+    /**
+     * @type {EventLike<Click>}
+     */
+    contextClick: null,
+
+    /**
+     * @type {boolean}
+     */
+    beingDragged: false,
+
+};
+
+
+export const mapReducer = (state = initialState, action) => {
+
+    const { type, payload } = action;
+    switch (type) {
+        case CLICK_CHANGED: {
+
+            return {
+                ...state,
+                click: payload
+            }
+        }
+        case CONTEXT_CLICK_CHANGED: {
+
+            return {
+                ...state,
+                contextClick: payload
+            };
+        }
+        case BEING_DRAGGED_CHANGED: {
+
+            return {
+                ...state,
+                beingDragged: payload
+            };
+        }
+    }
+
+    return state;
+};

--- a/src/modules/map/store/map.reducer.js
+++ b/src/modules/map/store/map.reducer.js
@@ -1,53 +1,66 @@
 export const CLICK_CHANGED = 'map/click';
 export const CONTEXT_CLICK_CHANGED = 'map/contextClick';
 export const BEING_DRAGGED_CHANGED = 'map/beingDragged';
+export const POINTER_CHANGED = 'map/pointer';
 
 export const initialState = {
 
-    /**
+	/**
      * @type {EventLike<Click>}
      */
-    click: null,
+	click: null,
 
-    /**
+	/**
      * @type {EventLike<Click>}
      */
-    contextClick: null,
+	contextClick: null,
 
-    /**
+	/**
      * @type {boolean}
      */
-    beingDragged: false,
+	beingDragged: false,
+
+	/**
+     * @type {EventLike<Click>}
+     */
+	pointer: null
 
 };
 
 
 export const mapReducer = (state = initialState, action) => {
 
-    const { type, payload } = action;
-    switch (type) {
-        case CLICK_CHANGED: {
+	const { type, payload } = action;
+	switch (type) {
+		case CLICK_CHANGED: {
 
-            return {
-                ...state,
-                click: payload
-            }
-        }
-        case CONTEXT_CLICK_CHANGED: {
+			return {
+				...state,
+				click: payload
+			};
+		}
+		case CONTEXT_CLICK_CHANGED: {
 
-            return {
-                ...state,
-                contextClick: payload
-            };
-        }
-        case BEING_DRAGGED_CHANGED: {
+			return {
+				...state,
+				contextClick: payload
+			};
+		}
+		case POINTER_CHANGED: {
 
-            return {
-                ...state,
-                beingDragged: payload
-            };
-        }
-    }
+			return {
+				...state,
+				pointer: payload
+			};
+		}
+		case BEING_DRAGGED_CHANGED: {
 
-    return state;
+			return {
+				...state,
+				beingDragged: payload
+			};
+		}
+	}
+
+	return state;
 };

--- a/src/modules/map/store/pointer.action.js
+++ b/src/modules/map/store/pointer.action.js
@@ -5,7 +5,7 @@
 
 import { $injector } from '../../../injection';
 import { EventLike } from '../../../utils/storeUtils';
-import { BEING_DRAGGED_CHANGED, CLICK_CHANGED, CONTEXT_CLICK_CHANGED, POINTER_CHANGED } from './map.reducer';
+import { BEING_DRAGGED_CHANGED, CLICK_CHANGED, CONTEXT_CLICK_CHANGED, POINTER_MOVE_CHANGED } from './pointer.reducer';
 
 /**
 * @typedef {Object} PointerEvent
@@ -48,9 +48,9 @@ export const setContextClick = (pointerEvent) => {
  * @function
  * @param {PointerEvent} pointerEvent 
  */
-export const setPointer = (pointerEvent) => {
+export const setPointerMove = (pointerEvent) => {
 	getStore().dispatch({
-		type: POINTER_CHANGED,
+		type: POINTER_MOVE_CHANGED,
 		payload: new EventLike(pointerEvent)
 	});
 };

--- a/src/modules/map/store/pointer.action.js
+++ b/src/modules/map/store/pointer.action.js
@@ -1,5 +1,5 @@
 /**
- * Action creators to update state concerning map related information
+ * Action creators concerning pointer based interactions of the user.
  * @module map/action
  */
 
@@ -56,7 +56,7 @@ export const setPointerMove = (pointerEvent) => {
 };
 
 /**
- * Sets information wether map is being dragged.
+ * Sets information wether the pointer is being dragged.
  * @function
  * @param {boolean} dragged 
  */

--- a/src/modules/map/store/pointer.reducer.js
+++ b/src/modules/map/store/pointer.reducer.js
@@ -1,17 +1,17 @@
-export const CLICK_CHANGED = 'map/click';
-export const CONTEXT_CLICK_CHANGED = 'map/contextClick';
-export const BEING_DRAGGED_CHANGED = 'map/beingDragged';
-export const POINTER_CHANGED = 'map/pointer';
+export const CLICK_CHANGED = 'pointer/click';
+export const CONTEXT_CLICK_CHANGED = 'pointer/contextClick';
+export const BEING_DRAGGED_CHANGED = 'pointer/beingDragged';
+export const POINTER_MOVE_CHANGED = 'pointer/move';
 
 export const initialState = {
 
 	/**
-     * @type {EventLike<Click>}
+     * @type {EventLike<PointerEvent>}
      */
 	click: null,
 
 	/**
-     * @type {EventLike<Click>}
+     * @type {EventLike<PointerEvent>}
      */
 	contextClick: null,
 
@@ -21,14 +21,14 @@ export const initialState = {
 	beingDragged: false,
 
 	/**
-     * @type {EventLike<Click>}
+     * @type {EventLike<PointerEvent>}
      */
-	pointer: null
+	move: null
 
 };
 
 
-export const mapReducer = (state = initialState, action) => {
+export const pointerReducer = (state = initialState, action) => {
 
 	const { type, payload } = action;
 	switch (type) {
@@ -46,11 +46,11 @@ export const mapReducer = (state = initialState, action) => {
 				contextClick: payload
 			};
 		}
-		case POINTER_CHANGED: {
+		case POINTER_MOVE_CHANGED: {
 
 			return {
 				...state,
-				pointer: payload
+				move: payload
 			};
 		}
 		case BEING_DRAGGED_CHANGED: {

--- a/src/modules/map/store/position.action.js
+++ b/src/modules/map/store/position.action.js
@@ -93,8 +93,8 @@ export const updatePointerPosition = (position) => {
 };
 
 /**
- * Sets a fit request,
- * The fitRequest object is wrapper by an {@link EventLike} object
+ * Sets a fit request.
+ * The fitRequest object is wrapper by an {@link EventLike} object.
  * @param {FitRequest} fitRequest
  * @function
  */

--- a/src/modules/map/store/position.action.js
+++ b/src/modules/map/store/position.action.js
@@ -1,8 +1,8 @@
 /**
- * Action creators to change/update the properties of map state.
+ * Action creators to change/update the properties concerning the resolution and center of a map.
  * @module map/action
  */
-import { ZOOM_CHANGED, CENTER_CHANGED, ZOOM_CENTER_CHANGED, POINTER_POSITION_CHANGED, FIT_REQUESTED } from './position.reducer';
+import { ZOOM_CHANGED, CENTER_CHANGED, ZOOM_CENTER_CHANGED, FIT_REQUESTED } from './position.reducer';
 import { $injector } from '../../../injection';
 import { EventLike } from '../../../utils/storeUtils';
 
@@ -78,17 +78,6 @@ export const changeCenter = (center) => {
 	getStore().dispatch({
 		type: CENTER_CHANGED,
 		payload: center
-	});
-};
-
-/**
- * Updates the pointer position.
- * @function
- */
-export const updatePointerPosition = (position) => {
-	getStore().dispatch({
-		type: POINTER_POSITION_CHANGED,
-		payload: position
 	});
 };
 

--- a/src/modules/map/store/position.reducer.js
+++ b/src/modules/map/store/position.reducer.js
@@ -1,7 +1,6 @@
 export const ZOOM_CHANGED = 'position/zoom';
 export const CENTER_CHANGED = 'position/center';
 export const ZOOM_CENTER_CHANGED = 'position/zoom_center';
-export const POINTER_POSITION_CHANGED = 'position/pointerPosition';
 export const FIT_REQUESTED = 'position/fit';
 
 
@@ -38,14 +37,6 @@ export const positionReducer = (state = initialState, action) => {
 				...state,
 				zoom: zoom,
 				center: center
-			};
-		}
-
-		case POINTER_POSITION_CHANGED: {
-
-			return {
-				...state,
-				pointerPosition: payload
 			};
 		}
 

--- a/src/modules/map/store/position.reducer.js
+++ b/src/modules/map/store/position.reducer.js
@@ -7,7 +7,6 @@ export const FIT_REQUESTED = 'position/fit';
 export const initialState = {
 	zoom: 12,
 	center: [1288239.2412306187, 6130212.561641981],
-	pointerPosition : null,
 	fitRequest : null
 };
 

--- a/src/services/StoreService.js
+++ b/src/services/StoreService.js
@@ -9,7 +9,7 @@ import { mapContextMenuReducer } from '../modules/map/store/mapContextMenu.reduc
 import ReduxQuerySync from 'redux-query-sync';
 import { measurementReducer } from '../modules/map/store/measurement.reducer';
 import { register as registerMeasurementObserver } from '../modules/map/store/measurement.observer';
-import { mapReducer } from '../modules/map/store/map.reducer';
+import { pointerReducer } from '../modules/map/store/pointer.reducer';
 
 
 
@@ -70,7 +70,7 @@ export class StoreService {
 			 * must be named like the field of the state
 			 * see: https://redux.js.org/recipes/structuring-reducers/initializing-state#combined-reducers
 			 */
-			map: mapReducer,
+			pointer: pointerReducer,
 			position: positionReducer,
 			sidePanel: sidePanelReducer,
 			contextMenue: contextMenueReducer,

--- a/src/services/StoreService.js
+++ b/src/services/StoreService.js
@@ -10,6 +10,7 @@ import ReduxQuerySync from 'redux-query-sync';
 import { measurementReducer } from '../modules/map/store/measurement.reducer';
 import { register as registerMeasurementObserver } from '../modules/map/store/measurement.observer';
 import { pointerReducer } from '../modules/map/store/pointer.reducer';
+import { mapReducer } from '../modules/map/store/map.reducer';
 
 
 
@@ -70,6 +71,7 @@ export class StoreService {
 			 * must be named like the field of the state
 			 * see: https://redux.js.org/recipes/structuring-reducers/initializing-state#combined-reducers
 			 */
+			map: mapReducer,
 			pointer: pointerReducer,
 			position: positionReducer,
 			sidePanel: sidePanelReducer,

--- a/src/services/StoreService.js
+++ b/src/services/StoreService.js
@@ -9,6 +9,7 @@ import { mapContextMenuReducer } from '../modules/map/store/mapContextMenu.reduc
 import ReduxQuerySync from 'redux-query-sync';
 import { measurementReducer } from '../modules/map/store/measurement.reducer';
 import { register as registerMeasurementObserver } from '../modules/map/store/measurement.observer';
+import { mapReducer } from '../modules/map/store/map.reducer';
 
 
 
@@ -69,6 +70,7 @@ export class StoreService {
 			 * must be named like the field of the state
 			 * see: https://redux.js.org/recipes/structuring-reducers/initializing-state#combined-reducers
 			 */
+			map: mapReducer,
 			position: positionReducer,
 			sidePanel: sidePanelReducer,
 			contextMenue: contextMenueReducer,

--- a/test/modules/footer/components/coordinateSelect/CoordinateSelect.test.js
+++ b/test/modules/footer/components/coordinateSelect/CoordinateSelect.test.js
@@ -1,8 +1,8 @@
 import { CoordinateSelect } from '../../../../../src/modules/footer/components/coordinateSelect/CoordinateSelect';
 import { $injector } from '../../../../../src/injection';
 import { TestUtils } from '../../../../test-utils.js';
-import { setPointer } from '../../../../../src/modules/map/store/map.action';
-import { mapReducer } from '../../../../../src/modules/map/store/map.reducer';
+import { setPointerMove } from '../../../../../src/modules/map/store/pointer.action';
+import { pointerReducer } from '../../../../../src/modules/map/store/pointer.reducer';
 
 window.customElements.define(CoordinateSelect.tag, CoordinateSelect);
 
@@ -29,12 +29,12 @@ describe('CoordinateSelect', () => {
 		const { touch = false } = config;
 
 		const state = {
-			map: {
+			pointer: {
 				pointer: null
 			}
 		};
 
-		TestUtils.setupStoreAndDi(state, { map: mapReducer });
+		TestUtils.setupStoreAndDi(state, { pointer: pointerReducer });
 
 		$injector
 			.registerSingleton('TranslationService', { translate: (key) => key });
@@ -59,7 +59,7 @@ describe('CoordinateSelect', () => {
 		it('adds a div which shows coordinate select and coordinate display', async () => {
 			const element = await setup({ touch: false });
 
-			setPointer({ coordinate: [12345, 67890], screenCoordinate: [] });
+			setPointerMove({ coordinate: [12345, 67890], screenCoordinate: [] });
 
 			const container = element.shadowRoot.querySelector('.coordinate-container');
 
@@ -84,7 +84,7 @@ describe('CoordinateSelect', () => {
 			const testCoordinate = [1211817.6233080907, 6168328.021915435]; 
 
 			// coordinates are shown after the pointer is moved, so initial there are no coordinates visible
-			setPointer({ coordinate: testCoordinate, screenCoordinate: [] });
+			setPointerMove({ coordinate: testCoordinate, screenCoordinate: [] });
 
 			expect(element.shadowRoot.querySelector('select').value).toEqual('99999');
 			expect(element.shadowRoot.querySelector('.select-coordinate-option').innerHTML.includes('TEST')).toBeTruthy();
@@ -105,7 +105,7 @@ describe('CoordinateSelect', () => {
 			const toLonLatMock = spyOn(coordinateServiceMock, 'toLonLat').and.returnValue([42, 42]);
 
 			const testCoordinate = [23, 23];
-			setPointer({ coordinate: testCoordinate, screenCoordinate: [] });
+			setPointerMove({ coordinate: testCoordinate, screenCoordinate: [] });
 
 			const select = element.shadowRoot.querySelector('select');
 
@@ -117,7 +117,7 @@ describe('CoordinateSelect', () => {
 			// change to code '1111' - toLonLat method is called
 			select.value = '1111';
 			select.dispatchEvent(new Event('change'));
-			setPointer({ coordinate: testCoordinate, screenCoordinate: [] });
+			setPointerMove({ coordinate: testCoordinate, screenCoordinate: [] });
 			expect(element.shadowRoot.innerHTML.includes('stringified coordinate')).toBeTruthy();
 			expect(toLonLatMock).toHaveBeenCalledWith(testCoordinate);
 			expect(stringifyMock).toHaveBeenCalledWith([42, 42], 1111, { digits: 5 });

--- a/test/modules/footer/components/coordinateSelect/CoordinateSelect.test.js
+++ b/test/modules/footer/components/coordinateSelect/CoordinateSelect.test.js
@@ -1,8 +1,8 @@
 import { CoordinateSelect } from '../../../../../src/modules/footer/components/coordinateSelect/CoordinateSelect';
-import { positionReducer } from '../../../../../src/modules/map/store/position.reducer';
 import { $injector } from '../../../../../src/injection';
-import { updatePointerPosition } from '../../../../../src/modules/map/store/position.action';
 import { TestUtils } from '../../../../test-utils.js';
+import { setPointer } from '../../../../../src/modules/map/store/map.action';
+import { mapReducer } from '../../../../../src/modules/map/store/map.reducer';
 
 window.customElements.define(CoordinateSelect.tag, CoordinateSelect);
 
@@ -29,13 +29,12 @@ describe('CoordinateSelect', () => {
 		const { touch = false } = config;
 
 		const state = {
-			position: {
-				zoom: 5,
-				pointerPosition: null
+			map: {
+				pointer: null
 			}
 		};
 
-		TestUtils.setupStoreAndDi(state, { position: positionReducer });
+		TestUtils.setupStoreAndDi(state, { map: mapReducer });
 
 		$injector
 			.registerSingleton('TranslationService', { translate: (key) => key });
@@ -60,7 +59,7 @@ describe('CoordinateSelect', () => {
 		it('adds a div which shows coordinate select and coordinate display', async () => {
 			const element = await setup({ touch: false });
 
-			updatePointerPosition([12345, 67890]);
+			setPointer({ coordinate: [12345, 67890], screenCoordinate: [] });
 
 			const container = element.shadowRoot.querySelector('.coordinate-container');
 
@@ -85,7 +84,7 @@ describe('CoordinateSelect', () => {
 			const testCoordinate = [1211817.6233080907, 6168328.021915435]; 
 
 			// coordinates are shown after the pointer is moved, so initial there are no coordinates visible
-			updatePointerPosition(testCoordinate); 
+			setPointer({ coordinate: testCoordinate, screenCoordinate: [] });
 
 			expect(element.shadowRoot.querySelector('select').value).toEqual('99999');
 			expect(element.shadowRoot.querySelector('.select-coordinate-option').innerHTML.includes('TEST')).toBeTruthy();
@@ -106,7 +105,7 @@ describe('CoordinateSelect', () => {
 			const toLonLatMock = spyOn(coordinateServiceMock, 'toLonLat').and.returnValue([42, 42]);
 
 			const testCoordinate = [23, 23];
-			updatePointerPosition(testCoordinate); 
+			setPointer({ coordinate: testCoordinate, screenCoordinate: [] });
 
 			const select = element.shadowRoot.querySelector('select');
 
@@ -118,7 +117,7 @@ describe('CoordinateSelect', () => {
 			// change to code '1111' - toLonLat method is called
 			select.value = '1111';
 			select.dispatchEvent(new Event('change'));
-			updatePointerPosition(testCoordinate); 
+			setPointer({ coordinate: testCoordinate, screenCoordinate: [] });
 			expect(element.shadowRoot.innerHTML.includes('stringified coordinate')).toBeTruthy();
 			expect(toLonLatMock).toHaveBeenCalledWith(testCoordinate);
 			expect(stringifyMock).toHaveBeenCalledWith([42, 42], 1111, { digits: 5 });
@@ -130,9 +129,6 @@ describe('CoordinateSelect', () => {
 			expect(transformMock).toHaveBeenCalledWith(testCoordinate, 3857, 99999);
 			expect(stringifyMock).toHaveBeenCalledWith([21, 21], 99999);
 
-			// pointer position initial state (null)
-			updatePointerPosition(null);
-			expect(element.shadowRoot.querySelector('.coordinate-label')).toBeFalsy();
 		});
 	});
 

--- a/test/modules/map/components/olMap/OlMap.test.js
+++ b/test/modules/map/components/olMap/OlMap.test.js
@@ -125,7 +125,7 @@ describe('OlMap', () => {
 	describe('pointermove', () => {
 		
 		describe('when pointer move', () => {
-			it('updates the \'pointer\' property in map store', async () => {
+			it('updates the \'pointer\' property in pointer store', async () => {
 				const element = await setup();
 				const map = element._map;
 				const coordinate = [38, 75];
@@ -140,7 +140,7 @@ describe('OlMap', () => {
 		});
 		
 		describe('when pointer is dragging', () => {
-			it('does NOT update the \'pointer\' property in map store', async () => {
+			it('does NOT update the \'pointer\' property in pointer store', async () => {
 				const element = await setup();
 				const map = element._map;
 				const coordinate = [38, 75];
@@ -157,7 +157,7 @@ describe('OlMap', () => {
 	describe('pointerdrag', () => {
 		
 		describe('when pointer drag', () => {
-			it('updates the \'beingDragged\' property in map store', async () => {
+			it('updates the \'beingDragged\' property in pointer store', async () => {
 				const element = await setup();
 				const map = element._map;
 				const coordinate = [38, 75];
@@ -176,6 +176,24 @@ describe('OlMap', () => {
 				simulateMapEvent(element._map, MapEventType.MOVEEND);
 				
 				expect(beingDraggedEndChangeSpy).toHaveBeenCalledOnceWith(false, store.getState());
+			});
+		});
+	});
+
+	describe('contextmenu', () => {
+		
+		describe('when contextmenu click', () => {
+			it('updates the \'contextclick\' property in pointer store', async () => {
+				const element = await setup();
+				const map = element._map;
+				const coordinate = [38, 75];
+				const screenCoordinate = [21, 42];
+				spyOn(map, 'getEventCoordinate').and.returnValue(coordinate);
+				
+				simulateMouseEvent(map, 'contextmenu', ...screenCoordinate);
+				
+				expect(store.getState().pointer.contextClick.payload.coordinate).toEqual(coordinate);
+				expect(store.getState().pointer.contextClick.payload.screenCoordinate).toEqual(screenCoordinate);
 			});
 		});
 	});

--- a/test/modules/map/components/olMap/OlMap.test.js
+++ b/test/modules/map/components/olMap/OlMap.test.js
@@ -15,7 +15,7 @@ import { simulateMapEvent, simulateMouseEvent } from './mapTestUtils';
 import VectorLayer from 'ol/layer/Vector';
 import { MEASUREMENT_LAYER_ID, register as registerMeasurementObserver } from '../../../../../src/modules/map/store/measurement.observer';
 import { measurementReducer } from '../../../../../src/modules/map/store/measurement.reducer';
-import { mapReducer } from '../../../../../src/modules/map/store/map.reducer';
+import { pointerReducer } from '../../../../../src/modules/map/store/pointer.reducer';
 import { observe } from '../../../../../src/utils/storeUtils';
 
 window.customElements.define(OlMap.tag, OlMap);
@@ -75,7 +75,7 @@ describe('OlMap', () => {
 		};
 
 		store = TestUtils.setupStoreAndDi(combinedState, {
-			map: mapReducer,
+			pointer: pointerReducer,
 			position: positionReducer,
 			layers: layersReducer,
 			measurement: measurementReducer
@@ -134,13 +134,13 @@ describe('OlMap', () => {
 				
 				simulateMouseEvent(element._map, MapBrowserEventType.POINTERMOVE, ...screenCoordinate);
 				
-				expect(store.getState().map.pointer.payload.coordinate).toEqual(coordinate);
-				expect(store.getState().map.pointer.payload.screenCoordinate).toEqual(screenCoordinate);
+				expect(store.getState().pointer.move.payload.coordinate).toEqual(coordinate);
+				expect(store.getState().pointer.move.payload.screenCoordinate).toEqual(screenCoordinate);
 			});
 		});
 		
 		describe('when pointer is dragging', () => {
-			it('dous NOT update the \'pointer\' property in map store', async () => {
+			it('does NOT update the \'pointer\' property in map store', async () => {
 				const element = await setup();
 				const map = element._map;
 				const coordinate = [38, 75];
@@ -149,7 +149,7 @@ describe('OlMap', () => {
 
 				simulateMouseEvent(element._map, MapBrowserEventType.POINTERMOVE, ...screenCoordinate, true);
 				
-				expect(store.getState().map.pointer).toBeNull();
+				expect(store.getState().pointer.move).toBeNull();
 			});
 		});
 	});
@@ -164,7 +164,7 @@ describe('OlMap', () => {
 				const screenCoordinate = [21, 42];
 				spyOn(map, 'getEventCoordinate').and.returnValue(coordinate);
 				const beingDraggedBeginChangeSpy = jasmine.createSpy();
-				observe(store, state => state.map.beingDragged, beingDraggedBeginChangeSpy);
+				observe(store, state => state.pointer.beingDragged, beingDraggedBeginChangeSpy);
 				
 				
 				simulateMouseEvent(element._map, MapBrowserEventType.POINTERDRAG, ...screenCoordinate, true);
@@ -172,7 +172,7 @@ describe('OlMap', () => {
 				expect(beingDraggedBeginChangeSpy).toHaveBeenCalledOnceWith(true, store.getState());
 				
 				const beingDraggedEndChangeSpy = jasmine.createSpy();
-				observe(store, state => state.map.beingDragged, beingDraggedEndChangeSpy);
+				observe(store, state => state.pointer.beingDragged, beingDraggedEndChangeSpy);
 				simulateMapEvent(element._map, MapEventType.MOVEEND);
 				
 				expect(beingDraggedEndChangeSpy).toHaveBeenCalledOnceWith(false, store.getState());

--- a/test/modules/map/components/olMap/OlMap.test.js
+++ b/test/modules/map/components/olMap/OlMap.test.js
@@ -15,6 +15,7 @@ import { simulateMapEvent, simulateMouseEvent } from './mapTestUtils';
 import VectorLayer from 'ol/layer/Vector';
 import { MEASUREMENT_LAYER_ID, register as registerMeasurementObserver } from '../../../../../src/modules/map/store/measurement.observer';
 import { measurementReducer } from '../../../../../src/modules/map/store/measurement.reducer';
+import { mapReducer } from '../../../../../src/modules/map/store/map.reducer';
 
 window.customElements.define(OlMap.tag, OlMap);
 
@@ -73,6 +74,7 @@ describe('OlMap', () => {
 		};
 
 		store = TestUtils.setupStoreAndDi(combinedState, {
+			map: mapReducer,
 			position: positionReducer,
 			layers: layersReducer,
 			measurement: measurementReducer
@@ -120,15 +122,17 @@ describe('OlMap', () => {
 	});
 
 	describe('when pointer move', () => {
-		it('pointer position store is updated', async () => {
+		it('updates the pointer property in map store', async () => {
 			const element = await setup();
 			const map = element._map;
-			const pointerPosition = ['foo', 'bar'];
-			spyOn(map, 'getEventCoordinate').and.returnValue(pointerPosition);
+			const coordinate = [38, 75];
+			const screenCoordinate = [21, 42];
+			spyOn(map, 'getEventCoordinate').and.returnValue(coordinate);
 
-			simulateMouseEvent(element._map, MapBrowserEventType.POINTERMOVE, 10, 0);
+			simulateMouseEvent(element._map, MapBrowserEventType.POINTERMOVE, ...screenCoordinate);
 
-			expect(store.getState().position.pointerPosition).toBe(pointerPosition);
+			expect(store.getState().map.pointer.payload.coordinate).toEqual(coordinate);
+			expect(store.getState().map.pointer.payload.screenCoordinate).toEqual(screenCoordinate);
 		});
 	});
 
@@ -136,12 +140,13 @@ describe('OlMap', () => {
 		it('do NOT store pointerPosition', async () => {
 			const element = await setup();
 			const map = element._map;
-			const pointerPosition = [99, 99];
-			spyOn(map, 'getEventCoordinate').and.returnValue(pointerPosition);
+			const coordinate = [38, 75];
+			const screenCoordinate = [21, 42];
+			spyOn(map, 'getEventCoordinate').and.returnValue(coordinate);
 
-			simulateMouseEvent(element._map, MapBrowserEventType.POINTERMOVE, 10, 0, true);
+			simulateMouseEvent(element._map, MapBrowserEventType.POINTERMOVE, ...screenCoordinate, true);
 
-			expect(store.getState().position.pointerPosition).toBeUndefined();
+			expect(store.getState().map.pointer).toBeNull();
 		});
 	});
 

--- a/test/modules/map/store/map.reducer.test.js
+++ b/test/modules/map/store/map.reducer.test.js
@@ -1,5 +1,5 @@
 import { mapReducer } from '../../../../src/modules/map/store/map.reducer';
-import { setClick, setContextClick, setBeingDragged } from '../../../../src/modules/map/store/map.action';
+import { setClick, setContextClick, setBeingDragged, setPointer } from '../../../../src/modules/map/store/map.action';
 import { TestUtils } from '../../../test-utils.js';
 
 
@@ -20,20 +20,29 @@ describe('mapReducer', () => {
 
 	it('changes the \'click\' property', () => {
 		const store = setup();
-		const click = { coordinate: [38, 57], screenCoordinate: [21, 42] };
+		const pointerEvent = { coordinate: [38, 57], screenCoordinate: [21, 42] };
 
-		setClick(click);
+		setClick(pointerEvent);
 
-		expect(store.getState().map.click.payload).toEqual(click);
+		expect(store.getState().map.click.payload).toEqual(pointerEvent);
 	});
 
 	it('changes the \'contextClick\' property', () => {
 		const store = setup();
-		const click = { coordinate: [57, 38], screenCoordinate: [42, 21] };
+		const pointerEvent = { coordinate: [57, 38], screenCoordinate: [42, 21] };
 
-		setContextClick(click);
+		setContextClick(pointerEvent);
 
-		expect(store.getState().map.contextClick.payload).toEqual(click);
+		expect(store.getState().map.contextClick.payload).toEqual(pointerEvent);
+	});
+
+	it('changes the \'pointer\' property', () => {
+		const store = setup();
+		const pointerEvent = { coordinate: [7, 8], screenCoordinate: [2, 1] };
+
+		setPointer(pointerEvent);
+
+		expect(store.getState().map.pointer.payload).toEqual(pointerEvent);
 	});
 
 	it('changes the \'beingDragged\' property', () => {

--- a/test/modules/map/store/map.reducer.test.js
+++ b/test/modules/map/store/map.reducer.test.js
@@ -1,0 +1,50 @@
+import { mapReducer } from '../../../../src/modules/map/store/map.reducer';
+import { setClick, setContextClick, setBeingDragged } from '../../../../src/modules/map/store/map.action';
+import { TestUtils } from '../../../test-utils.js';
+
+
+describe('mapReducer', () => {
+
+	const setup = (state) => {
+		return TestUtils.setupStoreAndDi(state, {
+			map: mapReducer
+		});
+	};
+
+	it('initiales the store with default values', () => {
+		const store = setup();
+		expect(store.getState().map.click).toBeNull();
+		expect(store.getState().map.contextClick).toBeNull();
+		expect(store.getState().map.beingDragged).toBeFalse();
+	});
+
+	it('changes the \'click\' property', () => {
+		const store = setup();
+		const click = { coordinate: [38, 57], screenCoordinate: [21, 42] };
+
+		setClick(click);
+
+		expect(store.getState().map.click.payload).toEqual(click);
+	});
+
+	it('changes the \'contextClick\' property', () => {
+		const store = setup();
+		const click = { coordinate: [57, 38], screenCoordinate: [42, 21] };
+
+		setContextClick(click);
+
+		expect(store.getState().map.contextClick.payload).toEqual(click);
+	});
+
+	it('changes the \'beingDragged\' property', () => {
+		const store = setup();
+
+		setBeingDragged(true);
+
+		expect(store.getState().map.beingDragged).toBeTrue();
+
+		setBeingDragged(false);
+
+		expect(store.getState().map.beingDragged).toBeFalse();
+	});
+});

--- a/test/modules/map/store/map.reducer.test.js
+++ b/test/modules/map/store/map.reducer.test.js
@@ -1,0 +1,50 @@
+import { mapReducer } from '../../../../src/modules/map/store/map.reducer';
+import { setMoveStart, setMoveEnd, setBeingMoved } from '../../../../src/modules/map/store/map.action';
+import { TestUtils } from '../../../test-utils.js';
+
+
+describe('mapReducer', () => {
+
+	const setup = (state) => {
+		return TestUtils.setupStoreAndDi(state, {
+			map: mapReducer
+		});
+	};
+
+	it('initiales the store with default values', () => {
+		const store = setup();
+		expect(store.getState().map.moveStart).toBeNull();
+		expect(store.getState().map.moveEnd).toBeNull();
+		expect(store.getState().map.beingMoved).toBeFalse();
+	});
+
+	it('changes the \'movestart\' property', () => {
+		const store = setup();
+
+		setMoveStart();
+
+		expect(store.getState().map.moveStart.payload).toEqual('movestart');
+	});
+
+	it('changes the \'moveend\' property', () => {
+		const store = setup();
+		
+		setMoveEnd();
+
+		expect(store.getState().map.moveEnd.payload).toEqual('moveend');
+	});
+
+	
+
+	it('changes the \'beingMoved\' property', () => {
+		const store = setup();
+
+		setBeingMoved(true);
+		
+		expect(store.getState().map.beingMoved).toBeTrue();
+		
+		setBeingMoved(false);
+		
+		expect(store.getState().map.beingMoved).toBeFalse();
+	});
+});

--- a/test/modules/map/store/pointer.reducer.test.js
+++ b/test/modules/map/store/pointer.reducer.test.js
@@ -1,5 +1,5 @@
-import { mapReducer } from '../../../../src/modules/map/store/map.reducer';
-import { setClick, setContextClick, setBeingDragged, setPointer } from '../../../../src/modules/map/store/map.action';
+import { pointerReducer } from '../../../../src/modules/map/store/pointer.reducer';
+import { setClick, setContextClick, setBeingDragged, setPointerMove } from '../../../../src/modules/map/store/pointer.action';
 import { TestUtils } from '../../../test-utils.js';
 
 
@@ -7,15 +7,15 @@ describe('mapReducer', () => {
 
 	const setup = (state) => {
 		return TestUtils.setupStoreAndDi(state, {
-			map: mapReducer
+			pointer: pointerReducer
 		});
 	};
 
 	it('initiales the store with default values', () => {
 		const store = setup();
-		expect(store.getState().map.click).toBeNull();
-		expect(store.getState().map.contextClick).toBeNull();
-		expect(store.getState().map.beingDragged).toBeFalse();
+		expect(store.getState().pointer.click).toBeNull();
+		expect(store.getState().pointer.contextClick).toBeNull();
+		expect(store.getState().pointer.beingDragged).toBeFalse();
 	});
 
 	it('changes the \'click\' property', () => {
@@ -24,7 +24,7 @@ describe('mapReducer', () => {
 
 		setClick(pointerEvent);
 
-		expect(store.getState().map.click.payload).toEqual(pointerEvent);
+		expect(store.getState().pointer.click.payload).toEqual(pointerEvent);
 	});
 
 	it('changes the \'contextClick\' property', () => {
@@ -33,16 +33,16 @@ describe('mapReducer', () => {
 
 		setContextClick(pointerEvent);
 
-		expect(store.getState().map.contextClick.payload).toEqual(pointerEvent);
+		expect(store.getState().pointer.contextClick.payload).toEqual(pointerEvent);
 	});
 
-	it('changes the \'pointer\' property', () => {
+	it('changes the \'move\' property', () => {
 		const store = setup();
 		const pointerEvent = { coordinate: [7, 8], screenCoordinate: [2, 1] };
 
-		setPointer(pointerEvent);
+		setPointerMove(pointerEvent);
 
-		expect(store.getState().map.pointer.payload).toEqual(pointerEvent);
+		expect(store.getState().pointer.move.payload).toEqual(pointerEvent);
 	});
 
 	it('changes the \'beingDragged\' property', () => {
@@ -50,10 +50,10 @@ describe('mapReducer', () => {
 
 		setBeingDragged(true);
 
-		expect(store.getState().map.beingDragged).toBeTrue();
+		expect(store.getState().pointer.beingDragged).toBeTrue();
 
 		setBeingDragged(false);
 
-		expect(store.getState().map.beingDragged).toBeFalse();
+		expect(store.getState().pointer.beingDragged).toBeFalse();
 	});
 });

--- a/test/modules/map/store/pointer.reducer.test.js
+++ b/test/modules/map/store/pointer.reducer.test.js
@@ -3,7 +3,7 @@ import { setClick, setContextClick, setBeingDragged, setPointerMove } from '../.
 import { TestUtils } from '../../../test-utils.js';
 
 
-describe('mapReducer', () => {
+describe('pointerReducer', () => {
 
 	const setup = (state) => {
 		return TestUtils.setupStoreAndDi(state, {


### PR DESCRIPTION
Add 
1. a reducer for pointer based interactions of a user with the map
2. a reducer for interactions with the map on a higher abstraction level, like moving the map

So we are able now to
- switch off geolocation tracking when the user is dragging the map
- refactor the trigger mechanism of the context menu