### PR TITLE
update states for measurement related and interactions

### DIFF
--- a/src/modules/map/components/olMap/handler/measure/OlMeasurementHandler.js
+++ b/src/modules/map/components/olMap/handler/measure/OlMeasurementHandler.js
@@ -320,8 +320,7 @@ export class OlMeasurementHandler extends OlLayerHandler {
 			}
 			else {
 				this._activateModify(null);
-			}
-			
+			}			
 		}
 	}
 

--- a/src/modules/map/components/olMap/handler/measure/OlMeasurementHandler.js
+++ b/src/modules/map/components/olMap/handler/measure/OlMeasurementHandler.js
@@ -130,7 +130,7 @@ export class OlMeasurementHandler extends OlLayerHandler {
 							f.set('srid', this._mapService.getSrid(), true);
 							layer.getSource().addFeature(f);
 							this._overlayManager.createDistanceOverlay(f);
-							this._overlayManager.createAreaOverlay(f);
+							this._overlayManager.createOrRemoveAreaOverlay(f);
 							this._overlayManager.createPartitionOverlays(f);
 							this._overlayManager.restoreManualOverlayPosition(f);
 							f.on('change', onFeatureChange);	
@@ -495,7 +495,7 @@ export class OlMeasurementHandler extends OlLayerHandler {
 				measureGeometry = new LineString(lineCoordinates);
 			}
 			
-			this._overlayManager.createAreaOverlay(feature);
+			this._overlayManager.createOrRemoveAreaOverlay(feature);
 			
 		}
 

