### PR TITLE
Rework state access in BaElement

### DIFF
--- a/src/modules/BaElement.js
+++ b/src/modules/BaElement.js
@@ -81,6 +81,15 @@ export class BaElement extends HTMLElement {
 	}
 
 	/**
+	 * Returns the current state.
+	 * @protected
+	 * @returns state of this element
+	 */
+	getState() {
+		return this._state;
+	}
+
+	/**
 	 *
 	 * @param {string} message 
 	 * @protected
@@ -148,7 +157,7 @@ export class BaElement extends HTMLElement {
 		if (!equals(this._state, extractedState)) {
 			this._state = extractedState;
 			this._observer.forEach(o => o());
-			this.onStateChanged();
+			this.onStateChanged(this._state);
 		}
 	}
 
@@ -164,9 +173,10 @@ export class BaElement extends HTMLElement {
 	 * and is called by each render cycle.
 	 * @abstract
 	 * @protected
+	 * @param {object} state state of this element
 	 * @returns {TemplateResult|nothing|null|undefined|''}
 	 */
-	createView() {
+	createView(/*eslint-disable no-unused-vars */state) {
 		// The child has not implemented this method.
 		throw new TypeError('Please implement abstract method #createView or do not call super.createView from child.');
 	}
@@ -177,9 +187,10 @@ export class BaElement extends HTMLElement {
 	 * 
 	 * @see {@link BaElement#onStateChanged}
 	 * @protected
-	 * @returns state of the elements {Object}
+	 * @param {object} globalState **global** state
+	 * @returns state of this elements
 	 */
-	extractState(/*eslint-disable no-unused-vars */state) {
+	extractState(/*eslint-disable no-unused-vars */globalState) {
 		return {};
 	}
 
@@ -205,7 +216,7 @@ export class BaElement extends HTMLElement {
 
 			const initialRendering = !this._rendered;
 			this.onBeforeRender(initialRendering);
-			const template = this.createView();
+			const template = this.createView(this._state);
 			if (this._isNothing(template)) {
 				renderLitHtml(template, this.getRenderTarget());
 			}
@@ -263,8 +274,9 @@ export class BaElement extends HTMLElement {
 	 * Called after the elements state has been changed. 
 	 * Per default {@link BaElement#render} is called. 
 	 * @protected
+	 * @param {object} state state of this element
 	 */
-	onStateChanged() {
+	onStateChanged(/*eslint-disable no-unused-vars */state) {
 		this.render();
 	}
 

--- a/src/modules/baseLayer/components/switcher/BaseLayerSwitcher.js
+++ b/src/modules/baseLayer/components/switcher/BaseLayerSwitcher.js
@@ -25,8 +25,8 @@ export class BaseLayerSwitcher extends BaElement {
 	/**
 	 * @override
 	 */
-	createView() {
-		const { currentTopicId, activeLayers, layersStoreReady } = this._state;
+	createView(state) {
+		const { currentTopicId, activeLayers, layersStoreReady } = state;
 
 		if (layersStoreReady) {
 
@@ -85,8 +85,8 @@ export class BaseLayerSwitcher extends BaElement {
 	/**
 	 * @override
 	 */
-	extractState(state) {
-		const { topics: { current: currentTopicId }, layers: { active: activeLayers, ready: layersStoreReady } } = state;
+	extractState(globalState) {
+		const { topics: { current: currentTopicId }, layers: { active: activeLayers, ready: layersStoreReady } } = globalState;
 		return { currentTopicId, activeLayers, layersStoreReady };
 	}
 

--- a/src/modules/contextMenue/components/ContextMenue.js
+++ b/src/modules/contextMenue/components/ContextMenue.js
@@ -56,8 +56,8 @@ export class ContextMenue extends BaElement {
 	/**
 	 * @override
 	 */
-	createView() {
-		const { pointer, commands } = this._state;
+	createView(state) {
+		const { pointer, commands } = state;
 		const isOpen = pointer !== false;
 		const onClick = (command) => {
 			command.action();
@@ -88,10 +88,10 @@ export class ContextMenue extends BaElement {
 
 	/**
 	 * @override
-	 * @param {Object} state 
+	 * @param {Object} globalState 
 	 */
-	extractState(state) {
-		const { contextMenue: { data } } = state;
+	extractState(globalState) {
+		const { contextMenue: { data } } = globalState;
 		return data;
 	}
 

--- a/src/modules/footer/components/Footer.js
+++ b/src/modules/footer/components/Footer.js
@@ -44,9 +44,9 @@ export class Footer extends BaElement {
 		return this._environmentService.isEmbedded();
 	}
 
-	createView() {
+	createView(state) {
 
-		const { open } = this._state;
+		const { open } = state;
 
 		const getOverlayClass = () => {
 			return (open && !this._portrait) ? 'is-open' : '';
@@ -76,10 +76,10 @@ export class Footer extends BaElement {
 
 	/**
 	 * @override
-	 * @param {Object} state 
+	 * @param {Object} globalState 
 	 */
-	extractState(state) {
-		const { mainMenu: { open } } = state;
+	extractState(globalState) {
+		const { mainMenu: { open } } = globalState;
 		return { open };
 	}
 

--- a/src/modules/footer/components/baseLayerInfo/BaseLayerInfo.js
+++ b/src/modules/footer/components/baseLayerInfo/BaseLayerInfo.js
@@ -20,9 +20,9 @@ export class BaseLayerInfo extends BaElement {
 	/**
      * @override 
      */
-	createView() {
+	createView(state) {
 		const translate = (key) => this._translationService.translate(key);
-		const { active, zoom } = this._state;
+		const { active, zoom } = state;
 
 		const geoResource = active[0] ? this._georesourceService.byId(active[0].id) : null;
 
@@ -43,10 +43,10 @@ export class BaseLayerInfo extends BaElement {
 
 	/**
 	  * @override
-	  * @param {Object} state 
+	  * @param {Object} globalState 
 	  */
-	extractState(state) {
-		const { layers: { active }, position: { zoom } } = state;
+	extractState(globalState) {
+		const { layers: { active }, position: { zoom } } = globalState;
 		return { active, zoom };
 	}
 

--- a/src/modules/footer/components/coordinateSelect/CoordinateSelect.js
+++ b/src/modules/footer/components/coordinateSelect/CoordinateSelect.js
@@ -36,11 +36,11 @@ export class CoordinateSelect extends BaElement {
 	/**
      *@override 
      */
-	createView() {
+	createView(state) {
 
 		const translate = (key) => this._translationService.translate(key);
 
-		const { pointerPosition } = this._state;
+		const { pointerPosition } = state;
 		
 		const getPointerPositionChange = () => {
 			switch (this._selectedCode) {
@@ -78,9 +78,9 @@ export class CoordinateSelect extends BaElement {
 	/**
      * @override 
      */
-	extractState(state) {
+	extractState(globalState) {
 		let pointerPosition = undefined;
-		const { pointer: { move } } = state;
+		const { pointer: { move } } = globalState;
 		if (move) {
 			pointerPosition = move.payload.coordinate;
 		}

--- a/src/modules/header/components/Header.js
+++ b/src/modules/header/components/Header.js
@@ -71,7 +71,7 @@ export class Header extends BaElement {
 		return this._environmentService.isEmbedded();
 	}
 
-	createView() {
+	createView(state) {
 
 		const showModalInfo = () => {
 			const payload = { title: 'Showcase', content: html`<ba-showcase></ba-showcase>` };
@@ -86,7 +86,7 @@ export class Header extends BaElement {
 			return this._minWidth ? 'is-desktop' : 'is-tablet';
 		};
 
-		const { open, tabIndex, fetching } = this._state;
+		const { open, tabIndex, fetching, layers } = state;
 
 		const getOverlayClass = () => {
 			return (open && !this._portrait) ? 'is-open' : '';
@@ -100,7 +100,6 @@ export class Header extends BaElement {
 			return (tabIndex === buttonIndex) ? 'is-active' : '';
 		};
 
-		const { layers } = this._state;
 		const layerCount = layers.length;
 
 		const onFocusInput = () => {
@@ -191,10 +190,10 @@ export class Header extends BaElement {
 
 	/**
 	 * @override
-	 * @param {Object} state 
+	 * @param {Object} globalState 
 	 */
-	extractState(state) {
-		const { mainMenu: { open, tabIndex }, network: { fetching }, layers: { active: layers } } = state;
+	extractState(globalState) {
+		const { mainMenu: { open, tabIndex }, network: { fetching }, layers: { active: layers } } = globalState;
 		return { open, tabIndex, fetching, layers };
 	}
 

--- a/src/modules/map/components/attributionInfo/AttributionInfo.js
+++ b/src/modules/map/components/attributionInfo/AttributionInfo.js
@@ -23,9 +23,9 @@ export class AttributionInfo extends BaElement {
 	/**
      * @override 
      */
-	createView() {
+	createView(state) {
 		const translate = (key) => this._translationService.translate(key);
-		const { active, zoom } = this._state;
+		const { active, zoom } = state;
 
 		const attributionsRaw = new Array(); 
 
@@ -91,10 +91,10 @@ export class AttributionInfo extends BaElement {
 
 	/**
 	  * @override
-	  * @param {Object} state 
+	  * @param {Object} globalState 
 	  */
-	extractState(state) {
-		const { layers: { active }, position: { zoom } } = state;
+	extractState(globalState) {
+		const { layers: { active }, position: { zoom } } = globalState;
 		return { active, zoom };
 	}
 

--- a/src/modules/map/components/contextMenu/MapContextMenu.js
+++ b/src/modules/map/components/contextMenu/MapContextMenu.js
@@ -46,9 +46,9 @@ export class MapContextMenu extends BaElement {
 	/**
 	 * @override
 	 */
-	createView() {
+	createView(state) {
 		const translate = (key) => this._translationService.translate(key);
-		const { coordinate, id } = this._state;
+		const { coordinate, id } = state;
 
 		if (!coordinate || !id) {
 			return nothing;
@@ -82,8 +82,8 @@ export class MapContextMenu extends BaElement {
 	/**
 	 * @override
 	 */
-	extractState(state) {
-		const { mapContextMenu: { coordinate, id } } = state;
+	extractState(globalState) {
+		const { mapContextMenu: { coordinate, id } } = globalState;
 		return { coordinate, id };
 	}
 

--- a/src/modules/map/components/geolocationButton/GeolocationButton.js
+++ b/src/modules/map/components/geolocationButton/GeolocationButton.js
@@ -22,8 +22,8 @@ export class GeolocationButton extends BaElement {
 	/**
 	 *@override 
 	 */
-	createView() {
-		const { active, denied } = this._state;
+	createView(state) {
+		const { active, denied } = state;
 		const translate = (key) => this._translationService.translate(key);
 		const onClick = () => {
 			if (active) {
@@ -56,8 +56,8 @@ export class GeolocationButton extends BaElement {
 		`;
 	}
 
-	extractState(state) {
-		const { geolocation: { active, denied } } = state;
+	extractState(globalState) {
+		const { geolocation: { active, denied } } = globalState;
 		return { active, denied };
 	}
 

--- a/src/modules/map/components/infoButton/InfoButton.js
+++ b/src/modules/map/components/infoButton/InfoButton.js
@@ -62,8 +62,8 @@ export class InfoButton extends BaElement {
         `;
 	} 
 
-	extractState(state) {
-		const { position: { zoom, center } } = state;
+	extractState(globalState) {
+		const { position: { zoom, center } } = globalState;
 		return { zoom, center };
 	}
 

--- a/src/modules/map/components/layerManager/LayerManager.js
+++ b/src/modules/map/components/layerManager/LayerManager.js
@@ -57,9 +57,9 @@ export class LayerManager extends BaElement {
 	/**
 	 * @override
 	 */
-	createView() {
+	createView(state) {
 		const translate = (key) => this._translationService.translate(key);
-		const { active } = this._state;		
+		const { active } = state;		
 		this._buildDraggableItems(active.filter(l => !l.constraints.hidden));
 
 		const isNeighbour = (index, otherIndex) => {
@@ -151,10 +151,10 @@ export class LayerManager extends BaElement {
 
 	/**
 	  * @override
-	  * @param {Object} state 
+	  * @param {Object} globalState 
 	  */
-	extractState(state) {
-		const { layers: { active } } = state;
+	extractState(globalState) {
+		const { layers: { active } } = globalState;
 
 		return { active };
 	}

--- a/src/modules/map/components/olMap/OlMap.js
+++ b/src/modules/map/components/olMap/OlMap.js
@@ -50,7 +50,7 @@ export class OlMap extends BaElement {
 	 * @override
 	 */
 	initialize() {
-		const { zoom, center } = this._state;
+		const { zoom, center } = this.getState();
 
 		this._view = new View({
 			center: center,
@@ -136,10 +136,10 @@ export class OlMap extends BaElement {
 
 	/**
 	 * @override
-	 * @param {Object} state 
+	 * @param {Object} globalState 
 	 */
-	extractState(state) {
-		const { position: { zoom, center, fitRequest }, layers: { active: layers } } = state;
+	extractState(globalState) {
+		const { position: { zoom, center, fitRequest }, layers: { active: layers } } = globalState;
 		return { zoom, center, fitRequest, layers };
 	}
 
@@ -163,7 +163,7 @@ export class OlMap extends BaElement {
 	}
 
 	_syncView() {
-		const { zoom, center } = this._state;
+		const { zoom, center } = this.getState();
 
 		if (!this._viewSyncBlocked) {
 
@@ -176,7 +176,7 @@ export class OlMap extends BaElement {
 	}
 
 	_syncOverlayLayer() {
-		const { layers } = this._state;
+		const { layers } = this.getState();
 
 		const updatedIds = layers.map(layer => layer.geoResourceId);
 		const currentIds = this._map.getLayers()

--- a/src/modules/menu/components/mainMenu/MainMenu.js
+++ b/src/modules/menu/components/mainMenu/MainMenu.js
@@ -77,9 +77,9 @@ export class MainMenu extends BaElement {
 	/**
 	 * @override
 	 */
-	createView() {
+	createView(state) {
 
-		const { open, tabIndex } = this._state;
+		const { open, tabIndex } = state;
 
 		this._activeTabIndex = tabIndex;
 
@@ -295,10 +295,10 @@ export class MainMenu extends BaElement {
 
 	/**
 	 * @override
-	 * @param {Object} state 
+	 * @param {Object} globalState 
 	 */
-	extractState(state) {
-		const { mainMenu: { open, tabIndex } } = state;
+	extractState(globalState) {
+		const { mainMenu: { open, tabIndex } } = globalState;
 		return { open, tabIndex };
 	}
 

--- a/src/modules/menu/components/mediaQueryPanel/MediaQueryPanel.js
+++ b/src/modules/menu/components/mediaQueryPanel/MediaQueryPanel.js
@@ -53,9 +53,9 @@ export class MediaQueryPanel extends BaElement {
 	/**
 	 * @override
 	 */
-	createView() {
+	createView(state) {
 
-		const { open } = this._state;
+		const { open } = state;
 
 		const getOrientationClass = () => {
 			return this._portrait ? 'is-portrait' : 'is-landscape';
@@ -83,10 +83,10 @@ export class MediaQueryPanel extends BaElement {
 
 	/**
 	 * @override
-	 * @param {Object} state 
+	 * @param {Object} globalState 
 	 */
-	extractState(state) {
-		const { sidePanel: { open } } = state;
+	extractState(globalState) {
+		const { sidePanel: { open } } = globalState;
 		return { open };
 	}
 

--- a/src/modules/menu/components/sidePanel/SidePanel.js
+++ b/src/modules/menu/components/sidePanel/SidePanel.js
@@ -58,9 +58,9 @@ export class SidePanel extends BaElement {
 	/**
 	 * @override
 	 */
-	createView() {
+	createView(state) {
 
-		const { open } = this._state;
+		const { open } = state;
 		const { portrait } = this._environmentService.getScreenOrientation();
 		const getOverlayClass = () => {
 			if (portrait) {
@@ -112,10 +112,10 @@ export class SidePanel extends BaElement {
 
 	/**
 	 * @override
-	 * @param {Object} state 
+	 * @param {Object} globalState 
 	 */
-	extractState(state) {
-		const { sidePanel: { open } } = state;
+	extractState(globalState) {
+		const { sidePanel: { open } } = globalState;
 		return { open };
 	}
 

--- a/src/modules/menu/components/toolBar/ToolBar.js
+++ b/src/modules/menu/components/toolBar/ToolBar.js
@@ -61,9 +61,9 @@ export class ToolBar extends BaElement {
 	/**
 	 * @override
 	 */
-	createView() {
+	createView(state) {
 
-		const { toolBar, toolContainer } = this._state;
+		const { toolBar, toolContainer } = state;
 		const toolBarOpen = toolBar.open;
 		const activeToolId = toolContainer.contentId;
 		const getOrientationClass = () => {
@@ -139,10 +139,10 @@ export class ToolBar extends BaElement {
 
 	/**
 	 * @override
-	 * @param {Object} state 
+	 * @param {Object} globalState 
 	 */
-	extractState(state) {
-		const { toolBar, toolContainer } = state;
+	extractState(globalState) {
+		const { toolBar, toolContainer } = globalState;
 		return { toolBar: toolBar, toolContainer: toolContainer };
 	}
 

--- a/src/modules/modal/components/Modal.js
+++ b/src/modules/modal/components/Modal.js
@@ -20,8 +20,8 @@ export class Modal extends BaElement {
 	/**
 	 * @override
 	 */
-	createView() {
-		const { title, content, visible } = this._state;
+	createView(state) {
+		const { title, content, visible } = state;
 		const translate = (key) => this._translationService.translate(key);
 
 		if (visible) {
@@ -45,10 +45,10 @@ export class Modal extends BaElement {
 	
 	/**
  * @override
- * @param {Object} state 
+ * @param {Object} globalState 
  */
-	extractState(state) {
-		const { modal: { title, content } } = state;
+	extractState(globalState) {
+		const { modal: { title, content } } = globalState;
 		const visible = content;
 		return { title, content, visible };
 	}

--- a/src/modules/toolbox/components/measureToolContent/MeasureToolContent.js
+++ b/src/modules/toolbox/components/measureToolContent/MeasureToolContent.js
@@ -28,9 +28,9 @@ export class MeasureToolContent extends BaElement {
 		this._isFirstMeasurement = true;
 	}
 
-	createView() {
+	createView(state) {
 		const translate = (key) => this._translationService.translate(key);
-		const { active, statistic } = this._state;
+		const { active, statistic } = state;
 		this._isFirstMeasurement = this._isFirstMeasurement ? (statistic.length === 0 ? true : false) : false;
 		this._tool.active = active;
 		const areaClasses = { 'is-area': statistic.area > 0 };
@@ -119,10 +119,10 @@ export class MeasureToolContent extends BaElement {
 
 	/**
 	 * @override
-	 * @param {Object} state 
+	 * @param {Object} globalState 
 	 */
-	extractState(state) {
-		const { measurement } = state;
+	extractState(globalState) {
+		const { measurement } = globalState;
 		return measurement;
 	}
 

--- a/src/modules/toolbox/components/toolContainer/ToolContainer.js
+++ b/src/modules/toolbox/components/toolContainer/ToolContainer.js
@@ -58,9 +58,9 @@ export class ToolContainer extends BaElement {
 	/**
 	 * @override
 	 */
-	createView() {
+	createView(state) {
 
-		const { open, contentId } = this._state;
+		const { open, contentId } = state;
 
 		let content;
 		switch (contentId) {
@@ -121,10 +121,10 @@ export class ToolContainer extends BaElement {
 
 	/**
  * @override
- * @param {Object} state 
+ * @param {Object} globalState 
  */
-	extractState(state) {
-		const { toolContainer } = state;
+	extractState(globalState) {
+		const { toolContainer } = globalState;
 		return toolContainer;
 	}
 

--- a/src/modules/uiTheme/components/provider/ThemeProvider.js
+++ b/src/modules/uiTheme/components/provider/ThemeProvider.js
@@ -18,7 +18,7 @@ export class ThemeProvider extends BaElement {
 
 	initialize() {
 
-		this._updateCss();
+		this._updateCss(this.getState());
 
 		//listen to theme changes on window
 		this._environmentService.getWindow().matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e => {
@@ -26,9 +26,9 @@ export class ThemeProvider extends BaElement {
 		});
 	}
 
-	_updateCss() {
+	_updateCss(state) {
 		
-		const { theme } = this._state;
+		const { theme } = state;
 		const cssClassToAdd = theme === 'dark' ? 'dark-theme' : 'light-theme';
 		const cssClassToRemove = theme === 'light' ? 'dark-theme' : 'light-theme';
 		this._environmentService.getWindow()
@@ -41,12 +41,12 @@ export class ThemeProvider extends BaElement {
 		return true;
 	}
 
-	onStateChanged() {
-		this._updateCss();
+	onStateChanged(state) {
+		this._updateCss(state);
 	}
 
-	extractState(state) {
-		const { uiTheme: { theme } } = state;
+	extractState(globalState) {
+		const { uiTheme: { theme } } = globalState;
 		return { theme };
 	}
 

--- a/src/modules/uiTheme/components/toggle/ThemeToggle.js
+++ b/src/modules/uiTheme/components/toggle/ThemeToggle.js
@@ -18,8 +18,8 @@ export class ThemeToggle extends BaElement {
 		this._translationService = TranslationService;
 	}
 
-	extractState(state) {
-		const { uiTheme: { theme } } = state;
+	extractState(globalState) {
+		const { uiTheme: { theme } } = globalState;
 		return { theme };
 	}
 
@@ -33,9 +33,9 @@ export class ThemeToggle extends BaElement {
 		}
 	}
 
-	createView() {
-		const isChecked = (this._state.theme === 'dark');
-		const title = this._translationService.translate('uiTheme_toggle_tooltip_' + this._state.theme);
+	createView(state) {
+		const isChecked = (state.theme === 'dark');
+		const title = this._translationService.translate('uiTheme_toggle_tooltip_' + state.theme);
 
 		return html`
 		<style>${css}</style>


### PR DESCRIPTION
Dear BA Devs, 
access to an element's state based on `this._state` is not allowed anymore ☝️

Use instead:

-  `createView(state)`
-  `this.getState()`