### PR TITLE
fix behavior of LayerItem on store-changes

### DIFF
--- a/src/modules/map/components/layerManager/LayerItem.js
+++ b/src/modules/map/components/layerManager/LayerItem.js
@@ -132,5 +132,6 @@ export class LayerItem extends BaElement {
 
 	set layer(value) {
 		this._layer = value;
+		this.render();
 	}
 }

--- a/src/modules/map/components/layerManager/LayerManager.js
+++ b/src/modules/map/components/layerManager/LayerManager.js
@@ -47,7 +47,6 @@ export class LayerManager extends BaElement {
 			};
 			if (old) {
 				displayProperties.collapsed = old.collapsed;
-				displayProperties.visible = old.visible;
 			}
 			draggableItems.push({ ...layer, isPlaceholder: false, listIndex: j + 1, isDraggable: true, ...displayProperties });
 			draggableItems.push({ zIndex: layer.zIndex + 1, isPlaceholder: true, listIndex: j + 2, isDraggable: false });

--- a/test/modules/map/components/layerManager/LayerManager.test.js
+++ b/test/modules/map/components/layerManager/LayerManager.test.js
@@ -4,6 +4,7 @@ import { layersReducer, defaultLayerProperties } from '../../../../../src/module
 import { TestUtils } from '../../../../test-utils';
 import { $injector } from '../../../../../src/injection';
 import { LayerItem } from '../../../../../src/modules/map/components/layerManager/LayerItem';
+import { modifyLayer } from '../../../../../src/modules/map/store/layers.action';
 
 window.customElements.define(Toggle.tag, Toggle);
 window.customElements.define(LayerItem.tag, LayerItem);
@@ -305,7 +306,77 @@ describe('LayerManager', () => {
 		});
 	});
 
+	describe('when layers are modified', () => { 		
 
+		it('renders changed layer.label', async() => {
+			const layer = {
+				...defaultLayerProperties,
+				id: 'id0', label: 'Foo'
+			};
+			const state = {
+				layers: {
+					active: [layer],
+					background: 'bg0'
+				}
+			};
+			const modifyableLayerProperties = { label:'Bar' };
+
+			const element = await setup(state);
+			const layerItem = element.shadowRoot.querySelector('ba-layer-item');
+			const layerLabel = layerItem.shadowRoot.querySelector('.layer-label');
+			expect(layerLabel.innerText).toBe('Foo');
+
+			modifyLayer('id0', modifyableLayerProperties);
+			expect(store.getState().layers.active[0].label).toBe(modifyableLayerProperties.label);
+			expect(layerLabel.innerText).toBe(modifyableLayerProperties.label);
+		});
+
+		it('renders changed layer.opacity', async() => {
+			const layer = {
+				...defaultLayerProperties, id: 'id0',
+			};
+			const state = {
+				layers: {
+					active: [layer],
+					background: 'bg0'
+				}
+			};
+			const modifyableLayerProperties = {  opacity:.55 };
+
+			const element = await setup(state);
+			const layerItem = element.shadowRoot.querySelector('ba-layer-item');
+			
+			const slider = layerItem.shadowRoot.querySelector('.opacity-slider');
+			
+			expect(slider.value).toBe('100');
+
+			modifyLayer('id0', modifyableLayerProperties);
+			expect(store.getState().layers.active[0].opacity).toBe(.55);
+			expect(slider.value).toBe('55');
+		});
+
+		it('renders changed layer.visible', async() => {
+			const layer = {
+				...defaultLayerProperties, id: 'id0', visible: false
+			};
+			const state = {
+				layers: {					
+					active: [layer],
+					background: 'bg0'
+				}
+			};
+			const modifyableLayerProperties = {  visible:true };
+
+			const element = await setup(state);
+			const layerItem = element.shadowRoot.querySelector('ba-layer-item');
+			const toggle = layerItem.shadowRoot.querySelector('ba-toggle');		
+			expect(toggle.checked).toBe(false);
+			
+			modifyLayer('id0', modifyableLayerProperties);
+			expect(store.getState().layers.active[0].visible).toBe(true);
+			expect(toggle.checked).toBe(true);
+		});		
+	});
 
 
 });


### PR DESCRIPTION
fix behavior of LayerItem and LayerManager, if ModifyableLayerProperties
are changed via modifyLayer

add tests for modifyLayer with valid ModifyableLayerProperties 

#215 