### PR TITLE
Avoid flickering of the rotation icon button

### DIFF
--- a/src/modules/map/components/olMap/OlMap.js
+++ b/src/modules/map/components/olMap/OlMap.js
@@ -24,13 +24,15 @@ export class OlMap extends BaElement {
 	constructor() {
 		super();
 		const {
+			MapService: mapService,
 			GeoResourceService: georesourceService,
 			LayerService: layerService,
 			EnvironmentService: environmentService,
 			OlMeasurementHandler: measurementHandler,
 			OlGeolocationHandler: geolocationHandler
-		} = $injector.inject('GeoResourceService', 'LayerService', 'EnvironmentService', 'OlMeasurementHandler', 'OlGeolocationHandler');
+		} = $injector.inject('MapService', 'GeoResourceService', 'LayerService', 'EnvironmentService', 'OlMeasurementHandler', 'OlGeolocationHandler');
 
+		this._mapService = mapService;
 		this._geoResourceService = georesourceService;
 		this._layerService = layerService;
 		this._environmentService = environmentService;
@@ -80,7 +82,7 @@ export class OlMap extends BaElement {
 				pinchRotate: false,
 				
 			}).extend([new PinchRotate({
-				threshold: .5
+				threshold: this._mapService.getMinimalRotation()
 			})])
 		});
 

