### PR TITLE
Add a util function for rendering BaElement tags

### DIFF
--- a/src/modules/BaElement.js
+++ b/src/modules/BaElement.js
@@ -1,4 +1,5 @@
 import { render as renderLitHtml, html, nothing } from 'lit-html';
+import { unsafeHTML } from 'lit-html/directives/unsafe-html';
 import { $injector } from '../injection';
 import { equals } from '../utils/storeUtils';
 import css from './baElement.css';
@@ -318,3 +319,17 @@ export class BaElement extends HTMLElement {
 		this._observer.push(createObserver(name, onChange));
 	}
 }
+
+
+/**
+ * Calls the static #tag method of a BaElement and renders the result as HTML.
+ * Returns a lit-html Part instance.
+ * @param {*} Clazz A class that inherits BaElement
+ * @returns {Part} A lit-html Part instance
+ */
+export const renderTagOf = (baElementClazz) => {
+	if (baElementClazz.prototype instanceof BaElement) {
+		return unsafeHTML(`<${baElementClazz.tag}/>`);
+	}
+	throw new TypeError(`${baElementClazz.name} does not inherit BaElement`);
+};

--- a/src/modules/menu/components/mainMenu/MainMenu.js
+++ b/src/modules/menu/components/mainMenu/MainMenu.js
@@ -1,22 +1,21 @@
 import { html, nothing } from 'lit-html';
-import { BaElement } from '../../../BaElement';
+import { BaElement, renderTagOf } from '../../../BaElement';
 import css from './mainMenu.css';
 import { toggle } from '../../store/mainMenu.action';
 import { $injector } from '../../../../injection';
 import { SearchContentPanel } from '../../../search/components/menu/SearchContentPanel';
-import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { DevInfo } from '../../../utils/components/devInfo/DevInfo';
 
 /**
  * @enum
  */
 export const MainMenuTabIndex = Object.freeze({
-	TOPICS: { id: 0, tag: null },
-	MAPS: { id: 1, tag: null },
-	MORE: { id: 2, tag: null },
-	ROUTING: { id: 3, tag: null },
-	SEARCH: { id: 4, tag: SearchContentPanel.tag },
-	FEATUREINFO: { id: 5, tag: null }
+	TOPICS: { id: 0, component: null },
+	MAPS: { id: 1, component: null },
+	MORE: { id: 2, component: null },
+	ROUTING: { id: 3, component: null },
+	SEARCH: { id: 4, component: SearchContentPanel },
+	FEATUREINFO: { id: 5, component: null }
 });
 
 
@@ -117,7 +116,7 @@ export class MainMenu extends BaElement {
 								</div>								
 							`)}
 						</div>
-						${unsafeHTML(`<${DevInfo.tag}/>`)}	
+						${renderTagOf(DevInfo)}	
 					</div>			
 				</div>			
 			</div>			
@@ -134,7 +133,7 @@ export class MainMenu extends BaElement {
 			case MainMenuTabIndex.MORE:
 				return this._demoMoreContent();
 			case MainMenuTabIndex.SEARCH:
-				return html`${unsafeHTML(`<${index.tag}/>`)}`;
+				return html`${renderTagOf(index.component)}`;
 			default:
 				return nothing;
 		}

--- a/src/services/provider/geoResource.provider.js
+++ b/src/services/provider/geoResource.provider.js
@@ -67,7 +67,7 @@ export const loadBvvGeoResources = async () => {
 /**
  * Helper function to parse BVV attributions.
  * @param {object} definition BVV geoResouce definition
- * @returns  {<Array<Attribution>|null}
+ * @returns  {Array<Attribution>|null}
  */
 export const parseBvvAttributionDefinition = (definition) => {
 

--- a/test/modules/BaElement.test.js
+++ b/test/modules/BaElement.test.js
@@ -1,4 +1,4 @@
-import { BaElement } from '../../src/modules/BaElement';
+import { BaElement, renderTagOf } from '../../src/modules/BaElement';
 import { html, nothing } from 'lit-html';
 import { TestUtils } from '../test-utils.js';
 
@@ -271,14 +271,14 @@ describe('BaElement', () => {
 
 		it('checks if a template result contains content', async () => {
 			const element = await TestUtils.render(BaElementImpl.tag);
-			
+
 			expect(element._isNothing(nothing)).toBeTrue();
 			expect(element._isNothing(undefined)).toBeTrue();
 			expect(element._isNothing(null)).toBeTrue();
 			expect(element._isNothing('')).toBeTrue();
 			expect(element._isNothing(html`some`)).toBeFalse();
 		});
-		
+
 		it('prepends the default css', async () => {
 			const element = await TestUtils.render(BaElementDefaultCss.tag);
 			expect(element.shadowRoot.querySelector('#defaultCss')).toBeTruthy();
@@ -288,6 +288,21 @@ describe('BaElement', () => {
 			const element = await TestUtils.render(BaElementNoDefaultCss.tag);
 			expect(element.shadowRoot.querySelector('#defaultCss')).toBeFalsy();
 		});
-		
+
 	});
 });
+
+describe('renderTagOf', () => {
+
+	it('throws an exception when class does not inherit BaElement', () => {
+		class Foo { }
+
+		expect(() => renderTagOf(Foo)).toThrowError(TypeError, 'Foo does not inherit BaElement');
+	});
+
+	it('renders the tag as html', () => {
+
+		expect(renderTagOf(BaElementImpl)).toBeTruthy();
+	});
+});
+

--- a/test/modules/menu/components/mainMenu/MainMenu.test.js
+++ b/test/modules/menu/components/mainMenu/MainMenu.test.js
@@ -17,12 +17,12 @@ describe('MainMenuTabIndex', () => {
 
 		expect(Object.entries(MainMenuTabIndex).length).toBe(6);
 		expect(Object.isFrozen(MainMenuTabIndex)).toBeTrue();
-		expect(MainMenuTabIndex.TOPICS).toEqual({ id: 0, tag: null });
-		expect(MainMenuTabIndex.MAPS).toEqual({ id: 1, tag: null });
-		expect(MainMenuTabIndex.MORE).toEqual({ id: 2, tag: null });
-		expect(MainMenuTabIndex.ROUTING).toEqual({ id: 3, tag: null });
-		expect(MainMenuTabIndex.SEARCH).toEqual({ id: 4, tag: SearchContentPanel.tag });
-		expect(MainMenuTabIndex.FEATUREINFO).toEqual({ id: 5, tag: null });
+		expect(MainMenuTabIndex.TOPICS).toEqual({ id: 0, component: null });
+		expect(MainMenuTabIndex.MAPS).toEqual({ id: 1, component: null });
+		expect(MainMenuTabIndex.MORE).toEqual({ id: 2, component: null });
+		expect(MainMenuTabIndex.ROUTING).toEqual({ id: 3, component: null });
+		expect(MainMenuTabIndex.SEARCH).toEqual({ id: 4, component: SearchContentPanel });
+		expect(MainMenuTabIndex.FEATUREINFO).toEqual({ id: 5, component: null });
 	});
 });
 


### PR DESCRIPTION
Util to include other imported BaElements in a view without knowing their exact tag.

````
import { renderTagOf } from ...
import { BaseLayerSwitcher } from ...

//and in createView()

return html`
	<div>
	     ${renderTagOf(BaseLayerSwitcher)}		
	</div>
	`;
````
We can directly reference the tag of an imported BaElement and do not need to reference them by a fragile string.
No support for attributes (and not planned).