### PR TITLE
update LayerManager for hidden layer

### DIFF
--- a/src/modules/map/components/layerManager/LayerManager.js
+++ b/src/modules/map/components/layerManager/LayerManager.js
@@ -59,8 +59,8 @@ export class LayerManager extends BaElement {
 	 */
 	createView() {
 		const translate = (key) => this._translationService.translate(key);
-		const { active } = this._state;
-		this._buildDraggableItems(active);
+		const { active } = this._state;		
+		this._buildDraggableItems(active.filter(l => !l.constraints.hidden));
 
 		const isNeighbour = (index, otherIndex) => {
 			return index === otherIndex || index - 1 === otherIndex || index + 1 === otherIndex;

--- a/test/modules/map/components/layerManager/LayerManager.test.js
+++ b/test/modules/map/components/layerManager/LayerManager.test.js
@@ -67,7 +67,7 @@ describe('LayerManager', () => {
 			expect(toggleElement.checked).toBeFalse();
 		});
 
-		it('with one hidden of two layer displays one layer item', async () => {
+		it('displays one out of two layers - one is hidden', async () => {
 			const layer = {
 				...defaultLayerProperties,
 				id: 'id0', label: 'label0', visible: true, zIndex: 0

--- a/test/modules/map/components/layerManager/LayerManager.test.js
+++ b/test/modules/map/components/layerManager/LayerManager.test.js
@@ -67,6 +67,27 @@ describe('LayerManager', () => {
 			expect(toggleElement.checked).toBeFalse();
 		});
 
+		it('with one hidden of two layer displays one layer item', async () => {
+			const layer = {
+				...defaultLayerProperties,
+				id: 'id0', label: 'label0', visible: true, zIndex: 0
+			};
+
+			const hiddenLayer = {
+				...defaultLayerProperties,
+				id: 'id1', label: 'label1', visible: false, zIndex: 0, constraints:{ hidden:true, alwaysOnTop:false }
+			};
+			const state = {
+				layers: {
+					active: [layer, hiddenLayer],
+					background: 'bg0'
+				}
+			};
+			const element = await setup(state);
+
+			expect(element.shadowRoot.querySelectorAll('.layer').length).toBe(1);
+		});
+
 		it('shows a title', async () => {
 			const stateEmpty = {
 				layers: {


### PR DESCRIPTION
update LayerManager to filter layers with 'hidden'-constraint evaluated
to `true`, to prevent rendering of related information. This behavior is needed
for instance for session-layers of tools.