--- a/src/modules/map/components/rotationButton/RotationButton.js
+++ b/src/modules/map/components/rotationButton/RotationButton.js
@@ -14,8 +14,9 @@ export class RotationButton extends BaElement {
 
 	constructor() {
 		super();
-		const { TranslationService } = $injector.inject('TranslationService');
-		this._translationService = TranslationService;
+		const { MapService: mapService, TranslationService: translationService } = $injector.inject('MapService', 'TranslationService');
+		this._mapService = mapService;
+		this._translationService = translationService;
 		this._timeoutId = null;
 	}
 
@@ -29,7 +30,7 @@ export class RotationButton extends BaElement {
 		 * In order to avoid a flickering icon, we delay hiding the icon.
 		 */
 		this.observe('liveRotation', liveRotation => {
-			if (Math.abs(liveRotation) >= RotationButton.ROTATION_THRESHOLD) {
+			if (Math.abs(liveRotation) >= this._mapService.getMinimalRotation()) {
 				if (this._timeoutId) {
 					clearTimeout(this._timeoutId);
 					this._timeoutId = null;
@@ -86,10 +87,6 @@ export class RotationButton extends BaElement {
 
 	static get tag() {
 		return 'ba-rotation-button';
-	}
-
-	static get ROTATION_THRESHOLD() {
-		return .05;
 	}
 
 	static get HIDE_BUTTON_DELAY_MS() {

--- a/src/services/MapService.js
+++ b/src/services/MapService.js
@@ -10,7 +10,7 @@ import { getBvvMapDefinitions } from './provider/mapDefinitions.provider';
 
 
 /**
-* Service for managing map releated meta data
+* Service for managing map related meta data.
 * @class
 */
 export class MapService {
@@ -73,6 +73,14 @@ export class MapService {
 				return this._coordinateService.toLonLatExtent(this._definitions.defaultExtent);
 		}
 		throw new Error('Unsupported SRID ' + srid);
+	}
+
+	/**
+	 * Returns the minimal angle in radians when rotation of the map should be accepted and applied.
+	 * @returns threshold value for rotating the map in radians.
+	 */
+	getMinimalRotation() {
+		return .05;
 	}
 
 }

--- a/test/modules/map/components/olMap/OlMap.test.js
+++ b/test/modules/map/components/olMap/OlMap.test.js
@@ -26,6 +26,12 @@ describe('OlMap', () => {
 	const initialZoomLevel = 10;
 	const initialRotationValue = .5;
 
+	const mapServiceStub = {
+		getMinimalRotation() {
+			return .05; 
+		}
+	};
+
 	const geoResourceServiceStub = {
 		byId(id) {
 			switch (id) {
@@ -40,9 +46,6 @@ describe('OlMap', () => {
 
 	const layerServiceMock = {
 		toOlLayer() { }
-	};
-
-	const mapServiceMock = {
 	};
 
 	const environmentServiceMock = {
@@ -97,8 +100,8 @@ describe('OlMap', () => {
 
 
 		$injector
+			.registerSingleton('MapService', mapServiceStub)
 			.registerSingleton('GeoResourceService', geoResourceServiceStub)
-			.registerSingleton('MapService', mapServiceMock)
 			.registerSingleton('EnvironmentService', environmentServiceMock)
 			.registerSingleton('OlMeasurementHandler', measurementLayerHandlerMock)
 			.registerSingleton('OlGeolocationHandler', geolocationLayerHandlerMock)

--- a/test/modules/map/components/rotationButton/RotationButton.test.js
+++ b/test/modules/map/components/rotationButton/RotationButton.test.js
@@ -11,6 +11,11 @@ describe('GeolocationButton', () => {
 	const defaultState = {
 		liveRotation: 0
 	};
+	const mapServiceStub = {
+		getMinimalRotation() {
+			return .05; 
+		}
+	};
 
 	const setup = async (positionState = defaultState) => {
 
@@ -20,6 +25,7 @@ describe('GeolocationButton', () => {
 
 		store = TestUtils.setupStoreAndDi(state, { position: positionReducer });
 		$injector
+			.registerSingleton('MapService', mapServiceStub)
 			.registerSingleton('TranslationService', { translate: (key) => key });
 
 
@@ -30,7 +36,6 @@ describe('GeolocationButton', () => {
 
 		it('defines constant values', async () => {
 
-			expect(RotationButton.ROTATION_THRESHOLD).toBe(.05);
 			expect(RotationButton.HIDE_BUTTON_DELAY_MS).toBe(1000);
 		});
 	});
@@ -40,7 +45,7 @@ describe('GeolocationButton', () => {
 		describe('liveRotation < threshold value', () => {
 
 			it('renders a geolocation button', async () => {
-				const liveRotationValue = RotationButton.ROTATION_THRESHOLD - .01;
+				const liveRotationValue = mapServiceStub.getMinimalRotation() - .01;
 				const element = await setup({ liveRotation: liveRotationValue });
 
 				expect(element.shadowRoot.children.length).toBe(0);
@@ -82,7 +87,7 @@ describe('GeolocationButton', () => {
 		});
 
 		it('hides the button when rotation < threshold', async () => {
-			const element = await setup({ liveRotation: RotationButton.ROTATION_THRESHOLD - .01 });
+			const element = await setup({ liveRotation:  mapServiceStub.getMinimalRotation() - .01 });
 
 			changeLiveRotation();
 

--- a/test/modules/map/components/rotationButton/RotationButton.test.js
+++ b/test/modules/map/components/rotationButton/RotationButton.test.js
@@ -31,6 +31,7 @@ describe('GeolocationButton', () => {
 		it('defines constant values', async () => {
 
 			expect(RotationButton.ROTATION_THRESHOLD).toBe(.05);
+			expect(RotationButton.HIDE_BUTTON_DELAY_MS).toBe(1000);
 		});
 	});
 
@@ -62,6 +63,14 @@ describe('GeolocationButton', () => {
 
 	describe('when rotation changes', () => {
 
+		beforeEach(async () => {
+			jasmine.clock().install();
+		});
+	
+		afterEach(function () {
+			jasmine.clock().uninstall();
+		});
+
 		it('rotates the button', async () => {
 			let liveRotationValue = .5;
 			const element = await setup({ liveRotation: liveRotationValue });
@@ -76,6 +85,22 @@ describe('GeolocationButton', () => {
 			const element = await setup({ liveRotation: RotationButton.ROTATION_THRESHOLD - .01 });
 
 			changeLiveRotation();
+
+			expect(element.shadowRoot.children.length).toBe(0);
+		});
+
+		it('avoids flickering', async () => {
+			const liveRotationValue = .5;
+			const element = await setup({ liveRotation: liveRotationValue });
+			
+			expect(element.shadowRoot.children.length).not.toBe(0);
+
+			changeLiveRotation();
+			jasmine.clock().tick(200);
+			changeLiveRotation(liveRotationValue);
+			jasmine.clock().tick(200);
+			changeLiveRotation();
+			jasmine.clock().tick(RotationButton.HIDE_BUTTON_DELAY_MS + 100);
 
 			expect(element.shadowRoot.children.length).toBe(0);
 		});

--- a/test/service/MapService.test.js
+++ b/test/service/MapService.test.js
@@ -83,5 +83,11 @@ describe('MapService', () => {
 
 		expect(instanceUnderTest.getDefaultGeodeticSrid()).toBe(9999);
 	});
+
+	it('provides minimal angle for rotation', () => {
+		const instanceUnderTest = setup();
+
+		expect(instanceUnderTest.getMinimalRotation()).toBe(.05);
+	});
 });
 


### PR DESCRIPTION
- avoid flickering of the icon button when rotating the map
- move the definition of the rotation threshold value to MapService