### PR TITLE
introduce UnitsService

### DIFF
--- a/src/injection/config.js
+++ b/src/injection/config.js
@@ -6,6 +6,7 @@ import { ProcessEnvConfigService } from '../services/ProcessEnvConfigService';
 import { HttpService } from '../services/HttpService';
 import { TranslationService } from '../services/TranslationService';
 import { ShareService } from '../services/ShareService';
+import { UnitsService } from '../services/UnitsService';
 import { GeoResourceService } from '../services/GeoResourceService';
 import { AltitudeService } from '../services/AltitudeService'; 
 import { UrlService } from '../services/UrlService';
@@ -31,6 +32,7 @@ $injector
 	.registerSingleton('AltitudeService', new AltitudeService())
 	.registerSingleton('SearchResultProviderService', new SearchResultProviderService())
 	.registerSingleton('ShareService', new ShareService())
+	.registerSingleton('UnitsService', new UnitsService())
 	.register('FileStorageService', BvvFileStorageService)
 	.register('UrlService', UrlService)
 	.registerSingleton('AdministrationService', new AdministrationService())

--- a/src/injection/config.js
+++ b/src/injection/config.js
@@ -32,7 +32,7 @@ $injector
 	.registerSingleton('AltitudeService', new AltitudeService())
 	.registerSingleton('SearchResultProviderService', new SearchResultProviderService())
 	.registerSingleton('ShareService', new ShareService())
-	.registerSingleton('UnitsService', new UnitsService())
+	.register('UnitsService', new UnitsService())
 	.register('FileStorageService', BvvFileStorageService)
 	.register('UrlService', UrlService)
 	.registerSingleton('AdministrationService', new AdministrationService())

