### PR TITLE
Improve BaElement's observe method

### DIFF
--- a/src/modules/map/components/olMap/OlMap.js
+++ b/src/modules/map/components/olMap/OlMap.js
@@ -141,6 +141,10 @@ export class OlMap extends BaElement {
 			const maxZoom = fitRequest.payload.options.maxZoom || this._view.getMaxZoom();
 			this._view.fit(fitRequest.payload.extent, { maxZoom: maxZoom, callback: onAfterFit });
 		});
+		//sync layers
+		this.observe('layers', () => this._syncLayers());
+		//sync the view
+		this.observe(['zoom', 'center', 'rotation', 'fitRequest'], () => this._syncView());
 	}
 
 	/**
@@ -164,8 +168,7 @@ export class OlMap extends BaElement {
 	 * @override
 	 */
 	onStateChanged() {
-		this._syncOverlayLayer();
-		this._syncView();
+		//nothing to do here
 	}
 
 	_getOlLayerById(id) {
@@ -194,7 +197,7 @@ export class OlMap extends BaElement {
 		}
 	}
 
-	_syncOverlayLayer() {
+	_syncLayers() {
 		const { layers } = this.getState();
 
 		const updatedIds = layers.map(layer => layer.geoResourceId);

--- a/test/modules/BaElement.test.js
+++ b/test/modules/BaElement.test.js
@@ -273,30 +273,58 @@ describe('BaElement', () => {
 			expect(element.shadowRoot.innerHTML.includes('42')).toBeTrue();
 			expect(onStateChangedSpy).toHaveBeenCalledWith(jasmine.any(Object));
 		});
-
-		it('calls registered observer', async () => {
+	});
+	
+	describe('observe', () => {
+		
+		it('registers observers', async () => {
 			const element = await TestUtils.render(BaElementImpl.tag);
 			const elementStateIndexCallback = jasmine.createSpy();
 			const someUnknownFieldCallback = jasmine.createSpy();
 			const someWhatNullFieldCallback = jasmine.createSpy();
-			const warnSpy = spyOn(console, 'warn');
+			const errorSpy = spyOn(console, 'error');
+			//let's register the elementStateIndexCallback three times
 			element.observe('elementStateIndex', elementStateIndexCallback);
+			element.observe(['elementStateIndex', 'elementStateIndex'], elementStateIndexCallback);
 			element.observe('someUnknowField', someUnknownFieldCallback);
 			element.observe('someWhatNull', someWhatNullFieldCallback);
 
-
+			//change state after registration
 			store.dispatch({
 				type: INDEX_CHANGED,
 				payload: 42
 			});
 
-			expect(elementStateIndexCallback).toHaveBeenCalledOnceWith(42);
-			expect(warnSpy).toHaveBeenCalledOnceWith('\'someUnknowField\' is not a field in the state of this BaElement');
+			expect(elementStateIndexCallback).toHaveBeenCalledWith(42);
+			expect(elementStateIndexCallback).toHaveBeenCalledTimes(3);
 			expect(someWhatNullFieldCallback).not.toHaveBeenCalled();
-			expect(warnSpy).not.toHaveBeenCalledOnceWith('\'someWhatNull\' is not a field in the state of this BaElement');
+			expect(someUnknownFieldCallback).not.toHaveBeenCalled();
+			expect(errorSpy).toHaveBeenCalledOnceWith('Could not register observer --> \'someUnknowField\' is not a field in the state of BaElementImpl');
 		});
-	});
 
+		it('registers observers and calls the callbacks immediately', async () => {
+			const element = await TestUtils.render(BaElementImpl.tag);
+			const elementStateIndexCallback = jasmine.createSpy();
+			const someUnknownFieldCallback = jasmine.createSpy();
+			const someWhatNullFieldCallback = jasmine.createSpy();
+			const errorSpy = spyOn(console, 'error');
+			
+			//change state before registration
+			store.dispatch({
+				type: INDEX_CHANGED,
+				payload: 42
+			});
+			element.observe('elementStateIndex', elementStateIndexCallback, true);
+			element.observe('someUnknowField', someUnknownFieldCallback, true);
+			element.observe('someWhatNull', someWhatNullFieldCallback, true);
+
+			expect(elementStateIndexCallback).toHaveBeenCalledOnceWith(42);
+			expect(someWhatNullFieldCallback).toHaveBeenCalledWith(null);
+			expect(someUnknownFieldCallback).not.toHaveBeenCalled();
+			expect(errorSpy).toHaveBeenCalledOnceWith('Could not register observer --> \'someUnknowField\' is not a field in the state of BaElementImpl');
+		});
+		
+	});
 	describe('default css', () => {
 
 		it('checks if a template result contains content', async () => {

--- a/test/modules/map/components/olMap/OlMap.test.js
+++ b/test/modules/map/components/olMap/OlMap.test.js
@@ -79,6 +79,7 @@ describe('OlMap', () => {
 				zoom: initialZoomLevel,
 				center: initialCenter,
 				rotation: initialRotationValue,
+				fitRequest: null
 			},
 		};
 		const combinedState = {


### PR DESCRIPTION
BaElement:
- allow multiple fields name
- add the possibility for an  immediate callback call after registration

OlMap:
- use the changes to synchronize view and layers separately