### PR TITLE
measurement -  persist data

### DIFF
--- a/src/modules/map/components/olMap/handler/measure/OlMeasurementHandler.js
+++ b/src/modules/map/components/olMap/handler/measure/OlMeasurementHandler.js
@@ -636,7 +636,8 @@ export class OlMeasurementHandler extends OlLayerHandler {
 	}
 
 	async _persistLayer() {
-		const label = 'FooBarBaz';
+		const translate = (key) => this._translationService.translate(key);
+		const label = translate('map_olMap_handler_measure_layer_label');
 		const options = { featureProjection: 'EPSG:3857', rightHanded: true, decimals: 8 };
 		const format = new KML({ writeStyles: true });
 		if (this._vectorLayer) {

--- a/src/modules/map/components/olMap/handler/measure/OlMeasurementHandler.js
+++ b/src/modules/map/components/olMap/handler/measure/OlMeasurementHandler.js
@@ -637,21 +637,21 @@ export class OlMeasurementHandler extends OlLayerHandler {
 		const label = 'FooBarBaz';
 		const options = { featureProjection: 'EPSG:3857', rightHanded: true, decimals: 8 };
 		const format = new KML({ writeStyles: true });
-		const data = format.writeFeatures(this._vectorLayer.getSource().getFeatures(), options);
-		console.log(data);
-		try {
-			const { fileId } = await this._fileStorageService.save(null, data, FileStorageServiceDataTypes.KML);
-			//create a georesource and set the data as source
-			const vgr = new VectorGeoResource(fileId, label, VectorSourceType.KML).setSource(data, 4326);
-			//register georesource
-			this._geoResourceService.addOrReplace(vgr);
-			//add a layer that displays the georesource in the map
-			addLayer(fileId, { label: label });
+		if (this._vectorLayer) {
+			const data = format.writeFeatures(this._vectorLayer.getSource().getFeatures(), options);
+			try {
+				const { fileId } = await this._fileStorageService.save(null, data, FileStorageServiceDataTypes.KML);
+				//create a georesource and set the data as source
+				const vgr = new VectorGeoResource(fileId, label, VectorSourceType.KML).setSource(data, 4326);
+				//register georesource
+				this._geoResourceService.addOrReplace(vgr);
+				//add a layer that displays the georesource in the map
+				addLayer(fileId, { label: label });
+			}
+			catch (error) {
+				console.error(error);
+			}
 		}
-		catch (error) {
-			console.error(error);
-		}
-
 	}
 
 	_getSnapTolerancePerDevice() {
@@ -662,8 +662,8 @@ export class OlMeasurementHandler extends OlLayerHandler {
 	}
 
 	/**
-	 * todo: extract Util-method to kind of 'OlMapUtils'-file
-	 */
+ * todo: extract Util-method to kind of 'OlMapUtils'-file
+ */
 	_isInCollection(item, itemCollection) {
 		let isInCollection = false;
 		itemCollection.forEach(i => {

--- a/src/modules/map/components/olMap/handler/measure/OlMeasurementHandler.js
+++ b/src/modules/map/components/olMap/handler/measure/OlMeasurementHandler.js
@@ -642,16 +642,17 @@ export class OlMeasurementHandler extends OlLayerHandler {
 		const format = new KML({ writeStyles: true });
 		if (this._vectorLayer) {
 			const data = format.writeFeatures(this._vectorLayer.getSource().getFeatures(), options);
-			try {
+			try {				
 				const { fileId } = await this._fileStorageService.save(null, data, FileStorageServiceDataTypes.KML);
 				//create a georesource and set the data as source
 				const vgr = new VectorGeoResource(fileId, label, VectorSourceType.KML).setSource(data, 4326);
 				//register georesource
-				this._geoResourceService.addOrReplace(vgr);
+				this._geoResourceService.addOrReplace(vgr);				
 				//add a layer that displays the georesource in the map
 				addLayer(fileId, { label: label });
 			}
 			catch (error) {
+				alert(error);
 				console.error(error);
 			}
 		}

--- a/src/modules/map/components/olMap/handler/measure/OlMeasurementHandler.js
+++ b/src/modules/map/components/olMap/handler/measure/OlMeasurementHandler.js
@@ -110,11 +110,12 @@ export class OlMeasurementHandler extends OlLayerHandler {
 				source: source,
 				style: measureStyleFunction
 			});
+			const saveDebounced = debounced(Debounce_Delay, () => this._save());
 			this._listeners.push(layer.on('change:visible', visibleChangedHandler));
 			this._listeners.push(layer.on('change:opacity', opacityChangedHandler));
 			this._listeners.push(source.on('addfeature', () => this._save()));
-			this._listeners.push(source.on('changefeature', () => this._saveDebounced())); 
-			this._listeners.push(source.on('removefeature', () => this._saveDebounced()));
+			this._listeners.push(source.on('changefeature', () => saveDebounced())); 
+			this._listeners.push(source.on('removefeature', () => saveDebounced()));
 			return layer;
 		};
 
@@ -401,10 +402,6 @@ export class OlMeasurementHandler extends OlLayerHandler {
 		}
 	}
 
-	_saveDebounced() {		
-		const save = debounced(Debounce_Delay, async() => await this._save());
-		save();
-	}
 
 	_updateMeasureTooltips(feature, isDrawing) {
 		let measureGeometry = feature.getGeometry();

--- a/src/modules/map/components/olMap/handler/measure/OlMeasurementHandler.js
+++ b/src/modules/map/components/olMap/handler/measure/OlMeasurementHandler.js
@@ -44,7 +44,7 @@ export const MeasureSnapType = {
 	FACE: 'face'
 };
 
-const Debounce_Delay = 2000;
+const Debounce_Delay = 1000;
 
 /**
  * Handler for measurement-interaction with the map
@@ -718,5 +718,9 @@ export class OlMeasurementHandler extends OlLayerHandler {
 		return isInCollection;
 	}
 
+	static get Debounce_Delay() {
+		return Debounce_Delay; 
+	
+	}
 
 }

--- a/src/modules/map/components/olMap/handler/measure/OlMeasurementHandler.js
+++ b/src/modules/map/components/olMap/handler/measure/OlMeasurementHandler.js
@@ -389,7 +389,7 @@ export class OlMeasurementHandler extends OlLayerHandler {
 				this._storeID = fileId;				
 			}
 			catch (error) {
-				console.warn('Could not store content initially:', error);			
+				console.warn('Could not store content initially:', error.message);			
 			}
 		}			
 		else {
@@ -397,7 +397,7 @@ export class OlMeasurementHandler extends OlLayerHandler {
 				await this._fileStorageService.save(this._storeID, this._storedContent, FileStorageServiceDataTypes.KML);	
 			}
 			catch (error) {
-				console.warn('Could not store content:', error);
+				console.warn('Could not store content:', error.message);
 			}	
 		}
 	}
@@ -693,7 +693,7 @@ export class OlMeasurementHandler extends OlLayerHandler {
 			addLayer(this._storeID, { label: label });
 		}
 		catch (error) {
-			console.error(error);
+			console.error(error.message);
 		}
 	}
 

--- a/src/modules/map/components/olMap/handler/measure/OlMeasurementHandler.js
+++ b/src/modules/map/components/olMap/handler/measure/OlMeasurementHandler.js
@@ -210,7 +210,7 @@ export class OlMeasurementHandler extends OlLayerHandler {
 		this._unreg(this._registeredObservers);
 		this._unreg(this._measureStateChangedListeners);
 
-		this._persistLayer();
+		this._convertToPermanentLayer();
 
 		this._draw = false;
 		this._modify = false;
@@ -665,7 +665,7 @@ export class OlMeasurementHandler extends OlLayerHandler {
 		element.addEventListener('mouseleave', handleMouseLeave);
 	}
 
-	async _persistLayer() {
+	async _convertToPermanentLayer() {
 		const translate = (key) => this._translationService.translate(key);
 		const label = translate('map_olMap_handler_measure_layer_label');
 		
@@ -678,6 +678,7 @@ export class OlMeasurementHandler extends OlLayerHandler {
 			console.warn('Could not store layer-data. The data will get lost after this session.');	
 			id = 'temp_measure_id';
 			// TODO: offline-support is needed to properly working with temporary ids
+			// TODO: propagate the failing to UI-feedback-channel 
 		}
 		
 		try {//create a georesource and set the data as source

--- a/src/modules/map/components/olMap/handler/measure/OlMeasurementHandler.js
+++ b/src/modules/map/components/olMap/handler/measure/OlMeasurementHandler.js
@@ -390,7 +390,12 @@ export class OlMeasurementHandler extends OlLayerHandler {
 			}
 		}			
 		else {
-			this._fileStorageService.save(this._storeID, this._storedContent, FileStorageServiceDataTypes.KML).catch(error => console.warn('Could not store content:', error));										
+			try {
+				await this._fileStorageService.save(this._storeID, this._storedContent, FileStorageServiceDataTypes.KML);	
+			}
+			catch (error) {
+				console.warn('Could not store content:', error);
+			}	
 		}
 	}
 

--- a/src/modules/map/components/olMap/handler/measure/OlMeasurementHandler.js
+++ b/src/modules/map/components/olMap/handler/measure/OlMeasurementHandler.js
@@ -334,6 +334,8 @@ export class OlMeasurementHandler extends OlLayerHandler {
 			};
 
 			event.feature.set('measurement', measureTooltip);
+			event.feature.setId('measurement' + '_' +
+				new Date().getTime());
 			listener = event.feature.on('change', onFeatureChange);
 			zoomListener = this._map.getView().on('change:resolution', () => this._updateMeasureTooltips(this._activeSketch, true));
 			this._overlayManager.add(measureTooltip);

--- a/src/modules/map/i18n/olMap.provider.js
+++ b/src/modules/map/i18n/olMap.provider.js
@@ -14,7 +14,8 @@ export const provide = (lang) => {
 				map_olMap_handler_measure_modify_click_drag_overlay:'Click then drag to move the label',
 				map_olMap_handler_measure_modify_key_for_delete:'Press DEL to delete the drawing',
 				map_olMap_handler_delete_last_point:'Press DEL to remove the last point drawn',
-				map_olMap_handler_measure_select:'Select existing or start new measurement'
+				map_olMap_handler_measure_select:'Select existing or start new measurement',
+				map_olMap_handler_measure_layer_label:'Measurement',
 			};
 
 		case 'de':
@@ -30,7 +31,8 @@ export const provide = (lang) => {
 				map_olMap_handler_measure_modify_click_drag_overlay:'Klicke und ziehen um die Beschriftung zu verschieben',
 				map_olMap_handler_measure_modify_key_for_delete:'Zeichnung löschen: ENTF Taste',
 				map_olMap_handler_delete_last_point:'Letzter Punkt löschen: ENTF Taste',
-				map_olMap_handler_measure_select:'bestehende Messung auswählen oder neue Messung beginnen'
+				map_olMap_handler_measure_select:'bestehende Messung auswählen oder neue Messung beginnen',
+				map_olMap_handler_measure_layer_label:'Messung',
 			};
 
 		default:

--- a/src/utils/timer.js
+++ b/src/utils/timer.js
@@ -14,8 +14,10 @@
  *  const tHandler = throttled(200, myHandler);
  *  domNode.addEventListener("mousemove", tHandler);
  * </pre>
- * @param {*} delay 
- * @param {*} fn 
+ * @param {number} delay Delay in ms
+ * @param {Function} fn The wrapped function
+ * @returns {Function} A function that throttles the wrapped function when called 
+ }} 
  */
 export function throttled(delay, fn) {
 	let lastCall = 0;
@@ -39,8 +41,9 @@ export function throttled(delay, fn) {
  *  const dHandler = debounced(200, myHandler);
  *  domNode.addEventListener("input", dHandler);
  * </pre>
- * @param {*} delay 
- * @param {*} fn 
+ * @param {number} delay Delay in ms
+ * @param {Function} fn The wrapped function
+ * @returns {Function} A function that debounces the wrapped function when called
  */
 export function debounced(delay, fn) {
 	let timerId;

--- a/test/modules/map/components/olMap/handler/measure/OlMeasurementHandler.test.js
+++ b/test/modules/map/components/olMap/handler/measure/OlMeasurementHandler.test.js
@@ -77,6 +77,14 @@ describe('OlMeasurementHandler', () => {
 		expect(handler.activate).toBeTruthy();
 		expect(handler.deactivate).toBeTruthy();
 		expect(handler.id).toBe(MEASUREMENT_LAYER_ID);
+	});	
+
+	describe('static properties', () => {
+
+		it('defines a debounce time', async () => {
+			expect(OlMeasurementHandler.Debounce_Delay).toBe(1000);
+		});
+
 	});
 
 	const simulateDrawEvent = (type, draw, feature) => {
@@ -727,7 +735,7 @@ describe('OlMeasurementHandler', () => {
 				classUnderTest.activate(map);
 				classUnderTest._vectorLayer.getSource().addFeature(feature); // -> first call of _save, caused by vectorsource:addfeature-event
 				feature.getGeometry().dispatchEvent('change');			// -> second call of debounced _save, caused by vectorsource:changefeature-event
-				jasmine.clock().tick(3000);				
+				jasmine.clock().tick(OlMeasurementHandler.Debounce_Delay);				
 
 				expect(saveSpy).toHaveBeenCalledTimes(2);
 			});		
@@ -747,7 +755,7 @@ describe('OlMeasurementHandler', () => {
 				feature.getGeometry().dispatchEvent('change');
 				feature.getGeometry().dispatchEvent('change');
 				feature.getGeometry().dispatchEvent('change');
-				jasmine.clock().tick(3000);				
+				jasmine.clock().tick(OlMeasurementHandler.Debounce_Delay);				
 
 				expect(saveSpy).toHaveBeenCalledTimes(2);
 			});		

--- a/test/modules/map/components/olMap/handler/measure/OlMeasurementHandler.test.js
+++ b/test/modules/map/components/olMap/handler/measure/OlMeasurementHandler.test.js
@@ -312,7 +312,7 @@ describe('OlMeasurementHandler', () => {
 			const feature = createFeature();
 			const addOrReplaceSpy = spyOn(geoResourceServiceMock, 'addOrReplace');
 			spyOn(fileStorageServiceMock, 'save').and.returnValue(
-				Promise.reject('42' )
+				Promise.reject(new Error('42') )
 			);			
 			const warnSpy = spyOn(console, 'warn');
 			
@@ -838,7 +838,7 @@ describe('OlMeasurementHandler', () => {
 			setTimeout(() => {								
 				expect(classUnderTest._storeID).toBeUndefined();
 				expect(classUnderTest._storedContent).toBeTruthy();
-				expect(warnSpy).toHaveBeenCalledWith('Could not store content initially:', jasmine.any(Error));
+				expect(warnSpy).toHaveBeenCalledWith('Could not store content initially:', jasmine.any(String));
 			});	
 			
 		});	
@@ -859,7 +859,7 @@ describe('OlMeasurementHandler', () => {
 			classUnderTest._save();
 			
 			setTimeout(() => {							
-				expect(warnSpy).toHaveBeenCalledWith('Could not store content:', jasmine.any(Error));				
+				expect(warnSpy).toHaveBeenCalledWith('Could not store content:', jasmine.any(String));				
 			});	
 			
 		});	

--- a/test/modules/map/components/olMap/handler/measure/OlMeasurementHandler.test.js
+++ b/test/modules/map/components/olMap/handler/measure/OlMeasurementHandler.test.js
@@ -674,6 +674,14 @@ describe('OlMeasurementHandler', () => {
 
 	describe('when storing layer', () => {
 		
+		beforeEach(function () {
+			jasmine.clock().install();
+		});
+	
+		afterEach(function () {
+			jasmine.clock().uninstall();
+		});
+
 		let target;
 		const setupMap = () => {
 			target = document.createElement('div');
@@ -708,7 +716,7 @@ describe('OlMeasurementHandler', () => {
 		};
 
 
-		it('stores after adding a feature', async (done) => {
+		it('stores after adding a feature', async () => {
 			const classUnderTest = new OlMeasurementHandler();
 			const map = setupMap();
 			const saveSpy = spyOn(fileStorageServiceMock, 'save').and.returnValue(
@@ -724,13 +732,12 @@ describe('OlMeasurementHandler', () => {
 				expect(classUnderTest._storeID).toBe('fooBarId');
 				expect(classUnderTest._storedContent).toBeTruthy();
 				expect(saveSpy).toHaveBeenCalledTimes(1);
-				expect(saveSpy).toHaveBeenCalledWith(null, jasmine.any(String), FileStorageServiceDataTypes.KML);				
-				done();
+				expect(saveSpy).toHaveBeenCalledWith(null, jasmine.any(String), FileStorageServiceDataTypes.KML);	
 			});	
 			
 		});			
 		
-		it('stores after a feature is changed', async (done) => {
+		it('stores after a feature is changed', async () => {
 			const classUnderTest = new OlMeasurementHandler();
 			const map = setupMap();
 			const saveSpy = spyOn(fileStorageServiceMock, 'save').and.returnValue(
@@ -742,18 +749,18 @@ describe('OlMeasurementHandler', () => {
 			classUnderTest.activate(map);
 			classUnderTest._vectorLayer.getSource().addFeature(feature);
 			feature.getGeometry().dispatchEvent('change');			
-			
+			jasmine.clock().tick(3000);
+
 			setTimeout(() => {								
 				expect(classUnderTest._storeID).toBe('fooBarId');
 				expect(classUnderTest._storedContent).toBeTruthy();
 				expect(saveSpy).toHaveBeenCalledTimes(2);
-				done();
 			});	
 			
 		});		
 
 
-		it('stores after a feature is removed', async (done) => {
+		it('stores after a feature is removed', async () => {
 			const classUnderTest = new OlMeasurementHandler();
 			const map = setupMap();
 			const saveSpy = spyOn(fileStorageServiceMock, 'save').and.returnValue(
@@ -765,16 +772,17 @@ describe('OlMeasurementHandler', () => {
 			classUnderTest.activate(map);
 			classUnderTest._vectorLayer.getSource().addFeature(feature);
 			classUnderTest._vectorLayer.getSource().removeFeature(feature);
+		
 
 			setTimeout(() => {								
 				expect(classUnderTest._storeID).toBe('fooBarId');
 				expect(classUnderTest._storedContent).toBeTruthy();				
-				expect(saveSpy).toHaveBeenCalledTimes(2);
-				done();
+				expect(saveSpy).toHaveBeenCalledTimes(1);		
+				jasmine.clock().tick(3000);		
 			});	
 		});		
 
-		it('stores with storeId on second store ', async (done) => {
+		it('stores with storeId on second store ', async () => {
 			const classUnderTest = new OlMeasurementHandler();
 			const saveSpy = spyOn(fileStorageServiceMock, 'save').and.returnValue(
 				Promise.resolve({ fileId: 'fooBarId' } )
@@ -790,13 +798,12 @@ describe('OlMeasurementHandler', () => {
 			setTimeout(() => {							
 				expect(classUnderTest._storedContent).toBeTruthy();
 				expect(saveSpy).toHaveBeenCalledTimes(1);
-				expect(saveSpy).toHaveBeenCalledWith('fooBarId', jasmine.any(String), FileStorageServiceDataTypes.KML);	
-				done();
+				expect(saveSpy).toHaveBeenCalledWith('fooBarId', jasmine.any(String), FileStorageServiceDataTypes.KML);				
 			});	
 			
 		});	
 
-		it('logs warning on failed initial store ', async (done) => {
+		it('logs warning on failed initial store ', async () => {
 			const classUnderTest = new OlMeasurementHandler();
 			const map = setupMap();
 			spyOn(fileStorageServiceMock, 'save').and.returnValue(
@@ -813,12 +820,11 @@ describe('OlMeasurementHandler', () => {
 				expect(classUnderTest._storeID).toBeUndefined();
 				expect(classUnderTest._storedContent).toBeTruthy();
 				expect(warnSpy).toHaveBeenCalledWith('Could not store content initially:', jasmine.any(Error));
-				done();
 			});	
 			
 		});	
 
-		it('logs warning on second store ', async (done) => {
+		it('logs warning on second store ', async () => {
 			const classUnderTest = new OlMeasurementHandler();
 			spyOn(fileStorageServiceMock, 'save').and.returnValue(
 				Promise.reject(new Error('Failed'))
@@ -834,8 +840,7 @@ describe('OlMeasurementHandler', () => {
 			classUnderTest._save();
 			
 			setTimeout(() => {							
-				expect(warnSpy).toHaveBeenCalledWith('Could not store content:', jasmine.any(Error));
-				done();
+				expect(warnSpy).toHaveBeenCalledWith('Could not store content:', jasmine.any(Error));				
 			});	
 			
 		});	

--- a/test/modules/map/i18n/olMap.provider.test.js
+++ b/test/modules/map/i18n/olMap.provider.test.js
@@ -18,6 +18,7 @@ describe('i18n for map module', () => {
 		expect(map.map_olMap_handler_measure_modify_key_for_delete).toBe('Zeichnung löschen: ENTF Taste');
 		expect(map.map_olMap_handler_delete_last_point).toBe('Letzter Punkt löschen: ENTF Taste');
 		expect(map.map_olMap_handler_measure_select).toBe('bestehende Messung auswählen oder neue Messung beginnen');
+		expect(map.map_olMap_handler_measure_layer_label).toBe('Messung');
 	});
 
 	it('provides translation for en', () => {
@@ -35,10 +36,11 @@ describe('i18n for map module', () => {
 		expect(map.map_olMap_handler_measure_modify_key_for_delete).toBe('Press DEL to delete the drawing');
 		expect(map.map_olMap_handler_delete_last_point).toBe('Press DEL to remove the last point drawn');
 		expect(map.map_olMap_handler_measure_select).toBe('Select existing or start new measurement');
+		expect(map.map_olMap_handler_measure_layer_label).toBe('Measurement');
 	});
 
 	it('have the expected amount of translations', () => {
-		const expectedSize = 11;
+		const expectedSize = 12;
 		const deMap = provide('de');
 		const enMap = provide('en');
 


### PR DESCRIPTION
after successful creating measurement-data, the data should be converted/promoted from session-data to full-qualified georesource-data