--- a/src/modules/map/components/olMap/handler/measure/GeometryUtils.js
+++ b/src/modules/map/components/olMap/handler/measure/GeometryUtils.js
@@ -169,45 +169,6 @@ export const getPartitionDelta = (geometry, resolution = 1, calculationHints = {
 	return delta;
 };
 
-
-/**
- * Appends the appropriate unit of measure to the specified number
- * @param {number} length 
- * @returns {String} the formatted length 
- */
-//todo:intermediate helper-function until kind of FormattingService is in place
-export const getFormattedLength = (length) => {
-	let formatted;
-	if (length > 999) {
-		formatted = Math.round((length / 1000) * 100) / 100 + ' ' + 'km';
-	}
-	else {
-		formatted = length !== 0 ? Math.round(length * 100) / 100 + ' ' + 'm' : '0 m';
-	}
-	return formatted;
-};
-
-/**
- * Appends the appropriate unit of measure to the specified number
- * @param {number} area 
- * @returns {String} the formatted length 
- */
-//todo: intermediate helper-function until kind of FormattingService is in place
-export const getFormattedArea = (area) => {
-	let formatted;
-	if (area >= 1000000) {
-		formatted = Math.round((area / 1000000) * 100) / 100 + ' ' + 'km&sup2;';
-	}
-	else if (area >= 10000) {
-		formatted = Math.round((area / 10000) * 100) / 100 + ' ' + 'ha';
-	}
-	else {
-		formatted = Math.round(area * 100) / 100 + ' ' + 'm&sup2;';
-	}
-	return formatted;
-};
-
-
 /**
  * Tests whether the vertex candidate is part of the geometry vertices
  * @param {Geometry} geometry the geometry

--- a/src/modules/map/components/olMap/handler/measure/MeasurementOverlay.js
+++ b/src/modules/map/components/olMap/handler/measure/MeasurementOverlay.js
@@ -1,9 +1,10 @@
 import { html } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { BaElement } from '../../../../../BaElement';
+import { $injector } from '../../../../../../injection';
 import css from './measure.css';
 import { classMap } from 'lit-html/directives/class-map.js';
-import { getAzimuth, getCoordinateAt, canShowAzimuthCircle, getGeometryLength, getArea, getFormattedArea, getFormattedLength } from './GeometryUtils';
+import { getAzimuth, getCoordinateAt, canShowAzimuthCircle, getGeometryLength, getArea } from './GeometryUtils';
 import { Polygon } from 'ol/geom';
 
 export const MeasurementOverlayTypes = {
@@ -41,6 +42,8 @@ export class MeasurementOverlay extends BaElement {
 
 	constructor() {
 		super();
+		const { UnitsService } = $injector.inject('UnitsService');
+		this._unitsService = UnitsService;
 		this._value = '';
 		this._static = false;
 		this._type = MeasurementOverlayTypes.TEXT;
@@ -94,14 +97,14 @@ export class MeasurementOverlay extends BaElement {
 			case MeasurementOverlayTypes.AREA:
 				this._contentFunction = () => {
 					if (this.geometry instanceof Polygon) {
-						return getFormattedArea(getArea(this._geometry, this._projectionHints));
+						return this._unitsService.formatArea(getArea(this._geometry, this._projectionHints));
 					}
 					return '';
 				};
 				break;
 			case MeasurementOverlayTypes.DISTANCE:
 				this._contentFunction = () => {
-					const length = getFormattedLength(getGeometryLength(this._geometry, this._projectionHints));
+					const length = this._unitsService.formatDistance(getGeometryLength(this._geometry, this._projectionHints));
 					if (canShowAzimuthCircle(this.geometry)) {
 						const azimuthValue = getAzimuth(this.geometry);
 						const azimuth = azimuthValue ? azimuthValue.toFixed(2) : '-';
@@ -114,7 +117,7 @@ export class MeasurementOverlay extends BaElement {
 			case MeasurementOverlayTypes.DISTANCE_PARTITION:
 				this._contentFunction = () => {
 					const length = getGeometryLength(this._geometry, this.projectionHints);
-					return getFormattedLength(length * this._value);
+					return this._unitsService.formatDistance(length * this._value);
 				};
 				break;
 			case MeasurementOverlayTypes.HELP:

--- a/src/services/UnitsService.js
+++ b/src/services/UnitsService.js
@@ -1,18 +1,18 @@
 import { $injector } from '../injection';
 
-const KILOMETER_IN_METERS = 1000;
-const SQUAREDKILOMETER_IN_SQUAREDMETERS = 1000000;
-const HEKTAR_IN_SQUAREDMETERS = 10000;
-const PROVIDER_METRIC = {
+const Kilometer_In_Meters = 1000;
+const Squaredkilometer_In_Squaredmeters = 1000000;
+const Hektar_In_Squaredmeters = 10000;
+const Provider_Metric = {
 	/**
     * Appends the metric unit of distance to the specified number
     * @param {number} distance 
     * @returns {String} the formatted value 
     */
-	distance:(distance) => {
+	distance(distance) {
 		let formatted;
-		if (distance > KILOMETER_IN_METERS - 1) {
-			formatted = Math.round((distance / KILOMETER_IN_METERS) * 100) / 100 + ' ' + 'km';
+		if (distance > Kilometer_In_Meters - 1) {
+			formatted = Math.round((distance / Kilometer_In_Meters) * 100) / 100 + ' ' + 'km';
 		}
 		else {
 			formatted = distance !== 0 ? Math.round(distance * 100) / 100 + ' ' + 'm' : '0 m';
@@ -24,13 +24,13 @@ const PROVIDER_METRIC = {
     * @param {number} area 
     * @returns {String} the formatted value 
     */
-	area:(area) => {
+	area(area) {
 		let formatted;
-		if (area >= SQUAREDKILOMETER_IN_SQUAREDMETERS) {
-			formatted = Math.round((area / SQUAREDKILOMETER_IN_SQUAREDMETERS) * 100) / 100 + ' ' + 'km&sup2;';
+		if (area >= Squaredkilometer_In_Squaredmeters) {
+			formatted = Math.round((area / Squaredkilometer_In_Squaredmeters) * 100) / 100 + ' ' + 'km&sup2;';
 		}
-		else if (area >= HEKTAR_IN_SQUAREDMETERS) {
-			formatted = Math.round((area / HEKTAR_IN_SQUAREDMETERS) * 100) / 100 + ' ' + 'ha';
+		else if (area >= Hektar_In_Squaredmeters) {
+			formatted = Math.round((area / Hektar_In_Squaredmeters) * 100) / 100 + ' ' + 'ha';
 		}
 		else {
 			formatted = Math.round(area * 100) / 100 + ' ' + 'm&sup2;';
@@ -61,7 +61,7 @@ export class UnitsService {
 		switch (this._systemOfUnits) {
 			case 'metric':                
 			default:
-				return PROVIDER_METRIC.distance(distance);
+				return Provider_Metric.distance(distance);
 		}
 	}
 
@@ -74,7 +74,7 @@ export class UnitsService {
 		switch (this._systemOfUnits) {
 			case 'metric':                
 			default:
-				return PROVIDER_METRIC.area(area);
+				return Provider_Metric.area(area);
 		}
 	}
 	

--- a/src/services/UnitsService.js
+++ b/src/services/UnitsService.js
@@ -1,0 +1,78 @@
+import { $injector } from '../injection';
+
+const PROVIDER_METRIC = {
+	/**
+    * Appends the metric unit of distance to the specified number
+    * @param {number} distance 
+    * @returns {String} the formatted value 
+    */
+	distance:(distance) => {
+		let formatted;
+		if (length > 999) {
+			formatted = Math.round((distance / 1000) * 100) / 100 + ' ' + 'km';
+		}
+		else {
+			formatted = distance !== 0 ? Math.round(distance * 100) / 100 + ' ' + 'm' : '0 m';
+		}
+		return formatted;
+	},
+	/**
+    * Appends the metric unit of area to the specified number
+    * @param {number} area 
+    * @returns {String} the formatted value 
+    */
+	area:(area) => {
+		let formatted;
+		if (area >= 1000000) {
+			formatted = Math.round((area / 1000000) * 100) / 100 + ' ' + 'km&sup2;';
+		}
+		else if (area >= 10000) {
+			formatted = Math.round((area / 10000) * 100) / 100 + ' ' + 'ha';
+		}
+		else {
+			formatted = Math.round(area * 100) / 100 + ' ' + 'm&sup2;';
+		}
+		return formatted;
+	}
+};
+
+/**
+ *  Service for formatting numbers with their respective unit of measurement
+ * @class
+ * @author thiloSchlemmer
+ */
+export class UnitsService {
+
+	constructor() {
+		const { ConfigService: configService } = $injector.inject('ConfigService');
+		this._systemOfUnits = configService.getValue('DEFAULT_UNIT_SYTEM', 'metric');
+	}
+
+	/**
+    * Appends the appropriate unit of distance to the specified number.
+    * The current unit of distance is set per config.
+    * @param {number} distance 
+    * @returns {String} the formatted value 
+    */
+	formatDistance(distance) {
+		switch (this._systemOfUnits) {
+			case 'metric':                
+			default:
+				return PROVIDER_METRIC.distance(distance);
+		}
+	}
+
+	/**
+    * Appends the appropriate areal unit to the specified number
+    * @param {number} area 
+    * @returns {String} the formatted value 
+    */
+	formatArea(area) {
+		switch (this._systemOfUnits) {
+			case 'metric':                
+			default:
+				return PROVIDER_METRIC.area(area);
+		}
+	}
+	
+}

--- a/src/services/UnitsService.js
+++ b/src/services/UnitsService.js
@@ -1,5 +1,8 @@
 import { $injector } from '../injection';
 
+const KILOMETER_IN_METERS = 1000;
+const SQUAREDKILOMETER_IN_SQUAREDMETERS = 1000000;
+const HEKTAR_IN_SQUAREDMETERS = 10000;
 const PROVIDER_METRIC = {
 	/**
     * Appends the metric unit of distance to the specified number
@@ -8,8 +11,8 @@ const PROVIDER_METRIC = {
     */
 	distance:(distance) => {
 		let formatted;
-		if (length > 999) {
-			formatted = Math.round((distance / 1000) * 100) / 100 + ' ' + 'km';
+		if (distance >= KILOMETER_IN_METERS) {
+			formatted = Math.round((distance / KILOMETER_IN_METERS) * 100) / 100 + ' ' + 'km';
 		}
 		else {
 			formatted = distance !== 0 ? Math.round(distance * 100) / 100 + ' ' + 'm' : '0 m';
@@ -23,11 +26,11 @@ const PROVIDER_METRIC = {
     */
 	area:(area) => {
 		let formatted;
-		if (area >= 1000000) {
-			formatted = Math.round((area / 1000000) * 100) / 100 + ' ' + 'km&sup2;';
+		if (area >= SQUAREDKILOMETER_IN_SQUAREDMETERS) {
+			formatted = Math.round((area / SQUAREDKILOMETER_IN_SQUAREDMETERS) * 100) / 100 + ' ' + 'km&sup2;';
 		}
-		else if (area >= 10000) {
-			formatted = Math.round((area / 10000) * 100) / 100 + ' ' + 'ha';
+		else if (area >= HEKTAR_IN_SQUAREDMETERS) {
+			formatted = Math.round((area / HEKTAR_IN_SQUAREDMETERS) * 100) / 100 + ' ' + 'ha';
 		}
 		else {
 			formatted = Math.round(area * 100) / 100 + ' ' + 'm&sup2;';

--- a/src/services/UnitsService.js
+++ b/src/services/UnitsService.js
@@ -11,7 +11,7 @@ const PROVIDER_METRIC = {
     */
 	distance:(distance) => {
 		let formatted;
-		if (distance >= KILOMETER_IN_METERS) {
+		if (distance > KILOMETER_IN_METERS - 1) {
 			formatted = Math.round((distance / KILOMETER_IN_METERS) * 100) / 100 + ' ' + 'km';
 		}
 		else {

--- a/test/modules/map/components/olMap/handler/measure/GeometryUtils.test.js
+++ b/test/modules/map/components/olMap/handler/measure/GeometryUtils.test.js
@@ -1,4 +1,4 @@
-import { getGeometryLength, getFormattedLength, getFormattedArea, getArea, canShowAzimuthCircle, getCoordinateAt, getAzimuth, isVertexOfGeometry, getPartitionDelta } from '../../../../../../../src/modules/map/components/olMap/handler/measure/GeometryUtils';
+import { getGeometryLength, getArea, canShowAzimuthCircle, getCoordinateAt, getAzimuth, isVertexOfGeometry, getPartitionDelta } from '../../../../../../../src/modules/map/components/olMap/handler/measure/GeometryUtils';
 import { Point, MultiPoint, LineString, Polygon, Circle, LinearRing } from 'ol/geom';
 
 
@@ -324,34 +324,5 @@ describe('getPartitionDelta', () => {
 		const delta = getPartitionDelta(lineString, resolution);
 		
 		expect(delta).toBe(1);
-	});
-});
-
-describe('getFormattedLength', () => {	
-	it('formats length with correct units ', () => {
-		const oneHundredMeters = 100;
-		const nineteenHundredNinetyNineMeters = 999;
-		const oneThousandMeters = 1000;
-		const tenThousandMeters = 10000;
-		const oneHundredThousandMeters = 100000;
-
-		expect(getFormattedLength(oneHundredMeters)).toBe('100 m');
-		expect(getFormattedLength(nineteenHundredNinetyNineMeters)).toBe('999 m');
-		expect(getFormattedLength(oneThousandMeters)).toBe('1 km');
-		expect(getFormattedLength(tenThousandMeters)).toBe('10 km');
-		expect(getFormattedLength(oneHundredThousandMeters)).toBe('100 km');
-	});
-});
-
-describe('getFormattedArea', () => {	
-	it('formats length with correct units ', () => {
-		const oneHundredSquaredMeters = 100;
-		const oneHectarinSquaredMeters = 10000;
-		
-		const oneSquaredKilometersInMeters = 1000000;
-
-		expect(getFormattedArea(oneHundredSquaredMeters)).toBe('100 m&sup2;');
-		expect(getFormattedArea(oneHectarinSquaredMeters)).toBe('1 ha');		
-		expect(getFormattedArea(oneSquaredKilometersInMeters)).toBe('1 km&sup2;');
 	});
 });

--- a/test/modules/map/components/olMap/handler/measure/HelpTooltip.test.js
+++ b/test/modules/map/components/olMap/handler/measure/HelpTooltip.test.js
@@ -6,6 +6,12 @@ import { TestUtils } from '../../../../../../test-utils.js';
 
 
 TestUtils.setupStoreAndDi({},);
+$injector.registerSingleton('UnitsService', { formatDistance:(distance) => {
+	return distance + ' m';
+},
+formatArea:(area) => {
+	return area + ' m²';
+} });
 $injector.registerSingleton('TranslationService', { translate: (key) => key });
 
 describe('HelpTooltip', () => {

--- a/test/modules/map/components/olMap/handler/measure/MeasurementOverlay.test.js
+++ b/test/modules/map/components/olMap/handler/measure/MeasurementOverlay.test.js
@@ -1,5 +1,7 @@
 import { MeasurementOverlay, MeasurementOverlayTypes } from '../../../../../../../src/modules/map/components/olMap/handler/measure/MeasurementOverlay';
+import { UnitsService } from '../../../../../../../src/services/UnitsService';
 import { LineString, Polygon } from 'ol/geom';
+import { $injector } from '../../../../../../../src/injection';
 import { TestUtils } from '../../../../../../test-utils.js';
 
 import proj4 from 'proj4';
@@ -10,7 +12,10 @@ describe('MeasurementOverlay', () => {
 
 	beforeEach(async () => {
 		TestUtils.setupStoreAndDi({});			
-
+		$injector.registerSingleton('ConfigService', {
+			getValue: () => { }
+		});
+		$injector.registerSingleton('UnitsService', new UnitsService());
 		proj4.defs('EPSG:25832', '+proj=utm +zone=32 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +axis=neu');
 		register(proj4);
 	});

--- a/test/modules/map/components/olMap/handler/measure/MeasurementOverlay.test.js
+++ b/test/modules/map/components/olMap/handler/measure/MeasurementOverlay.test.js
@@ -1,5 +1,4 @@
 import { MeasurementOverlay, MeasurementOverlayTypes } from '../../../../../../../src/modules/map/components/olMap/handler/measure/MeasurementOverlay';
-import { UnitsService } from '../../../../../../../src/services/UnitsService';
 import { LineString, Polygon } from 'ol/geom';
 import { $injector } from '../../../../../../../src/injection';
 import { TestUtils } from '../../../../../../test-utils.js';
@@ -11,11 +10,14 @@ window.customElements.define(MeasurementOverlay.tag, MeasurementOverlay);
 describe('MeasurementOverlay', () => {
 
 	beforeEach(async () => {
-		TestUtils.setupStoreAndDi({});			
-		$injector.registerSingleton('ConfigService', {
-			getValue: () => { }
-		});
-		$injector.registerSingleton('UnitsService', new UnitsService());
+		TestUtils.setupStoreAndDi({});		
+	
+		$injector.registerSingleton('UnitsService', { formatDistance:(distance) => {
+			return distance + ' m';
+		},
+		formatArea:(area) => {
+			return area + ' m²';
+		} });
 		proj4.defs('EPSG:25832', '+proj=utm +zone=32 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +axis=neu');
 		register(proj4);
 	});

--- a/test/modules/map/components/olMap/handler/measure/MeasurementOverlay.test.js
+++ b/test/modules/map/components/olMap/handler/measure/MeasurementOverlay.test.js
@@ -11,12 +11,13 @@ describe('MeasurementOverlay', () => {
 
 	beforeEach(async () => {
 		TestUtils.setupStoreAndDi({});		
-	
-		$injector.registerSingleton('UnitsService', { formatDistance:(distance) => {
-			return distance + ' m';
+		// eslint-disable-next-line no-unused-vars
+		$injector.registerSingleton('UnitsService', { formatDistance(distance) {
+			return 'THE DISTANCE IN m';
 		},
-		formatArea:(area) => {
-			return area + ' m²';
+		// eslint-disable-next-line no-unused-vars
+		formatArea(area) {
+			return 'THE AREA IN m²';
 		} });
 		proj4.defs('EPSG:25832', '+proj=utm +zone=32 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +axis=neu');
 		register(proj4);
@@ -68,7 +69,7 @@ describe('MeasurementOverlay', () => {
 			expect(div.classList.contains('floating')).toBeTrue();
 			expect(element.type).toBe(MeasurementOverlayTypes.DISTANCE);			
 			expect(element.static).toBeFalse();
-			expect(div.innerText).toBe('90.00°/1 m');			
+			expect(div.innerText).toBe('90.00°/THE DISTANCE IN m');			
 		});
 
 		it('renders the area view', async () => {
@@ -83,7 +84,7 @@ describe('MeasurementOverlay', () => {
 			expect(div.classList.contains('floating')).toBeTrue();
 			expect(element.type).toBe(MeasurementOverlayTypes.AREA);			
 			expect(element.static).toBeFalse();
-			expect(div.innerText).toBe('100 m²');			
+			expect(div.innerText).toBe('THE AREA IN m²');			
 		});
 
 		it('renders the distance-partition view', async () => {
@@ -101,7 +102,7 @@ describe('MeasurementOverlay', () => {
 			expect(div.classList.contains('floating')).toBeTrue();
 			expect(element.type).toBe(MeasurementOverlayTypes.DISTANCE_PARTITION);			
 			expect(element.static).toBeFalse();
-			expect(div.innerText).toBe('10 m');			
+			expect(div.innerText).toBe('THE DISTANCE IN m');			
 		});
 
 		it('renders the static distance view', async () => {
@@ -114,68 +115,19 @@ describe('MeasurementOverlay', () => {
 			expect(div.classList.contains('static')).toBeTrue();
 			expect(div.classList.contains('floating')).toBeFalse();
 			expect(element.type).toBe(MeasurementOverlayTypes.DISTANCE);			
-			expect(div.innerText).toBe('90.00°/1 m');			
+			expect(div.innerText).toBe('90.00°/THE DISTANCE IN m');			
 		});
 
-		it('renders formatted distance 1 m ', async () => {
+		it('renders formatted distance', async () => {
 			const geodeticGeometry = new LineString([[0, 0], [1, 0]]);
 			const properties = { type:MeasurementOverlayTypes.DISTANCE, geometry:geodeticGeometry, projectionHints:{ fromProjection:'EPSG:3857', toProjection:'EPSG:25832' } };
 			const element = await setup(properties);			
 			const div = element.shadowRoot.querySelector('div');
 
-			expect(div.innerText).toBe('90.00°/1 m');
+			expect(div.innerText).toBe('90.00°/THE DISTANCE IN m');
 		});
 
-		it('renders formatted distance 10 m ', async () => {
-			const geodeticGeometry = new LineString([[0, 0], [10, 0]]);
-			const properties = { type:MeasurementOverlayTypes.DISTANCE, geometry:geodeticGeometry, projectionHints:{ fromProjection:'EPSG:3857', toProjection:'EPSG:25832' } };
-			const element = await setup(properties);			
-			const div = element.shadowRoot.querySelector('div');
-
-			expect(div.innerText).toBe('90.00°/10 m');
-		});
-
-		it('renders formatted distance 100 m ', async () => {
-			const geodeticGeometry = new LineString([[0, 0], [100, 0]]);
-			const properties = { type:MeasurementOverlayTypes.DISTANCE, geometry:geodeticGeometry, projectionHints:{ fromProjection:'EPSG:3857', toProjection:'EPSG:25832' } };
-			const element = await setup(properties);			
-
-			const div = element.shadowRoot.querySelector('div');
-
-			expect(div.innerText).toBe('90.00°/100 m');
-		});
-
-		it('renders formatted distance 1 km ', async () => {
-			const geodeticGeometry = new LineString([[0, 0], [1000, 0]]);
-			const properties = { type:MeasurementOverlayTypes.DISTANCE, geometry:geodeticGeometry, projectionHints:{ fromProjection:'EPSG:3857', toProjection:'EPSG:25832' } };
-			const element = await setup(properties);			
-
-			const div = element.shadowRoot.querySelector('div');
-
-			expect(div.innerText).toBe('90.00°/1 km');
-		});
-
-		it('renders formatted distance 10 km ', async () => {
-			const geodeticGeometry = new LineString([[0, 0], [10000, 0]]);
-			const properties = { type:MeasurementOverlayTypes.DISTANCE, geometry:geodeticGeometry, projectionHints:{ fromProjection:'EPSG:3857', toProjection:'EPSG:25832' } };
-			const element = await setup(properties);			
-
-			const div = element.shadowRoot.querySelector('div');
-
-			expect(div.innerText).toBe('90.00°/10 km');
-		});
-
-		it('renders formatted distance 1.25 km ', async () => {
-			const geodeticGeometry = new LineString([[0, 0], [1234, 0]]);
-			const properties = { type:MeasurementOverlayTypes.DISTANCE, geometry:geodeticGeometry, projectionHints:{ fromProjection:'EPSG:3857', toProjection:'EPSG:25832' } };
-			const element = await setup(properties);			
-
-			const div = element.shadowRoot.querySelector('div');
-
-			expect(div.innerText).toBe('90.00°/1.23 km');
-		});
-
-		it('renders formatted area 1 ha', async () => {
+		it('renders formatted area', async () => {
 			const geodeticGeometry = new Polygon([[[0, 0], [120, 0], [120, 120], [0, 120], [0, 0]]]);
 			const properties = { type:MeasurementOverlayTypes.AREA, geometry:geodeticGeometry, projectionHints:{ fromProjection:'EPSG:3857', toProjection:'EPSG:25832' } };
 			const element = await setup(properties);			
@@ -185,20 +137,7 @@ describe('MeasurementOverlay', () => {
 			expect(div.classList.contains('floating')).toBeTrue();
 			expect(element.type).toBe(MeasurementOverlayTypes.AREA);			
 			expect(element.static).toBeFalse();
-			expect(div.innerText).toBe('1.44 ha');			
-		});
-
-		it('renders formatted area 1 km²', async () => {
-			const geodeticGeometry = new Polygon([[[0, 0], [1100, 0], [1100, 1100], [0, 1100], [0, 0]]]);
-			const properties = { type:MeasurementOverlayTypes.AREA, geometry:geodeticGeometry, projectionHints:{ fromProjection:'EPSG:3857', toProjection:'EPSG:25832' } };
-			const element = await setup(properties);			
-			const div = element.shadowRoot.querySelector('div');
-
-			expect(div.classList.contains('area')).toBeTrue();
-			expect(div.classList.contains('floating')).toBeTrue();
-			expect(element.type).toBe(MeasurementOverlayTypes.AREA);			
-			expect(element.static).toBeFalse();
-			expect(div.innerText).toBe('1.21 km²');			
+			expect(div.innerText).toBe('THE AREA IN m²');			
 		});
 	});
 

--- a/test/modules/map/components/olMap/handler/measure/OlMeasurementHandler.test.js
+++ b/test/modules/map/components/olMap/handler/measure/OlMeasurementHandler.test.js
@@ -25,6 +25,12 @@ TestUtils.setupStoreAndDi({},);
 $injector.registerSingleton('TranslationService', { translate: (key) => key });
 $injector.registerSingleton('MapService', { getSrid: () => 3857, getDefaultGeodeticSrid: () => 25832 });
 $injector.registerSingleton('EnvironmentService', environmentServiceMock);
+$injector.registerSingleton('UnitsService', { formatDistance:(distance) => {
+	return distance + ' m';
+},
+formatArea:(area) => {
+	return area + ' m²';
+} });
 
 proj4.defs('EPSG:25832', '+proj=utm +zone=32 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +axis=neu');
 register(proj4);

--- a/test/service/UnitsService.test.js
+++ b/test/service/UnitsService.test.js
@@ -1,0 +1,58 @@
+import { UnitsService } from '../../src/services/UnitsService';
+import { $injector } from '../../src/injection';
+
+
+describe('UnitsService', () => {
+
+	let instanceUnderTest;
+	const configService = {
+		getValue: () => { }
+	};
+
+	beforeAll(() => {
+		$injector
+			.registerSingleton('ConfigService', configService);
+	});
+
+	beforeEach(() => {
+		instanceUnderTest = new UnitsService();
+	});
+
+	it('provides default formatted distance', () => {
+		spyOn(configService, 'getValue').and.returnValue(null);
+		
+		expect(instanceUnderTest.formatDistance(42)).toBe('42 m');		
+	});
+
+	it('provides default formatted area', () => {
+		spyOn(configService, 'getValue').and.returnValue(null);
+		
+		expect(instanceUnderTest.formatArea(42)).toBe('42 m&sup2;');		
+	});
+
+	it('provides formatted distance', () => {
+		const systemOfUnits = 'metric';
+		
+		spyOn(configService, 'getValue').and.returnValue(systemOfUnits);
+		
+		expect(instanceUnderTest.formatDistance(42)).toBe('42 m');
+		expect(instanceUnderTest.formatDistance(999)).toBe('999 m');
+		expect(instanceUnderTest.formatDistance(1000)).toBe('1 km');
+		expect(instanceUnderTest.formatDistance(1234)).toBe('1.23 km');
+		expect(instanceUnderTest.formatDistance(10000)).toBe('10 km');
+	});
+
+	it('provides formatted area', () => {
+		const systemOfUnits = 'metric';
+		
+		spyOn(configService, 'getValue').and.returnValue(systemOfUnits);
+		
+		expect(instanceUnderTest.formatArea(42)).toBe('42 m&sup2;');
+		expect(instanceUnderTest.formatArea(999)).toBe('999 m&sup2;');
+		expect(instanceUnderTest.formatArea(1000000)).toBe('1 km&sup2;');
+		expect(instanceUnderTest.formatArea(1234567)).toBe('1.23 km&sup2;');
+		expect(instanceUnderTest.formatArea(10000)).toBe('1 ha');
+		expect(instanceUnderTest.formatArea(12345)).toBe('1.23 ha');
+		expect(instanceUnderTest.formatArea(10000000)).toBe('10 km&sup2;');
+	});
+});


### PR DESCRIPTION
as enhancement and refactoring for two utility-methods, this PR introduce a service to format distance- and area-values with their respective unit.

This refactoring is needed for future implementations, where such values have to displayed by arbitrary components with the same formatting rule.