### PR TITLE
fix calculation and usage of partitionDeltas

### DIFF
--- a/src/modules/map/components/olMap/handler/measure/GeometryUtils.js
+++ b/src/modules/map/components/olMap/handler/measure/GeometryUtils.js
@@ -166,7 +166,6 @@ export const getPartitionDelta = (geometry, resolution = 1, calculationHints = {
 		}	
 		partitionLength = partitionLength * stepFactor;
 	}
-	console.log(delta);
 	return delta;
 };
 

--- a/src/modules/map/components/olMap/handler/measure/GeometryUtils.js
+++ b/src/modules/map/components/olMap/handler/measure/GeometryUtils.js
@@ -146,6 +146,7 @@ export const getAzimuth = (geometry) => {
 export const getPartitionDelta = (geometry, resolution = 1, calculationHints = {}) => {
 	const length = getGeometryLength(geometry, calculationHints);
 	const stepFactor = 10;
+	const minDelta = 0.01; // results in max 100 allowed partitions 
 	const minPartitionLength = 10;
 	const maxPartitionLength = 100000;
 	let delta = 1;
@@ -159,11 +160,13 @@ export const getPartitionDelta = (geometry, resolution = 1, calculationHints = {
 	while (partitionLength <= maxPartitionLength) {
 		if ( isValidForResolution(partitionLength)) {
 			delta = partitionLength / length;
-			break;
+			if (minDelta < delta) {
+				break;
+			}			
 		}	
 		partitionLength = partitionLength * stepFactor;
 	}
-
+	console.log(delta);
 	return delta;
 };
 

--- a/src/modules/map/components/olMap/handler/measure/GeometryUtils.js
+++ b/src/modules/map/components/olMap/handler/measure/GeometryUtils.js
@@ -137,21 +137,31 @@ export const getAzimuth = (geometry) => {
 /**
  * Calculates delta-value as a factor of the length of a provided geometry, 
  * to get equal-distanced partition points related to the start of the geometry.
+ * The count of the points is based on the resolution of the MapView.
  * @param {Geometry} geometry the linear/area-like geometry
+ * @param {number} resolution the resolution of the MapView, e. g. map.getView().getResolution()
  * @param {CalculationHints} calculationHints calculationHints for a optional transformation
  * @returns {number} the delta, a value between 0 and 1
  */
-export const getPartitionDelta = (geometry, calculationHints = {}) => {
+export const getPartitionDelta = (geometry, resolution = 1, calculationHints = {}) => {
 	const length = getGeometryLength(geometry, calculationHints);
+	const stepFactor = 10;
+	const minPartitionLength = 10;
+	const maxPartitionLength = 100000;
 	let delta = 1;
-	if (length > 200000) {
-		delta = 100000 / length;
-	}
-	else if (length > 20000) {
-		delta = 10000 / length;
-	}
-	else if (length !== 0) {
-		delta = 1000 / length;
+	const minLengthResolution = 20;
+	const isValidForResolution = (partition) => {
+		const partitionResolution = partition / resolution;
+		return partitionResolution > minLengthResolution && length > partition ;
+	};	
+
+	let partitionLength = minPartitionLength;
+	while (partitionLength <= maxPartitionLength) {
+		if ( isValidForResolution(partitionLength)) {
+			delta = partitionLength / length;
+			break;
+		}	
+		partitionLength = partitionLength * stepFactor;
 	}
 
 	return delta;

--- a/src/modules/map/components/olMap/handler/measure/OlMeasurementHandler.js
+++ b/src/modules/map/components/olMap/handler/measure/OlMeasurementHandler.js
@@ -200,6 +200,7 @@ export class OlMeasurementHandler extends OlLayerHandler {
 		});
 
 		let listener;
+		let zoomListener;
 
 		const finishMeasurementTooltip = (event) => {
 
@@ -217,6 +218,7 @@ export class OlMeasurementHandler extends OlLayerHandler {
 			}
 			this._activeSketch = null;
 			unByKey(listener);
+			unByKey(zoomListener);
 		};
 
 		const activateModify = (event) => {
@@ -235,6 +237,7 @@ export class OlMeasurementHandler extends OlLayerHandler {
 			this._isSnapOnLastPoint = false;
 			event.feature.set('measurement', measureTooltip);
 			listener = event.feature.on('change', event => this._updateMeasureTooltips(event.target, true));
+			zoomListener = this._map.getView().on('change:resolution', () => this._updateMeasureTooltips(this._activeSketch, true));
 			this._overlayManager.add(measureTooltip);
 		});
 
@@ -293,9 +296,8 @@ export class OlMeasurementHandler extends OlLayerHandler {
 
 		// add partition tooltips on the line
 		const partitions = feature.get('partitions') || [];
-
-
-		const delta = getPartitionDelta(measureGeometry, this._projectionHints);
+		const resolution = this._map.getView().getResolution();
+		const delta = getPartitionDelta(measureGeometry, resolution, this._projectionHints);
 		let partitionIndex = 0;
 		for (let i = delta; i < 1; i += delta, partitionIndex++) {
 			let partition = partitions[partitionIndex] || false;

--- a/test/modules/map/components/olMap/handler/measure/GeometryUtils.test.js
+++ b/test/modules/map/components/olMap/handler/measure/GeometryUtils.test.js
@@ -1,5 +1,6 @@
-import { getGeometryLength, getArea, canShowAzimuthCircle, getCoordinateAt, getAzimuth, isVertexOfGeometry } from '../../../../../../../src/modules/map/components/olMap/handler/measure/GeometryUtils';
+import { getGeometryLength, getArea, canShowAzimuthCircle, getCoordinateAt, getAzimuth, isVertexOfGeometry, getPartitionDelta } from '../../../../../../../src/modules/map/components/olMap/handler/measure/GeometryUtils';
 import { Point, MultiPoint, LineString, Polygon, Circle, LinearRing } from 'ol/geom';
+
 
 describe('getGeometryLength', () => {
 	it('calculates length of LineString', () => {
@@ -296,5 +297,32 @@ describe('isVertexOfGeometry', () => {
 		const isVertex = isVertexOfGeometry(geometry, vertexCandidate);
 
 		expect(isVertex).toBeFalse();
+	});
+});
+
+describe('getPartitionDelta', () => {
+	
+	it('calculates a default delta', () => {
+		const lineString = new LineString([[0, 0], [15, 0]]);		
+
+		const delta = getPartitionDelta(lineString);
+		
+		expect(delta).toBe(1);
+	});
+
+	it('calculates a delta with standard resolution', () => {
+		const lineString = new LineString([[0, 0], [200, 0]]);		
+
+		const delta = getPartitionDelta(lineString);
+		
+		expect(delta).toBe(0.5);
+	});
+
+	it('calculates a delta with defined resolution', () => {
+		const lineString = new LineString([[0, 0], [5000, 0]]);		
+		const resolution = 50;
+		const delta = getPartitionDelta(lineString, resolution);
+		
+		expect(delta).toBe(1);
 	});
 });

--- a/test/modules/map/components/olMap/handler/measure/OlMeasurementHandler.test.js
+++ b/test/modules/map/components/olMap/handler/measure/OlMeasurementHandler.test.js
@@ -189,9 +189,9 @@ describe('OlMeasurementHandler', () => {
 	});
 
 	describe('when draw a line', () => {
-		const initialCenter = fromLonLat([11.57245, 48.14021]);
+		const initialCenter = fromLonLat([0, 0]);
 
-		const setupMap = () => {
+		const setupMap = (zoom = 10) => {
 
 			return new Map({
 				layers: [
@@ -204,7 +204,7 @@ describe('OlMeasurementHandler', () => {
 				target: 'map',
 				view: new View({
 					center: initialCenter,
-					zoom: 1,
+					zoom: zoom					
 				}),
 			});
 
@@ -225,20 +225,7 @@ describe('OlMeasurementHandler', () => {
 			expect(baOverlay.outerHTML).toBe('<ba-measure-overlay></ba-measure-overlay>');
 		});
 
-		it('creates partition tooltips for long line', () => {
-			const classUnderTest = new OlMeasurementHandler();
-			const map = setupMap();
-			const geometry = new LineString([[0, 0], [1234, 0]]);
-			const feature = new Feature({ geometry: geometry });
-
-			classUnderTest.activate(map);
-			simulateDrawEvent('drawstart', classUnderTest._draw, feature);
-			feature.getGeometry().dispatchEvent('change');
-
-			expect(feature.get('partitions').length).toBe(1);
-		});
-
-		it('creates partition tooltips for longer line', () => {
+		it('creates partition tooltips for line small zoom', () => {
 			const classUnderTest = new OlMeasurementHandler();
 			const map = setupMap();
 			const geometry = new LineString([[0, 0], [12345, 0]]);
@@ -248,7 +235,46 @@ describe('OlMeasurementHandler', () => {
 			simulateDrawEvent('drawstart', classUnderTest._draw, feature);
 			feature.getGeometry().dispatchEvent('change');
 
+			expect(feature.get('partitions').length).toBe(1);
+		});
+
+		it('creates partition tooltips for line in big zoom', () => {
+			const classUnderTest = new OlMeasurementHandler();
+			const map = setupMap(15);
+			const geometry = new LineString([[0, 0], [1234, 0]]);
+			const feature = new Feature({ geometry: geometry });
+
+			classUnderTest.activate(map);
+			simulateDrawEvent('drawstart', classUnderTest._draw, feature);
+			feature.getGeometry().dispatchEvent('change');
+
 			expect(feature.get('partitions').length).toBe(12);
+		});
+
+		it('creates partition tooltips for line in bigger zoom', () => {
+			const classUnderTest = new OlMeasurementHandler();
+			const map = setupMap(20);
+			const geometry = new LineString([[0, 0], [123, 0]]);
+			const feature = new Feature({ geometry: geometry });
+
+			classUnderTest.activate(map);
+			simulateDrawEvent('drawstart', classUnderTest._draw, feature);
+			feature.getGeometry().dispatchEvent('change');
+
+			expect(feature.get('partitions').length).toBe(12);
+		});
+
+		it('creates partition tooltips for line in biggest zoom', () => {
+			const classUnderTest = new OlMeasurementHandler();
+			const map = setupMap(28);
+			const geometry = new LineString([[0, 0], [12, 0]]);
+			const feature = new Feature({ geometry: geometry });
+
+			classUnderTest.activate(map);
+			simulateDrawEvent('drawstart', classUnderTest._draw, feature);
+			feature.getGeometry().dispatchEvent('change');
+
+			expect(feature.get('partitions').length).toBe(1);
 		});
 
 		it('creates partition tooltips very long line', () => {
@@ -274,13 +300,13 @@ describe('OlMeasurementHandler', () => {
 			simulateDrawEvent('drawstart', classUnderTest._draw, feature);
 			feature.getGeometry().dispatchEvent('change');
 
-			expect(feature.get('partitions').length).toBe(12);
+			expect(feature.get('partitions').length).toBe(123);
 		});
 
 		it('creates partition tooltips for not closed polygon', () => {
 			const classUnderTest = new OlMeasurementHandler();
 			const map = setupMap();
-			const geometry = new Polygon([[[0, 0], [500, 0], [550, 550], [0, 500]]]);
+			const geometry = new Polygon([[[0, 0], [5000, 0], [5500, 5500], [0, 5000]]]);
 			const feature = new Feature({ geometry: geometry });
 
 			classUnderTest.activate(map);
@@ -293,20 +319,20 @@ describe('OlMeasurementHandler', () => {
 		it('creates partition tooltips for not closed large polygon', () => {
 			const classUnderTest = new OlMeasurementHandler();
 			const map = setupMap();
-			const geometry = new Polygon([[[0, 0], [5000, 0], [5500, 5500], [0, 5000]]]);
+			const geometry = new Polygon([[[0, 0], [10000, 0], [10000, 10000], [0, 10000]]]);
 			const feature = new Feature({ geometry: geometry });
 
 			classUnderTest.activate(map);
 			simulateDrawEvent('drawstart', classUnderTest._draw, feature);
 			feature.getGeometry().dispatchEvent('change');
 
-			expect(feature.get('partitions').length).toBe(10);
+			expect(feature.get('partitions').length).toBe(2);
 		});
 
 		it('removes partition tooltips after shrinking very long line', () => {
 			const classUnderTest = new OlMeasurementHandler();
 			const map = setupMap();
-			const geometry = new LineString([[0, 0], [12345, 0]]);
+			const geometry = new LineString([[0, 0], [123456, 0]]);
 			const feature = new Feature({ geometry: geometry });
 
 			classUnderTest.activate(map);
@@ -315,7 +341,7 @@ describe('OlMeasurementHandler', () => {
 
 			expect(feature.get('partitions').length).toBe(12);
 
-			geometry.setCoordinates([[0, 0], [1234, 0]]);
+			geometry.setCoordinates([[0, 0], [12345, 0]]);
 			feature.getGeometry().dispatchEvent('change');
 
 			expect(feature.get('partitions').length).toBe(1);

--- a/test/modules/map/components/olMap/handler/measure/OlMeasurementHandler.test.js
+++ b/test/modules/map/components/olMap/handler/measure/OlMeasurementHandler.test.js
@@ -347,6 +347,23 @@ describe('OlMeasurementHandler', () => {
 			expect(feature.get('partitions').length).toBe(1);
 		});
 
+		it('removes partition tooltips after zoom out', () => {
+			const classUnderTest = new OlMeasurementHandler();
+			const map = setupMap(15);
+			const geometry = new LineString([[0, 0], [1234, 0]]);
+			const feature = new Feature({ geometry: geometry });
+
+			classUnderTest.activate(map);
+			simulateDrawEvent('drawstart', classUnderTest._draw, feature);
+			feature.getGeometry().dispatchEvent('change');
+
+			expect(feature.get('partitions').length).toBe(12);
+
+			map.getView().setZoom(13);
+
+			expect(feature.get('partitions').length).toBe(1);
+		});
+
 		it('unregister tooltip-listener after finish drawing', () => {
 			const classUnderTest = new OlMeasurementHandler();
 			const map = setupMap();

--- a/test/modules/map/components/olMap/handler/measure/OlMeasurementHandler.test.js
+++ b/test/modules/map/components/olMap/handler/measure/OlMeasurementHandler.test.js
@@ -300,7 +300,7 @@ describe('OlMeasurementHandler', () => {
 			simulateDrawEvent('drawstart', classUnderTest._draw, feature);
 			feature.getGeometry().dispatchEvent('change');
 
-			expect(feature.get('partitions').length).toBe(123);
+			expect(feature.get('partitions').length).toBe(12);
 		});
 
 		it('creates partition tooltips for not closed polygon', () => {


### PR DESCRIPTION
The calculation of the partitionDeltas for a geometry is now based
on the given resolution ot the mapview, to prevent an overload of
partitionpoints in edge cases.

Add listener to the event 'change:resolution' of map.getView() to
refresh the overlays on zoom interactions while drawing