### PR TITLE
fix test expectations in LayerManager.test

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -5,7 +5,7 @@ process.env.FIREFOX_BIN = playwright.firefox.executablePath();
 process.env.CHROME_BIN = playwright.chromium.executablePath();
 process.env.WEBKIT_HEADLESS_BIN = playwright.webkit.executablePath();
 
-const browsers = process.env.KARMA_BROWSERS ? process.env.KARMA_BROWSERS.split(',') : ['ChromeHeadless', 'FirefoxHeadless'];
+const browsers = process.env.KARMA_BROWSERS ? process.env.KARMA_BROWSERS.split(',') : ['ChromeHeadless', 'FirefoxHeadless', 'WebkitHeadless'];
 
 module.exports = function (config) {
 	config.set({

--- a/test/modules/map/components/layerManager/LayerManager.test.js
+++ b/test/modules/map/components/layerManager/LayerManager.test.js
@@ -149,9 +149,9 @@ describe('LayerManager', () => {
 	describe('when layer items dragged', () => {
 		let element;
 		beforeEach(async () => {
-			const layer0 = { ...defaultLayerProperties, id: 'id0', label: '', visible: true, zIndex: 0 };
-			const layer1 = { ...defaultLayerProperties, id: 'id1', label: '', visible: true, zIndex: 1 };
-			const layer2 = { ...defaultLayerProperties, id: 'id2', label: '', visible: true, zIndex: 2 };
+			const layer0 = { ...defaultLayerProperties, id: 'id0', label: 'Label 0', visible: true, zIndex: 0 };
+			const layer1 = { ...defaultLayerProperties, id: 'id1', label: 'Label 1', visible: true, zIndex: 1 };
+			const layer2 = { ...defaultLayerProperties, id: 'id2', label: 'Label 2', visible: true, zIndex: 2 };
 			const state = {
 				layers: {
 					active: [layer0, layer1, layer2],
@@ -221,12 +221,11 @@ describe('LayerManager', () => {
 			layerElement.dispatchEvent(dragstartEvt);
 
 			const placeholders = [...element.shadowRoot.querySelectorAll('.placeholder')];
-
+			const activePlaceholders = [...element.shadowRoot.querySelectorAll('.placeholder-active')];
 			expect(placeholders.length).toBe(4);
-			expect(placeholders[0].innerText).toBe('1');
-			expect(placeholders[1].innerText).toBe('1');
-			expect(placeholders[2].innerText).toBe('2');
-			expect(placeholders[3].innerText).toBe('3');
+			expect(activePlaceholders.length).toBe(2);
+			expect(activePlaceholders[0].innerText).toBe('2');
+			expect(activePlaceholders[1].innerText).toBe('3');
 		});
 
 		it('on dragstart should update placeholder-content for dragging 2th layer', () => {
@@ -238,12 +237,11 @@ describe('LayerManager', () => {
 			layerElement.dispatchEvent(dragstartEvt);
 
 			const placeholders = [...element.shadowRoot.querySelectorAll('.placeholder')];
-
+			const activePlaceholders = [...element.shadowRoot.querySelectorAll('.placeholder-active')];
 			expect(placeholders.length).toBe(4);
-			expect(placeholders[0].innerText).toBe('1');
-			expect(placeholders[1].innerText).toBe('2');
-			expect(placeholders[2].innerText).toBe('2');
-			expect(placeholders[3].innerText).toBe('3');
+			expect(activePlaceholders.length).toBe(2);
+			expect(activePlaceholders[0].innerText).toBe('1');
+			expect(activePlaceholders[1].innerText).toBe('3');
 		});
 
 		it('on dragstart should update placeholder-content for dragging 3th layer', () => {
@@ -255,12 +253,11 @@ describe('LayerManager', () => {
 			layerElement.dispatchEvent(dragstartEvt);
 
 			const placeholders = [...element.shadowRoot.querySelectorAll('.placeholder')];
-
+			const activePlaceholders = [...element.shadowRoot.querySelectorAll('.placeholder-active')];
 			expect(placeholders.length).toBe(4);
-			expect(placeholders[0].innerText).toBe('1');
-			expect(placeholders[1].innerText).toBe('2');
-			expect(placeholders[2].innerText).toBe('3');
-			expect(placeholders[3].innerText).toBe('3');
+			expect(activePlaceholders.length).toBe(2);
+			expect(activePlaceholders[0].innerText).toBe('1');
+			expect(activePlaceholders[1].innerText).toBe('2');
 		});
 
 		it('on dragEnter of neighbouring placeholder no style changed', () => {

--- a/test/modules/modal/components/Modal.test.js
+++ b/test/modules/modal/components/Modal.test.js
@@ -38,7 +38,8 @@ describe('Modal', () => {
 
 			expect(element.shadowRoot.querySelector('.modal')).toBeTruthy();
 			expect(element.shadowRoot.querySelector('.modal__title').innerText).toBe('title');
-			expect(element.shadowRoot.querySelector('.modal__content').innerText).toBe('content');
+			//Note: Webkit appends a line break to the 'content' in this case
+			expect(element.shadowRoot.querySelector('.modal__content').innerText).toMatch(/content[\r\n]?/);
 		});
 
 		it('closes the modal', async () => {


### PR DESCRIPTION
fixes #387

it seems that the Playwright Webkit browser (Safari 14, Headless) does not update the invisible elements. Therefore, the tests are more detailed and only the visible elements are tested.