### PR TITLE
Register observer asynchronously

### DIFF
--- a/src/modules/BaObserver.js
+++ b/src/modules/BaObserver.js
@@ -18,7 +18,7 @@ export class BaObserver {
 	constructor() {
 		if (this.constructor === BaObserver) {
 			// Abstract class can not be constructed.
-			throw new TypeError('Can not construct abstract class.');
+			throw new Error('Can not construct abstract class.');
 		}
 	}
 
@@ -29,9 +29,9 @@ export class BaObserver {
 	* @public
 	* @param {Store} store the redux store
 	*/
-	register(/*eslint-disable no-unused-vars */store) {
+	async register(/*eslint-disable no-unused-vars */store) {
 		// The child has not implemented this method.
-		throw new TypeError('Please implement abstract method #register or do not call super.register from child.');
+		throw new Error('Please implement abstract method #register or do not call super.register from child.');
 	}
 
 }

--- a/src/modules/BaObserver.js
+++ b/src/modules/BaObserver.js
@@ -25,9 +25,13 @@ export class BaObserver {
 
 	/**
 	* Called by the global StoreService after injector is marked as ready.
+	* <br>
+	* Returns a promise when registration is complete. It's up to the implementation to
+	* decide about the payload of the resolved promise.
 	* @abstract
 	* @public
 	* @param {Store} store the redux store
+	* @returns {Promise<?>}
 	*/
 	async register(/*eslint-disable no-unused-vars */store) {
 		// The child has not implemented this method.

--- a/src/modules/map/store/ContextClickObserver.js
+++ b/src/modules/map/store/ContextClickObserver.js
@@ -14,7 +14,7 @@ export class ContextClickObserver extends BaObserver {
 	 * @override
 	 * @param {Store} store 
 	 */
-	register(store) {
+	async register(store) {
 
 		//create and add a MapContextMenu element
 		const mapContextMenu = document.createElement(MapContextMenu.tag);

--- a/src/modules/map/store/GeolocationObserver.js
+++ b/src/modules/map/store/GeolocationObserver.js
@@ -110,7 +110,7 @@ export class GeolocationObserver extends BaObserver {
 	 * @override
 	 * @param {Store} store 
 	 */
-	register(store) {
+	async register(store) {
 		
 		const onGeolocationActivityChange = (active) => {
 

--- a/src/modules/map/store/LayersObserver.js
+++ b/src/modules/map/store/LayersObserver.js
@@ -93,7 +93,7 @@ export class LayersObserver extends BaObserver {
 	/**
 	 * @override
 	 */
-	register() {
+	async register() {
 		this._init();
 	}
 }

--- a/src/modules/map/store/LayersObserver.js
+++ b/src/modules/map/store/LayersObserver.js
@@ -94,6 +94,6 @@ export class LayersObserver extends BaObserver {
 	 * @override
 	 */
 	async register() {
-		this._init();
+		return await this._init();
 	}
 }

--- a/src/modules/map/store/MeasurementObserver.js
+++ b/src/modules/map/store/MeasurementObserver.js
@@ -14,7 +14,7 @@ export class MeasurementObserver extends BaObserver {
 	 * @override
 	 * @param {Store} store 
 	 */
-	register(store) {
+	async register(store) {
 
 		const extract = (state) => {
 			return state.measurement.active;

--- a/src/modules/map/store/PositionObserver.js
+++ b/src/modules/map/store/PositionObserver.js
@@ -76,7 +76,7 @@ export class PositionObserver extends BaObserver {
 	/**
 	 * @override
 	 */
-	register() {
+	async register() {
 		this._init();
 	}
 }

--- a/src/services/StoreService.js
+++ b/src/services/StoreService.js
@@ -42,7 +42,7 @@ export class StoreService {
 
 		this._store = createStore(rootReducer);
 
-		$injector.onReady(() => {
+		$injector.onReady(async () => {
 
 			const {
 				GeolocationObserver: geolocationObserver,
@@ -61,11 +61,11 @@ export class StoreService {
 					'EnvironmentService'
 				);
 
-			measurementObserver.register(this._store);
-			geolocationObserver.register(this._store);
-			layersObserver.register(this._store);
-			positionObserver.register(this._store);
-			contextClickObserver.register(this._store);
+			await layersObserver.register(this._store);
+			await positionObserver.register(this._store);
+			await measurementObserver.register(this._store);
+			await geolocationObserver.register(this._store);
+			await contextClickObserver.register(this._store);
 
 			//we remove all query params shown in the browsers address bar
 			setTimeout(() => {

--- a/test/modules/BaObserver.test.js
+++ b/test/modules/BaObserver.test.js
@@ -9,15 +9,21 @@ describe('BaObserver', () => {
 
 		describe('constructor', () => {
 			it('throws excepetion when instantiated without inheritance', () => {
-				expect(() => new BaObserver()).toThrowError(TypeError, 'Can not construct abstract class.');
+				expect(() => new BaObserver()).toThrowError(Error, 'Can not construct abstract class.');
 			});
 		});
 
 		describe('methods', () => {
-			it('throws excepetion when abstract #createView is called without overriding', () => {
-				expect(() => new BaObserverNoImpl().register()).toThrowError(TypeError, 'Please implement abstract method #register or do not call super.register from child.');
+			it('throws excepetion when abstract #createView is called without overriding', (done) => {
+
+				new BaObserverNoImpl().register().then(() => {
+					done(new Error('Promise should not be resolved'));
+				}, (reason) => {
+					expect(reason.message).toContain('Please implement abstract method #register or do not call super.register from child.');
+					expect(reason).toBeInstanceOf(Error);
+					done();
+				});
 			});
 		});
-
 	});
 });

--- a/test/modules/map/store/ContextClickObserver.test.js
+++ b/test/modules/map/store/ContextClickObserver.test.js
@@ -22,10 +22,10 @@ describe('ContextClickObserver', () => {
 	};
 
 	describe('on register', () => {
-		it('it inserts the mapcontextmenu container', () => {
+		it('it inserts the mapcontextmenu container', async () => {
 			const store = setup();
 
-			new ContextClickObserver().register(store);
+			await new ContextClickObserver().register(store);
 
 			const element = document.querySelector(MapContextMenu.tag);
 			expect(element).toBeTruthy();

--- a/test/modules/map/store/GeolocationObserver.test.js
+++ b/test/modules/map/store/GeolocationObserver.test.js
@@ -51,13 +51,13 @@ describe('GeolocationObserver', () => {
 
 	describe('register', () => {
 
-		it('activates and deactivates the geolocation observer', () => {
+		it('activates and deactivates the geolocation observer', async () => {
 			const store = setup();
 			const instanceUnderTest = new GeolocationObserver();
 			const activateSpy = spyOn(instanceUnderTest, '_activate');
 			const deactivateSpy = spyOn(instanceUnderTest, '_deactivate');
 
-			instanceUnderTest.register(store);
+			await instanceUnderTest.register(store);
 
 			expect(activateSpy).not.toHaveBeenCalled();
 			expect(deactivateSpy).not.toHaveBeenCalled();
@@ -73,13 +73,13 @@ describe('GeolocationObserver', () => {
 			expect(deactivateSpy).toHaveBeenCalled();
 		});
 
-		it('adds and removes the geolocation layer', () => {
+		it('adds and removes the geolocation layer', async () => {
 			const store = setup();
 			const instanceUnderTest = new GeolocationObserver();
 			spyOn(instanceUnderTest, '_activate');
 			spyOn(instanceUnderTest, '_deactivate');
 
-			instanceUnderTest.register(store);
+			await instanceUnderTest.register(store);
 
 			activate();
 
@@ -91,11 +91,11 @@ describe('GeolocationObserver', () => {
 			expect(store.getState().layers.active.length).toBe(0);
 		});
 
-		it('registers an observer for beingDragged changes', () => {
+		it('registers an observer for beingDragged changes', async () => {
 			const store = setup();
 			const instanceUnderTest = new GeolocationObserver();
 
-			instanceUnderTest.register(store);
+			await instanceUnderTest.register(store);
 
 			setTracking(true);
 			activate();

--- a/test/modules/map/store/LayersObserver.test.js
+++ b/test/modules/map/store/LayersObserver.test.js
@@ -36,17 +36,16 @@ describe('LayersObserver', () => {
 
 	describe('register', () => {
 
-		it('calls #register', async () => {
+		it('calls #_init and awaits its completion', async () => {
 			const store = setup();
 			const instanceUnderTest = new LayersObserver();
-			const spy = spyOn(instanceUnderTest, '_init');
+			const spy = spyOn(instanceUnderTest, '_init').and.returnValue(Promise.resolve(true));
 
-			await instanceUnderTest.register(store);
+			const result = await instanceUnderTest.register(store);
 
+			expect(result).toBeTrue();
 			expect(spy).toHaveBeenCalledTimes(1);
 		});
-
-
 	});
 
 

--- a/test/modules/map/store/LayersObserver.test.js
+++ b/test/modules/map/store/LayersObserver.test.js
@@ -36,12 +36,12 @@ describe('LayersObserver', () => {
 
 	describe('register', () => {
 
-		it('calls #register', () => {
+		it('calls #register', async () => {
 			const store = setup();
 			const instanceUnderTest = new LayersObserver();
 			const spy = spyOn(instanceUnderTest, '_init');
 
-			instanceUnderTest.register(store);
+			await instanceUnderTest.register(store);
 
 			expect(spy).toHaveBeenCalledTimes(1);
 		});

--- a/test/modules/map/store/MeasurementObserver.test.js
+++ b/test/modules/map/store/MeasurementObserver.test.js
@@ -18,10 +18,10 @@ describe('MeasurementObserver', () => {
 	};
 
 
-	it('adds or removes the measurement layer', () => {
+	it('adds or removes the measurement layer', async () => {
 		const store = setup();
 		const instanceUnderTest = new MeasurementObserver();
-		instanceUnderTest.register(store);
+		await instanceUnderTest.register(store);
 		
 		activate();
 

--- a/test/modules/map/store/PositionObserver.test.js
+++ b/test/modules/map/store/PositionObserver.test.js
@@ -40,12 +40,12 @@ describe('LayersObserver', () => {
 
 	describe('register', () => {
 
-		it('calls #register', () => {
+		it('calls #register', async () => {
 			const store = setup();
 			const instanceUnderTest = new PositionObserver();
 			const spy = spyOn(instanceUnderTest, '_init');
 
-			instanceUnderTest.register(store);
+			await instanceUnderTest.register(store);
 
 			expect(spy).toHaveBeenCalledTimes(1);
 		});

--- a/test/service/StoreService.test.js
+++ b/test/service/StoreService.test.js
@@ -47,7 +47,7 @@ describe('StoreService', () => {
 			expect(reducerKeys.includes('geolocation')).toBeTrue();
 		});
 
-		it('registers all observers', () => {
+		it('registers all observers', (done) => {
 
 			const measurementObserverSpy = spyOn(measurementObserverMock, 'register');
 			const geolocationObserverSpy = spyOn(geolocationObserverMock, 'register');
@@ -67,17 +67,22 @@ describe('StoreService', () => {
 				.ready();
 
 			const store = instanceUnderTest.getStore();
-			expect(measurementObserverSpy).toHaveBeenCalledWith(store);
-			expect(geolocationObserverSpy).toHaveBeenCalledWith(store);
-			expect(layersObserverSpy).toHaveBeenCalledWith(store);
-			expect(positionObserverSpy).toHaveBeenCalledWith(store);
-			expect(contextClickObserverSpy).toHaveBeenCalledWith(store);
+
+			setTimeout(() => {
+
+				expect(measurementObserverSpy).toHaveBeenCalledWith(store);
+				expect(geolocationObserverSpy).toHaveBeenCalledWith(store);
+				expect(layersObserverSpy).toHaveBeenCalledWith(store);
+				expect(positionObserverSpy).toHaveBeenCalledWith(store);
+				expect(contextClickObserverSpy).toHaveBeenCalledWith(store);
+				done();
+			});
 		});
 
 		it('removes all query params by calling #replaceState on history', (done) => {
 			const replaceStateMock = spyOn(windowMock.history, 'replaceState');
 			new StoreService();
-			
+
 			$injector
 				.reset()
 				.registerSingleton('MeasurementObserver', measurementObserverMock)
@@ -89,8 +94,10 @@ describe('StoreService', () => {
 				.ready();
 
 			setTimeout(() => {
-				expect(replaceStateMock).toHaveBeenCalled();
-				done();
+				setTimeout(() => {
+					expect(replaceStateMock).toHaveBeenCalled();
+					done();
+				});
 			});
 		});
 	});


### PR DESCRIPTION
Based on this changes it is possible to define a logical order during initialization of the app.
For example, the information about configured background layers should be loaded before the geoResources are actually
fetched from the backend.