### PR TITLE
Fix wrong method call in CoordinateService test

### DIFF
--- a/test/service/OlCoordinateService.test.js
+++ b/test/service/OlCoordinateService.test.js
@@ -131,7 +131,7 @@ describe('OlCoordinateService', () => {
 					const extent25832 = [1288239.2412306187, 6130212.561641981, 1289239.2412306187, 6132212.561641981];
 
 					expect(() => {
-						instanceUnderTest.transform(extent25832, 25832, 25834);
+						instanceUnderTest.transformExtent(extent25832, 25832, 25834);
 					})
 						.toThrowError(/Unsupported SRID: 25834/);
 				});


### PR DESCRIPTION
It does makes sense when a test for `transformExtent` also uses that method...