--- a/src/modules/map/components/olMap/handler/measure/OlMeasurementHandler.js
+++ b/src/modules/map/components/olMap/handler/measure/OlMeasurementHandler.js
@@ -316,11 +316,9 @@ export class OlMeasurementHandler extends OlLayerHandler {
 	_finish( ) {
 		if (this._draw.getActive()) {
 			if (this._activeSketch) {
-				console.log('Finish with new drawing');
 				this._draw.finishDrawing();
 			}
 			else {
-				console.log('Finish without new drawing');
 				this._activateModify(null);
 			}
 			

--- a/src/modules/map/components/olMap/handler/measure/OlMeasurementHandler.js
+++ b/src/modules/map/components/olMap/handler/measure/OlMeasurementHandler.js
@@ -1,4 +1,5 @@
 import { DragPan, Draw, Modify, Select, Snap } from 'ol/interaction';
+import { MapBrowserEvent } from 'ol';
 import { Vector as VectorSource } from 'ol/source';
 import { Vector as VectorLayer } from 'ol/layer';
 import { unByKey } from 'ol/Observable';
@@ -317,6 +318,14 @@ export class OlMeasurementHandler extends OlLayerHandler {
 		if (this._draw.getActive()) {
 			if (this._activeSketch) {
 				this._draw.finishDrawing();
+				const event = new Event('click');
+				event.clientX = this._map.getView().getCenter()[0];
+				event.clientY = this._map.getView().getCenter()[1];
+				event.pageX = this._map.getView().getCenter()[0];
+				event.pageY = this._map.getView().getCenter()[1];
+				event.shiftKey = false;
+				const mapEvent = new MapBrowserEvent('click', this._map, event);
+				this._map.dispatchEvent(mapEvent);		
 			}
 			else {
 				this._activateModify(null);

--- a/src/modules/map/components/olMap/handler/measure/OverlayManager.js
+++ b/src/modules/map/components/olMap/handler/measure/OverlayManager.js
@@ -77,16 +77,24 @@ export class OverlayManager {
 
 	createAreaOverlay(feature) {
 		if (feature.getGeometry() instanceof Polygon) {		
+			let areaOverlay = feature.get('area');
 			if (feature.getGeometry().getArea())	{
 				const isDraggable = !this._environmentService.isTouch();
-				let areaOverlay = feature.get('area');
+				
 				if (!areaOverlay) {
 					areaOverlay = this.create({ positioning: 'top-center' }, MeasurementOverlayTypes.AREA, this._projectionHints, isDraggable);
 					this.add(areaOverlay);
 				}
 				this.update(areaOverlay, feature.getGeometry());
-				feature.set('area', areaOverlay);	
+				feature.set('area', areaOverlay);					
+			}
+			else {
+				if (areaOverlay) {
+					this.remove(areaOverlay);
+					feature.set('area', null);					
+				}
 			}		
+
 		}		
 	}
 

--- a/src/modules/map/components/olMap/handler/measure/OverlayManager.js
+++ b/src/modules/map/components/olMap/handler/measure/OverlayManager.js
@@ -75,7 +75,7 @@ export class OverlayManager {
 	}
 
 
-	createAreaOverlay(feature) {
+	createOrRemoveAreaOverlay(feature) {
 		if (feature.getGeometry() instanceof Polygon) {		
 			let areaOverlay = feature.get('area');
 			if (feature.getGeometry().getArea())	{
@@ -94,7 +94,6 @@ export class OverlayManager {
 					feature.set('area', null);					
 				}
 			}		
-
 		}		
 	}
 

--- a/src/modules/map/store/measurement.action.js
+++ b/src/modules/map/store/measurement.action.js
@@ -2,7 +2,7 @@
  * Action creators to activate/deactive the measurement tool
  * @module map/action
  */
-import { ACTIVE_CHANGED, STATISTIC_CHANGED, RESET_REQUESTED, REMOVE_REQUESTED } from './measurement.reducer';
+import { ACTIVE_CHANGED, STATISTIC_CHANGED, MODE_CHANGED, RESET_REQUESTED, FINISH_REQUESTED, REMOVE_REQUESTED } from './measurement.reducer';
 import { $injector } from '../../../injection';
 import { EventLike } from '../../../utils/storeUtils';
 
@@ -48,6 +48,19 @@ export const setStatistic = (stat) => {
 };
 
 /**
+ * set the mode of a measurement.
+ * @function
+ */
+export const setMode = (mode) => {
+	getStore().dispatch({
+		type: MODE_CHANGED,
+		payload: mode
+	});
+};
+
+
+
+/**
  * set the reset request.
  * @function
  */
@@ -57,6 +70,19 @@ export const reset = () => {
 		payload: new EventLike('reset')
 	});
 };
+
+
+/**
+ * set the reset request.
+ * @function
+ */
+export const finish = () => {
+	getStore().dispatch({
+		type: FINISH_REQUESTED,
+		payload: new EventLike('finish')
+	});
+};
+
 
 /**
  * set the delete request.

--- a/src/modules/map/store/measurement.reducer.js
+++ b/src/modules/map/store/measurement.reducer.js
@@ -1,5 +1,7 @@
 export const ACTIVE_CHANGED = 'measurement/active';
 export const STATISTIC_CHANGED = 'measurement/statistic';
+export const MODE_CHANGED = 'measurement/mode';
+export const FINISH_REQUESTED = 'measurement/finish';
 export const RESET_REQUESTED = 'measurement/reset';
 export const REMOVE_REQUESTED = 'measurement/remove';
 
@@ -14,9 +16,21 @@ export const initialState = {
  	 */
 	statistic:{ length:0, area:0 },
 	/**
+	 * @type {String}
+	 */
+	mode: null,	
+	/**
+	 * @type EventLike
+	 */	
+	finish:null,
+	/**
 	 * @type EventLike
 	 */
-	reset:null
+	reset:null,
+	/**
+	 * @type EventLike
+	 */
+	remove:null
 };
 
 export const measurementReducer = (state = initialState, action) => {
@@ -36,6 +50,22 @@ export const measurementReducer = (state = initialState, action) => {
 			return {
 				...state,
 				statistic: payload
+
+			};
+		}
+		case MODE_CHANGED: {
+
+			return {
+				...state,
+				mode: payload
+
+			};
+		}
+		case FINISH_REQUESTED: {
+
+			return {
+				...state,
+				finish: payload
 
 			};
 		}

--- a/src/modules/toolbox/components/measureToolContent/MeasureToolContent.js
+++ b/src/modules/toolbox/components/measureToolContent/MeasureToolContent.js
@@ -16,8 +16,9 @@ export class MeasureToolContent extends BaElement {
 	constructor() {
 		super();
 
-		const { TranslationService: translationService, UnitsService: unitsService } = $injector.inject('TranslationService', 'UnitsService');
+		const { TranslationService: translationService, EnvironmentService: environmentService, UnitsService: unitsService } = $injector.inject('TranslationService', 'EnvironmentService', 'UnitsService');
 		this._translationService = translationService;
+		this._environmentService = environmentService;
 		this._unitsService = unitsService;
 		this._tool = {
 			name: 'measure',
@@ -109,7 +110,7 @@ export class MeasureToolContent extends BaElement {
 		};
 		// Start-New-Button
 		const startNewCompliantModes = ['draw', 'modify', 'select'];
-		const finishAllowed = statistic.area > 0 && mode === 'draw';
+		const finishAllowed = (this._environmentService.isTouch() ? statistic.length > 0 : statistic.area > 0) && mode === 'draw';
 		if (startNewCompliantModes.includes(mode) ) {
 			let id = 'startnew';
 			let title = translate('toolbox_measureTool_start_new');

--- a/src/modules/toolbox/components/measureToolContent/MeasureToolContent.js
+++ b/src/modules/toolbox/components/measureToolContent/MeasureToolContent.js
@@ -126,10 +126,10 @@ export class MeasureToolContent extends BaElement {
 		}
 
 		// Remove-Button
-		const removeAllowed = mode === 'draw' ? statistic.area > 0 : statistic.length > 0;
+		const removeAllowed = mode === 'draw' ? (this._environmentService.isTouch() ? statistic.length > 0 : statistic.area > 0 ) : statistic.length > 0 ;
 		if (removeAllowed) {
 			const id = 'remove';
-			const title = translate('toolbox_drawTool_delete');
+			const title = mode === 'draw' ? translate('toolbox_measureTool_delete_point') : translate('toolbox_measureTool_delete_measure');
 			const onClick =  () => remove();
 			buttons.push(getButton(id, title, onClick));
 		}

--- a/src/modules/toolbox/components/measureToolContent/MeasureToolContent.js
+++ b/src/modules/toolbox/components/measureToolContent/MeasureToolContent.js
@@ -4,7 +4,7 @@ import { classMap } from 'lit-html/directives/class-map.js';
 import { BaElement } from '../../../BaElement';
 import { $injector } from '../../../../injection';
 import clipboardIcon from './assets/clipboard.svg';
-import { remove, reset } from '../../../map/store/measurement.action';
+import { finish, remove, reset } from '../../../map/store/measurement.action';
 
 import css from './measureToolContent.css';
 /**
@@ -30,25 +30,11 @@ export class MeasureToolContent extends BaElement {
 
 	createView(state) {
 		const translate = (key) => this._translationService.translate(key);
-		const { active, statistic } = state;
-		this._isFirstMeasurement = this._isFirstMeasurement ? (statistic.length === 0 ? true : false) : false;
+		const { active, statistic, mode } = state;
 		this._tool.active = active;
 		const areaClasses = { 'is-area': statistic.area > 0 };
-		const measurementClasses = { 'is-first': this._isFirstMeasurement };
-		const removeAllowed = statistic.length > 0;
-		const removeClasses = {
-			'is-remove': removeAllowed,
-			'is-not-remove': !removeAllowed
-		};
-
-		const onClickReset = () => {
-			reset();
-		};
-
-		const onClickRemove = () => {
-			remove();
-		};
-
+	
+		const buttons = this._getButtons(state);
 		const buildPackage = (measurement) => {
 			const splitted = measurement.split(' ');
 			if (splitted.length === 2) {
@@ -66,7 +52,7 @@ export class MeasureToolContent extends BaElement {
                 	<div class="tool-container__header">  
 						<span class='tool-container__header-text'>                
 							${translate('toolbox_measureTool_header')}                   
-						</span>   						             
+						</span>   						             <span>(${mode})</span>
                 	</div>      
 					<div class="tool-container__text">				
 					<div class='tool-container__text-item'>
@@ -99,22 +85,56 @@ export class MeasureToolContent extends BaElement {
 					</div>
 				</div>				
 				<div class="tool-container__buttons-secondary">                         						 
-					<button id=startnew class="tool-container__button ${classMap(measurementClasses)}" 
-					title=${translate('toolbox_measureTool_start_new')}
-						@click=${onClickReset}>								
-							${translate('toolbox_measureTool_start_new')}
-						</button>				
-					<button id=remove class="tool-container__button ${classMap(removeClasses)}"
-						title=${translate('toolbox_drawTool_delete')}
-						@click=${onClickRemove}>
-						${translate('toolbox_drawTool_delete')}
-						</button>
+					${buttons}
 					</div>                
             	</div>	  
             </div>	  
      
         `;
 
+	}
+
+	_getButtons(state) {
+		const buttons = [];
+		const translate = (key) => this._translationService.translate(key);
+		const { active, statistic, mode } = state;
+		this._isFirstMeasurement = this._isFirstMeasurement ? (statistic.length === 0 ? true : false) : false;
+		this._tool.active = active;
+	
+		const getButton = (id, title, onClick) => {
+			return html`<button id=${id} 
+								class="tool-container__button" 
+								title=${title}
+								@click=${onClick}>${title}</button>`;
+		};
+		// Start-New-Button
+		const startNewCompliantModes = ['draw', 'modify', 'select'];
+		const finishAllowed = statistic.area > 0 && mode === 'draw';
+		if (startNewCompliantModes.includes(mode) ) {
+			let id = 'startnew';
+			let title = translate('toolbox_measureTool_start_new');
+			let onClick =  () => reset();
+			// alternate Finish-Button			
+			if (finishAllowed) {
+				id = 'finish';
+				title = translate('toolbox_drawTool_finish');
+				onClick =  () => finish();				
+			}
+			
+			buttons.push(getButton(id, title, onClick));
+		}
+
+		// Remove-Button
+		const removeAllowed = statistic.length > 0;
+		if (removeAllowed) {
+			const id = 'remove';
+			const title = translate('toolbox_drawTool_delete');
+			const onClick =  () => remove();
+			buttons.push(getButton(id, title, onClick));
+		}
+
+		
+		return buttons;
 	}
 
 	/**

--- a/src/modules/toolbox/components/measureToolContent/MeasureToolContent.js
+++ b/src/modules/toolbox/components/measureToolContent/MeasureToolContent.js
@@ -125,7 +125,7 @@ export class MeasureToolContent extends BaElement {
 		}
 
 		// Remove-Button
-		const removeAllowed = statistic.length > 0;
+		const removeAllowed = mode === 'draw' ? statistic.area > 0 : statistic.length > 0;
 		if (removeAllowed) {
 			const id = 'remove';
 			const title = translate('toolbox_drawTool_delete');

--- a/src/modules/toolbox/i18n/toolbox.provider.js
+++ b/src/modules/toolbox/i18n/toolbox.provider.js
@@ -18,6 +18,7 @@ export const provide = (lang) => {
 				toolbox_measureTool_stats_length: 'Length',
 				toolbox_measureTool_stats_area: 'Area',
 				toolbox_measureTool_start_new: 'Start New',
+				toolbox_drawTool_finish:'Finish'
 			};
 
 		case 'de':
@@ -37,6 +38,7 @@ export const provide = (lang) => {
 				toolbox_measureTool_stats_length: 'Länge',
 				toolbox_measureTool_stats_area: 'Fläche',
 				toolbox_measureTool_start_new: 'Neue Messung',
+				toolbox_drawTool_finish:'Fertig'
 			};
 
 		default:

--- a/src/modules/toolbox/i18n/toolbox.provider.js
+++ b/src/modules/toolbox/i18n/toolbox.provider.js
@@ -9,7 +9,6 @@ export const provide = (lang) => {
 				toolbox_drawTool_text: 'Text',
 				toolbox_drawTool_line: 'Line',
 				toolbox_drawTool_polygon: 'Polygon',
-				toolbox_drawTool_delete: 'Delete',
 				toolbox_drawTool_share: 'Share',
 				toolbox_drawTool_save: 'Save',
 				toolbox_drawTool_info: 'Your drawing will be automatically saved for one year. By using this service you agree to the terms of use.',
@@ -18,6 +17,8 @@ export const provide = (lang) => {
 				toolbox_measureTool_stats_length: 'Length',
 				toolbox_measureTool_stats_area: 'Area',
 				toolbox_measureTool_start_new: 'Start New',
+				toolbox_measureTool_delete_point:'Delete last point',
+				toolbox_measureTool_delete_measure:'Delete measure',
 				toolbox_drawTool_finish:'Finish'
 			};
 
@@ -29,7 +30,6 @@ export const provide = (lang) => {
 				toolbox_drawTool_text: 'Text',
 				toolbox_drawTool_line: 'Linie',
 				toolbox_drawTool_polygon: 'Polygon',
-				toolbox_drawTool_delete: 'Löschen',
 				toolbox_drawTool_share: 'Teilen',
 				toolbox_drawTool_save: 'Speichern',
 				toolbox_drawTool_info: 'Ihre Zeichnung wird automatisch für ein Jahr gespeichert. Durch die Nutzung dieses Dienstes stimmen Sie den Nutzungsbedingungen zu.',
@@ -38,6 +38,8 @@ export const provide = (lang) => {
 				toolbox_measureTool_stats_length: 'Länge',
 				toolbox_measureTool_stats_area: 'Fläche',
 				toolbox_measureTool_start_new: 'Neue Messung',
+				toolbox_measureTool_delete_point: 'letzten Punkt löschen',
+				toolbox_measureTool_delete_measure: 'Messung löschen',
 				toolbox_drawTool_finish:'Fertig'
 			};
 

--- a/test/modules/map/components/olMap/handler/measure/OlMeasurementHandler.test.js
+++ b/test/modules/map/components/olMap/handler/measure/OlMeasurementHandler.test.js
@@ -234,7 +234,7 @@ describe('OlMeasurementHandler', () => {
 				const classUnderTest = new OlMeasurementHandler();
 				const map = setupMap();
 				map.addInteraction = jasmine.createSpy();
-				const removeSpy = spyOn(classUnderTest, '_removeSelectedFeatures').and.callThrough();
+				const removeSpy = spyOn(classUnderTest, '_remove').and.callThrough();
 
 				classUnderTest.activate(map);
 				remove();
@@ -585,9 +585,9 @@ describe('OlMeasurementHandler', () => {
 
 		it('removes currently drawing two-point feature if keypressed', () => {
 			const classUnderTest = new OlMeasurementHandler();
-			classUnderTest._reset = jasmine.createSpy().and.callThrough();
+			const startNewSpy = spyOn(classUnderTest, '_startNew');
 			const map = setupMap();
-			const geometry = new Polygon([[[0, 0], [500, 0], [0, 0]]]);
+			const geometry = new Polygon([[[0, 0], [0, 0]]]);
 			const feature = new Feature({ geometry: geometry });
 			const deleteKeyCode = 46;
 
@@ -597,7 +597,7 @@ describe('OlMeasurementHandler', () => {
 			expect(classUnderTest._modify.getActive()).toBeFalse();
 
 			simulateKeyEvent(deleteKeyCode);
-			expect(classUnderTest._reset).toHaveBeenCalled();
+			expect(startNewSpy).toHaveBeenCalled();
 		});
 
 		it('removes drawn feature if keypressed', () => {

--- a/test/modules/map/components/olMap/handler/measure/OlMeasurementHandler.test.js
+++ b/test/modules/map/components/olMap/handler/measure/OlMeasurementHandler.test.js
@@ -264,7 +264,7 @@ describe('OlMeasurementHandler', () => {
 			
 			spyOn(map, 'getLayers').and.returnValue({ getArray:() => [{ get:() => 'lastId' }] });
 			spyOn(classUnderTest._overlayManager, 'createDistanceOverlay').and.callFake(() => {});
-			spyOn(classUnderTest._overlayManager, 'createAreaOverlay').and.callFake(() => {});
+			spyOn(classUnderTest._overlayManager, 'createOrRemoveAreaOverlay').and.callFake(() => {});
 			spyOn(classUnderTest._overlayManager, 'createPartitionOverlays').and.callFake(() => {});
 			classUnderTest._lastMeasurementId = 'lastId';
 			const spy = spyOn(geoResourceServiceMock, 'byId').and.returnValue(vectorGeoResource);
@@ -307,7 +307,7 @@ describe('OlMeasurementHandler', () => {
 			
 			spyOn(map, 'getLayers').and.returnValue({ getArray:() => [{ get:() => 'lastId' }] });
 			spyOn(classUnderTest._overlayManager, 'createDistanceOverlay').and.callFake(() => {});
-			spyOn(classUnderTest._overlayManager, 'createAreaOverlay').and.callFake(() => {});
+			spyOn(classUnderTest._overlayManager, 'createOrRemoveAreaOverlay').and.callFake(() => {});
 			spyOn(classUnderTest._overlayManager, 'createPartitionOverlays').and.callFake(() => {});
 			spyOn(geoResourceServiceMock, 'byId').and.returnValue(vectorGeoResource);
 			classUnderTest._lastMeasurementId = 'lastId';			

--- a/test/modules/map/components/olMap/handler/measure/OverlayManager.test.js
+++ b/test/modules/map/components/olMap/handler/measure/OverlayManager.test.js
@@ -221,6 +221,32 @@ describe('OverlayManager', () => {
 		expect(feature.get('partitions').length).toBe(1);
 	});
 
+	it('removes area overlay after change from polygon to line', () => {
+		const addOverlaySpy = jasmine.createSpy();
+		const removeOverlaySpy = jasmine.createSpy();
+		const mapMock = { 
+			addOverlay: addOverlaySpy,
+			removeOverlay:removeOverlaySpy,
+			getInteractions() {
+				return { getArray:() => [] };
+			},
+			getView() {
+				return { getResolution:() => 50 };
+			} };
+
+		const classUnderTest = new OverlayManager(mapMock);
+		const geometry =  new Polygon([[[0, 0], [5000, 0], [5500, 5500], [0, 5000]]]);
+		const feature = new Feature({ geometry: geometry });
+		
+		classUnderTest.createOrRemoveAreaOverlay(feature);
+		expect(feature.get('area')).toBeTruthy();
+
+		// change to Line
+		geometry.setCoordinates([[0, 0], [12345, 0]]);
+		classUnderTest.createOrRemoveAreaOverlay(feature);
+
+		expect(feature.get('area')).toBeFalsy();
+	});
 
 	it('writes manual overlay-position to the related feature', () => {
 		const mapStub = {};

--- a/test/modules/toolbox/components/measureToolContent/MeasureToolContent.test.js
+++ b/test/modules/toolbox/components/measureToolContent/MeasureToolContent.test.js
@@ -55,17 +55,14 @@ describe('MeasureToolContent', () => {
 
 		it('builds the tool', async () => {
 			const element = await setup();
-
 			expect(element._tool).toBeTruthy();
-			// expect(element.shadowRoot.querySelector('.tool-container__buttons')).toBeTruthy();
-			expect(element.shadowRoot.querySelectorAll('#remove').length).toBe(1);
-			expect(element.shadowRoot.querySelectorAll('#startnew').length).toBe(1);
 		});
 
 		it('resets the measurement', async () => {
 			const state = {
 				measurement: {
 					active: true,
+					mode:'draw',
 					statistic: { length: 42, area: 0 },
 					reset: null,
 					remove: null,

--- a/test/modules/toolbox/components/measureToolContent/MeasureToolContent.test.js
+++ b/test/modules/toolbox/components/measureToolContent/MeasureToolContent.test.js
@@ -44,9 +44,10 @@ describe('MeasureToolContent', () => {
 		$injector
 			.registerSingleton('EnvironmentService', {
 				isEmbedded: () => embed,
-				getWindow: () => windowMock
-			})
-			.registerSingleton('TranslationService', { translate: (key) => key })
+				getWindow: () => windowMock,
+				isTouch:() => false
+
+			}).registerSingleton('TranslationService', { translate: (key) => key })
 			.register('UnitsService', MockClass);
 		return TestUtils.render(MeasureToolContent.tag);
 	};

--- a/test/modules/toolbox/components/measureToolContent/MeasureToolContent.test.js
+++ b/test/modules/toolbox/components/measureToolContent/MeasureToolContent.test.js
@@ -58,6 +58,43 @@ describe('MeasureToolContent', () => {
 			expect(element._tool).toBeTruthy();
 		});
 
+		it('displays the finish-button', async () => {
+			const state = {
+				measurement: {
+					active: true,
+					mode:'draw',
+					statistic: { length: 42, area: 21 },
+					reset: null,
+					remove: null,
+					finish:null
+				}
+			};
+			const element = await setup(state);			
+
+			expect(element._tool).toBeTruthy();
+			expect(element.shadowRoot.querySelector('#finish')).toBeTruthy();						
+		});
+
+		it('finishes the measurement', async () => {
+			const state = {
+				measurement: {
+					active: true,
+					mode:'draw',
+					statistic: { length: 42, area: 21 },
+					reset: null,
+					remove: null,
+					finish:null
+				}
+			};
+			const element = await setup(state);
+			const finishButton = element.shadowRoot.querySelector('#finish');
+
+			finishButton.click();
+
+			expect(store.getState().measurement.finish).toBeInstanceOf(EventLike);
+		});
+
+
 		it('resets the measurement', async () => {
 			const state = {
 				measurement: {

--- a/test/modules/toolbox/components/toolContainer/ToolContainer.test.js
+++ b/test/modules/toolbox/components/toolContainer/ToolContainer.test.js
@@ -48,7 +48,8 @@ describe('ToolContainer', () => {
 		$injector
 			.registerSingleton('EnvironmentService', {
 				isEmbedded: () => embed,
-				getWindow: () => windowMock
+				getWindow: () => windowMock,
+				isTouch:() => false
 			})			
 			.registerSingleton('TranslationService', { translate: (key) => key })
 			.registerSingleton('SearchResultProviderService', { getGeoresourceSearchResultProvider: () => { } })

--- a/test/modules/toolbox/i18n/toolbox.provider.test.js
+++ b/test/modules/toolbox/i18n/toolbox.provider.test.js
@@ -12,7 +12,6 @@ describe('i18n for menu module', () => {
 		expect(map.toolbox_drawTool_text).toBe('Text');
 		expect(map.toolbox_drawTool_line).toBe('Linie');
 		expect(map.toolbox_drawTool_polygon).toBe('Polygon');
-		expect(map.toolbox_drawTool_delete).toBe('Löschen');
 		expect(map.toolbox_drawTool_share).toBe('Teilen');
 		expect(map.toolbox_drawTool_save).toBe('Speichern');
 		expect(map.toolbox_drawTool_info).toBe('Ihre Zeichnung wird automatisch für ein Jahr gespeichert. Durch die Nutzung dieses Dienstes stimmen Sie den Nutzungsbedingungen zu.');
@@ -21,6 +20,8 @@ describe('i18n for menu module', () => {
 		expect(map.toolbox_measureTool_stats_length).toBe('Länge');
 		expect(map.toolbox_measureTool_stats_area).toBe('Fläche');
 		expect(map.toolbox_measureTool_start_new).toBe('Neue Messung');
+		expect(map.toolbox_measureTool_delete_point).toBe('letzten Punkt löschen');
+		expect(map.toolbox_measureTool_delete_measure).toBe('Messung löschen');
 		expect(map.toolbox_drawTool_finish).toBe('Fertig');
 	});
 
@@ -32,8 +33,7 @@ describe('i18n for menu module', () => {
 		expect(map.toolbox_drawTool_symbol).toBe('Symbol');
 		expect(map.toolbox_drawTool_text).toBe('Text');
 		expect(map.toolbox_drawTool_line).toBe('Line');
-		expect(map.toolbox_drawTool_polygon).toBe('Polygon');
-		expect(map.toolbox_drawTool_delete).toBe('Delete');
+		expect(map.toolbox_drawTool_polygon).toBe('Polygon');		
 		expect(map.toolbox_drawTool_share).toBe('Share');
 		expect(map.toolbox_drawTool_save).toBe('Save');
 		expect(map.toolbox_drawTool_info).toBe('Your drawing will be automatically saved for one year. By using this service you agree to the terms of use.');
@@ -42,11 +42,13 @@ describe('i18n for menu module', () => {
 		expect(map.toolbox_measureTool_stats_length).toBe('Length');
 		expect(map.toolbox_measureTool_stats_area).toBe('Area');
 		expect(map.toolbox_measureTool_start_new).toBe('Start New');
+		expect(map.toolbox_measureTool_delete_point).toBe('Delete last point');
+		expect(map.toolbox_measureTool_delete_measure).toBe('Delete measure');
 		expect(map.toolbox_drawTool_finish).toBe('Finish');
 	});
 
 	it('have the expected amount of translations', () => {
-		const expectedSize = 15;
+		const expectedSize = 16;
 		const deMap = provide('de');
 		const enMap = provide('en');
 

--- a/test/modules/toolbox/i18n/toolbox.provider.test.js
+++ b/test/modules/toolbox/i18n/toolbox.provider.test.js
@@ -21,6 +21,7 @@ describe('i18n for menu module', () => {
 		expect(map.toolbox_measureTool_stats_length).toBe('Länge');
 		expect(map.toolbox_measureTool_stats_area).toBe('Fläche');
 		expect(map.toolbox_measureTool_start_new).toBe('Neue Messung');
+		expect(map.toolbox_drawTool_finish).toBe('Fertig');
 	});
 
 	it('provides translation for en', () => {
@@ -41,10 +42,11 @@ describe('i18n for menu module', () => {
 		expect(map.toolbox_measureTool_stats_length).toBe('Length');
 		expect(map.toolbox_measureTool_stats_area).toBe('Area');
 		expect(map.toolbox_measureTool_start_new).toBe('Start New');
+		expect(map.toolbox_drawTool_finish).toBe('Finish');
 	});
 
 	it('have the expected amount of translations', () => {
-		const expectedSize = 14;
+		const expectedSize = 15;
 		const deMap = provide('de');
 		const enMap = provide('en');
 


### PR DESCRIPTION
update states for measurement in the store and justify interactions related to measurements

- adding `mode` to `store/measurement`
- `isTouch` is taking into account for MeasurementToolContent and the displayed Buttons