### PR TITLE
Rework ContextMenu 

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -20,6 +20,7 @@
   <ba-theme-provider></ba-theme-provider>
   <ba-notification-panel></ba-notification-panel>
   <ba-modal></ba-modal>
+  <ba-map-context-menu></ba-map-context-menu>
 </body>
 
 </html>

--- a/src/modules/commons/components/icon/Icon.js
+++ b/src/modules/commons/components/icon/Icon.js
@@ -89,9 +89,10 @@ export class Icon extends MvuElement {
 			--size: ${size}em; 
 			background: ${color}; 
 		}`;
-		const anchorClassHover = `.anchor:hover .icon{
+		const anchorClassHover = color_hover ? `.anchor:hover .icon{
+			transform: scale(1.1);
 			background: ${color_hover}; 
-		}`;
+		}` : '';
 		const customIconClass = icon ? `.icon-custom {
 			mask : url("${icon}");
 			-webkit-mask-image : url("${icon}");
@@ -174,7 +175,7 @@ export class Icon extends MvuElement {
 	}
 
 	/**
-	 * @property {string} color_hover=var(--primary-color) - Hover color as Css variable
+	 * @property {string} color_hover=var(--primary-color) - Hover color as Css variable. A value of `null` removes the hover effect.
 	 */
 	set color_hover(value) {
 		this.signal(Update_Color_Hover, value);

--- a/src/modules/commons/components/icon/icon.css
+++ b/src/modules/commons/components/icon/icon.css
@@ -11,11 +11,7 @@
     filter: brightness(0.8) ;
     cursor: not-allowed;   
 }
-  
-.anchor:hover .icon {
-    transform: scale(1.1);
-}
-  
+
 .icon:active {
     transform: scale(1.15);
 }

--- a/src/modules/map/components/contextMenu/MapContextMenu.js
+++ b/src/modules/map/components/contextMenu/MapContextMenu.js
@@ -1,25 +1,42 @@
 import { html, nothing } from 'lit-html';
 import { styleMap } from 'lit-html/directives/style-map.js';
-import { BaElement } from '../../../BaElement';
+import { MvuElement } from '../../../MvuElement';
 import css from './mapContextMenu.css';
 import { $injector } from '../../../../injection';
 import { close as closeContextMenu } from '../../store/mapContextMenu.action';
 import closeIcon from './assets/x-square.svg';
+
+const Update = 'update';
 
 /**
  *
  * @class
  * @author taulinger
  */
-export class MapContextMenu extends BaElement {
+export class MapContextMenu extends MvuElement {
 
 	constructor() {
-		super();
+		super({
+			coordinate: null,
+			content: null
+		});
 		const {
 			TranslationService: translastionService
 		} = $injector.inject('TranslationService');
 
 		this._translationService = translastionService;
+	}
+
+	onInitialize() {
+		this.observe(state => state.mapContextMenu, data => this.signal(Update, data));
+	}
+
+	update(type, data) {
+		const { coordinate, content } = data;
+		switch (type) {
+			case Update:
+				return { coordinate: coordinate, content: content };
+		}
 	}
 
 	_calculateSector(coordinate) {
@@ -47,9 +64,9 @@ export class MapContextMenu extends BaElement {
 	/**
 	 * @override
 	 */
-	createView(state) {
+	createView(model) {
 		const translate = (key) => this._translationService.translate(key);
-		const { coordinate, content } = state;
+		const { coordinate, content } = model;
 
 		if (!coordinate || !content) {
 			return nothing;
@@ -73,14 +90,6 @@ export class MapContextMenu extends BaElement {
 			<div class='header'>${translate('map_contextMenu_header')}<ba-icon class='close' .icon='${closeIcon}' .title=${translate('map_contextMenu_close_button')} .size=${1.5} .color=${'white'} .color_hover=${'white'} @click=${closeContextMenu}></ba-icon></div>
 			${content}
         </div>`;
-	}
-
-	/**
-	 * @override
-	 */
-	extractState(globalState) {
-		const { mapContextMenu: { coordinate, content } } = globalState;
-		return { coordinate, content };
 	}
 
 	static get tag() {

--- a/src/modules/map/components/contextMenu/MapContextMenu.js
+++ b/src/modules/map/components/contextMenu/MapContextMenu.js
@@ -9,6 +9,7 @@ import closeIcon from './assets/x-square.svg';
 /**
  *
  * @class
+ * @author taulinger
  */
 export class MapContextMenu extends BaElement {
 
@@ -48,9 +49,9 @@ export class MapContextMenu extends BaElement {
 	 */
 	createView(state) {
 		const translate = (key) => this._translationService.translate(key);
-		const { coordinate, id } = state;
+		const { coordinate, content } = state;
 
-		if (!coordinate || !id) {
+		if (!coordinate || !content) {
 			return nothing;
 		}
 
@@ -66,11 +67,6 @@ export class MapContextMenu extends BaElement {
 		const style = { '--mouse-x': coordinate[0] + 'px', '--mouse-y': coordinate[1] + yOffset + 'px' };
 		const sectorClass = 'sector-' + sector;
 
-
-		//get content element
-		const content = document.getElementById(id);
-		//extract content element from the dom and render it here
-		//see: https://lit-html.polymer-project.org/guide/template-reference#supported-data-types-for-text-bindings -> Node
 		return html`
         <style>${css}</style>
 		<div class='context-menu ${sectorClass}' style=${styleMap(style)}>
@@ -83,8 +79,8 @@ export class MapContextMenu extends BaElement {
 	 * @override
 	 */
 	extractState(globalState) {
-		const { mapContextMenu: { coordinate, id } } = globalState;
-		return { coordinate, id };
+		const { mapContextMenu: { coordinate, content } } = globalState;
+		return { coordinate, content };
 	}
 
 	static get tag() {

--- a/src/modules/map/components/contextMenu/MapContextMenuContent.js
+++ b/src/modules/map/components/contextMenu/MapContextMenuContent.js
@@ -1,14 +1,34 @@
 import { html, nothing } from 'lit-html';
-import { BaElement } from '../../../BaElement';
 import css from './mapContextMenuContent.css';
 import { $injector } from '../../../../injection';
 import clipboardIcon from './assets/clipboard.svg';
+import { MvuElement } from '../../../MvuElement';
+
+const Update_Coordinate = 'update_coordinate';
+const Update_Altitude = 'update_altitude';
+const Update_Administration = 'update_administration';
 
 
-export class MapContextMenuContent extends BaElement {
+
+/**
+ * @class
+ * @author taulinger
+ * @author thiloSchlemmer
+ * @author alsturm
+ * @author bakir_en
+ */
+export class MapContextMenuContent extends MvuElement {
 
 	constructor() {
-		super();
+		super({
+			coordinate: null,
+			altitude: null,
+			administration: {
+				community: null,
+				district: null
+			}
+		});
+
 		const {
 			MapService: mapService,
 			CoordinateService: coordinateService,
@@ -24,62 +44,71 @@ export class MapContextMenuContent extends BaElement {
 		this._shareService = shareService;
 		this._altitudeService = altitudeService;
 		this._administrationService = administrationService;
+	}
 
-		this._altitude = null;
-		this._community = null;
-		this._district = null;
+	update(type, data, model) {
+		switch (type) {
+			case Update_Coordinate:
+				return { ...model, coordinate: data };
+			case Update_Altitude:
+				return { ...model, altitude: data };
+			case Update_Administration:
+				return { ...model, administration: data };
+		}
 	}
 
 	set coordinate(coordinateInMapSrid) {
-		this._coordinate = coordinateInMapSrid;
-		this._getAltitude();
-		this._getAdministration();
+		this.signal(Update_Coordinate, coordinateInMapSrid);
+		this._getAltitude(coordinateInMapSrid);
+		this._getAdministration(coordinateInMapSrid);
 	}
 
 	/**
 	 * @private
 	 */
-	async _getAltitude() {
+	async _getAltitude(coordinate) {
 		try {
-			this._altitude = await this._altitudeService.getAltitude(this._coordinate) + ' (m)';
+			const altitude = await this._altitudeService.getAltitude(coordinate) + ' (m)';
+			this.signal(Update_Altitude, altitude);
 		}
 		catch (e) {
-			this._altitude = '-';
 			console.warn(e.message);
+			this.signal(Update_Altitude, null);
 		}
-		this.render();
 	}
 
 	/**
 	 * @private
 	 */
-	async _getAdministration() {
+	async _getAdministration(coordinate) {
 		try {
-			const administration = await this._administrationService.getAdministration(this._coordinate);
-			this._community = administration.community;
-			this._district = administration.district;
+			const administration = await this._administrationService.getAdministration(coordinate);
+			this.signal(Update_Administration, administration);
 		}
 		catch (e) {
-			this._community = '-';
-			this._district = '-';
 			console.warn(e.message);
+			this.signal(Update_Administration, {
+				community: null,
+				district: null
+			});
 		}
-		this.render();
 	}
 
 
-	createView() {
+	createView(model) {
+
+		const { coordinate, altitude, administration: { community, district } } = model;
 		const translate = (key) => this._translationService.translate(key);
 
 
-		if (this._coordinate) {
-			const sridDefinitions = this._mapService.getSridDefinitionsForView(this._coordinate);
+		if (coordinate) {
+			const sridDefinitions = this._mapService.getSridDefinitionsForView(coordinate);
 			const stringifiedCoords = sridDefinitions.map(definition => {
 				const { label, code } = definition;
-				const transformedCoordinate = this._coordinateService.transform(this._coordinate, this._mapService.getSrid(), code);
+				const transformedCoordinate = this._coordinateService.transform(coordinate, this._mapService.getSrid(), code);
 
 				const copyCoordinate = () => {
-					this._shareService.copyToClipboard(transformedCoordinate.join(', ')).then(() => {}, () => {
+					this._shareService.copyToClipboard(transformedCoordinate.join(', ')).then(() => { }, () => {
 						console.warn('Clipboard API not available');
 					});
 				};
@@ -95,10 +124,10 @@ export class MapContextMenuContent extends BaElement {
 
 			<div class="container">
   				<ul class="content">
-				  	<li><span class='label'>${translate('map_contextMenuContent_community_label')}</span><span class='coordinate'>${this._community}</span></li>
-					<li><span class='label'>${translate('map_contextMenuContent_district_label')}</span><span class='coordinate'>${this._district}</span></li>
+				  	<li><span class='label'>${translate('map_contextMenuContent_community_label')}</span><span class='coordinate'>${community || '-'}</span></li>
+					<li><span class='label'>${translate('map_contextMenuContent_district_label')}</span><span class='coordinate'>${district || '-'}</span></li>
 					${stringifiedCoords.map((strCoord) => html`<li>${strCoord}</li>`)}
-					<li><span class='label'>${translate('map_contextMenuContent_altitude_label')}</span><span class='coordinate'>${this._altitude}</span></li>
+					<li><span class='label'>${translate('map_contextMenuContent_altitude_label')}</span><span class='coordinate'>${altitude || '-'}</span></li>
   				</ul>
 			</div>
 			`;

--- a/src/modules/map/components/contextMenu/MapContextMenuContent.js
+++ b/src/modules/map/components/contextMenu/MapContextMenuContent.js
@@ -126,6 +126,7 @@ export class MapContextMenuContent extends MvuElement {
 			emitNotification(message, LevelTypes.WARN);
 			console.warn('Clipboard API not available');
 
+			//disable all buttons
 			this.getRenderTarget().querySelectorAll(Icon.tag).forEach(baIcon => {
 				baIcon.icon = clipboardIcon;
 				baIcon.color = color;

--- a/src/modules/map/components/contextMenu/MapContextMenuContent.js
+++ b/src/modules/map/components/contextMenu/MapContextMenuContent.js
@@ -105,8 +105,6 @@ export class MapContextMenuContent extends MvuElement {
 		const onClickCallback = baIcon.onClick;
 		const successColor = 'var(--sucess-color)';
 
-
-
 		this._shareService.copyToClipboard(transformedCoordinate.join(', ')).then(() => {
 			//change the icon
 			baIcon.color = successColor;
@@ -137,12 +135,10 @@ export class MapContextMenuContent extends MvuElement {
 		});
 	}
 
-
 	createView(model) {
 
 		const { coordinate, altitude, administration: { community, district } } = model;
 		const translate = (key) => this._translationService.translate(key);
-
 
 		if (coordinate) {
 			const sridDefinitions = this._mapService.getSridDefinitionsForView(coordinate);
@@ -161,7 +157,6 @@ export class MapContextMenuContent extends MvuElement {
 				</span>
 				`;
 			});
-
 
 			return html`
 			<style>${css}</style>

--- a/src/modules/map/components/contextMenu/MapContextMenuContent.js
+++ b/src/modules/map/components/contextMenu/MapContextMenuContent.js
@@ -6,6 +6,7 @@ import checkedIcon from './assets/checked.svg';
 import { MvuElement } from '../../../MvuElement';
 import { emitNotification } from '../../../../store/notifications/notifications.action';
 import { LevelTypes } from '../../../../store/notifications/notifications.reducer';
+import { Icon } from '../../../commons/components/icon/Icon';
 
 const Update_Coordinate = 'update_coordinate';
 const Update_Altitude = 'update_altitude';
@@ -104,13 +105,15 @@ export class MapContextMenuContent extends MvuElement {
 		const onClickCallback = baIcon.onClick;
 		const successColor = 'var(--sucess-color)';
 
-		//change the icon
-		baIcon.color = successColor;
-		baIcon.color_hover = successColor;
-		baIcon.icon = checkedIcon;
-		baIcon.onClick = () => { };
+
 
 		this._shareService.copyToClipboard(transformedCoordinate.join(', ')).then(() => {
+			//change the icon
+			baIcon.color = successColor;
+			baIcon.color_hover = null;
+			baIcon.icon = checkedIcon;
+			baIcon.onClick = () => { };
+
 			setTimeout(() => {
 				//reset the icon
 				baIcon.icon = clipboardIcon;
@@ -119,13 +122,17 @@ export class MapContextMenuContent extends MvuElement {
 				baIcon.onClick = onClickCallback;
 			}, 1000);
 		}, () => {
-			emitNotification(this._translationService.translate('map_contextMenuContent_clipboard_error'), LevelTypes.WARN);
+			const message = this._translationService.translate('map_contextMenuContent_clipboard_error');
+			emitNotification(message, LevelTypes.WARN);
 			console.warn('Clipboard API not available');
-			//disable the icon
-			baIcon.icon = clipboardIcon;
-			baIcon.color = color;
-			baIcon.color_hover = color_hover;
-			baIcon.disabled = true;
+
+			this.getRenderTarget().querySelectorAll(Icon.tag).forEach(baIcon => {
+				baIcon.icon = clipboardIcon;
+				baIcon.color = color;
+				baIcon.color_hover = color_hover;
+				baIcon.disabled = true;
+				baIcon.title = message;
+			});
 		});
 	}
 

--- a/src/modules/map/components/contextMenu/assets/checked.svg
+++ b/src/modules/map/components/contextMenu/assets/checked.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-check-lg" viewBox="0 0 16 16"><!-- MIT License -->
+  <path d="M13.485 1.431a1.473 1.473 0 0 1 2.104 2.062l-7.84 9.801a1.473 1.473 0 0 1-2.12.04L.431 8.138a1.473 1.473 0 0 1 2.084-2.083l4.111 4.112 6.82-8.69a.486.486 0 0 1 .04-.045z"/>
+</svg>

--- a/src/modules/map/i18n/contextMenu.provider.js
+++ b/src/modules/map/i18n/contextMenu.provider.js
@@ -9,7 +9,8 @@ export const provide = (lang) => {
 				map_contextMenuContent_altitude_label: 'Alt.',
 				map_contextMenuContent_community_label: 'Community',
 				map_contextMenuContent_district_label: 'District',
-				map_contextMenuContent_copy_icon: 'Copy to clipboard'
+				map_contextMenuContent_copy_icon: 'Copy to clipboard',
+				map_contextMenuContent_clipboard_error: '"Copy to clipboard" is not available'
 			};
 
 		case 'de':
@@ -20,7 +21,8 @@ export const provide = (lang) => {
 				map_contextMenuContent_altitude_label: 'Höhe',
 				map_contextMenuContent_community_label: 'Gemeinde',
 				map_contextMenuContent_district_label: 'Gemarkung',
-				map_contextMenuContent_copy_icon: 'In die Zwischenablage kopieren'
+				map_contextMenuContent_copy_icon: 'In die Zwischenablage kopieren',
+				map_contextMenuContent_clipboard_error: '"In die Zwischenablage kopieren" steht nicht zur Verfügung'
 			};
 
 		default:

--- a/src/modules/map/store/ContextClickPlugin.js
+++ b/src/modules/map/store/ContextClickPlugin.js
@@ -1,8 +1,7 @@
 import { observe } from '../../../utils/storeUtils';
 import { BaPlugin } from '../../../store/BaPlugin';
-import { MapContextMenu } from '../components/contextMenu/MapContextMenu';
-import { MapContextMenuContent } from '../components/contextMenu/MapContextMenuContent';
 import { close, open } from './mapContextMenu.action';
+import { html } from 'lit-html';
 
 
 /**
@@ -18,28 +17,9 @@ export class ContextClickPlugin extends BaPlugin {
 	 */
 	async register(store) {
 
-		//create and add a MapContextMenu element
-		const mapContextMenu = document.createElement(MapContextMenu.tag);
-		document.body.appendChild(mapContextMenu);
-		const contentElementId = MapContextMenuContent.tag + '_generatedByContextMenuEventHandler';
-
 		const onContextClick = (eventlike) => {
 			const evt = eventlike.payload;
-
-
-			/**
-			 * On every contextmenu event we create a new content element and add it to the DOM.
-			 * We do not pollute the DOM because the map-context-menu extracts it immediately from there (by id)
-			 * and inserts it in its Shadow DOM.
-			 *
-			 * Here we could also load different kind of content panels dependent from current state.
-			 */
-			const mapContextMenuContent = document.createElement(MapContextMenuContent.tag);
-			mapContextMenuContent.id = contentElementId;
-			mapContextMenuContent.coordinate = evt.coordinate;
-			document.body.appendChild(mapContextMenuContent);
-
-			open([evt.screenCoordinate[0], evt.screenCoordinate[1]], contentElementId);
+			open([evt.screenCoordinate[0], evt.screenCoordinate[1]], html`<ba-map-context-menu-content .coordinate=${evt.coordinate}></ba-map-context-menu-content`);
 		};
 
 		observe(store, state => state.pointer.contextClick, onContextClick);

--- a/src/modules/map/store/mapContextMenu.action.js
+++ b/src/modules/map/store/mapContextMenu.action.js
@@ -28,10 +28,10 @@ const getStore = () => {
  * @function
  * @param {ContextMenuData} contextMenuData the data to display the contextmenu at a specific point with specific entries
  */
-export const open = (coordinate, id) => {
+export const open = (coordinate, content) => {
 	getStore().dispatch({
 		type: MAP_CONTEXT_MENU_CLICKED,
-		payload: { coordinate: coordinate, id: id }
+		payload: { coordinate: coordinate, content: content }
 	});
 };
 

--- a/src/modules/map/store/mapContextMenu.reducer.js
+++ b/src/modules/map/store/mapContextMenu.reducer.js
@@ -2,7 +2,7 @@ export const MAP_CONTEXT_MENU_CLICKED = 'event/contextMenu';
 
 export const initialState = {
 	coordinate: null,
-	id: null
+	content: null
 };
 
 export const mapContextMenuReducer = (state = initialState, action) => {
@@ -12,7 +12,7 @@ export const mapContextMenuReducer = (state = initialState, action) => {
 			return {
 				...state,
 				coordinate: payload.coordinate,
-				id: payload.id
+				content: payload.content
 			};
 		}
 	}

--- a/test/e2e/page.spec.js
+++ b/test/e2e/page.spec.js
@@ -79,5 +79,9 @@ test.describe('page', () => {
 		test('should contain a <ba-notification-panel> component', async ({ page }) => {
 			expect(await page.$$('ba-notification-panel')).toHaveLength(1);
 		});
+
+		test('should contain a <ba-map-context-menu> component', async ({ page }) => {
+			expect(await page.$$('ba-map-context-menu')).toHaveLength(1);
+		});
 	});
 });

--- a/test/modules/commons/components/Icon.test.js
+++ b/test/modules/commons/components/Icon.test.js
@@ -38,6 +38,7 @@ describe('Icon', () => {
 			expect(element.shadowRoot.styleSheets[1].cssRules.item(0).cssText).toContain('--size: 2em; background: var(--primary-color);');
 			//anchorClassHover
 			expect(element.shadowRoot.styleSheets[1].cssRules.item(1).cssText).toContain('background: var(--primary-color);');
+			expect(element.shadowRoot.styleSheets[1].cssRules.item(1).cssText).toContain('transform: scale(1.1)');
 			//customIconClass
 			expect(element.shadowRoot.styleSheets[1].cssRules.item(2).cssText).toContain('data:image/svg+xml;base64,PHN2ZyB4');
 
@@ -90,6 +91,11 @@ describe('Icon', () => {
 			element.color_hover = 'var(--foo)';
 
 			expect(element.shadowRoot.styleSheets[1].cssRules.item(1).cssText).toContain('background: var(--foo);');
+
+			element.color_hover = null;
+
+			expect(element.shadowRoot.styleSheets[1].cssRules.item(1).cssText).not.toContain('background: var(--primary-color);');
+			expect(element.shadowRoot.styleSheets[1].cssRules.item(1).cssText).not.toContain('transform: scale(1.1)');
 		});
 	});
 

--- a/test/modules/map/components/contextMenu/MapContextMenu.test.js
+++ b/test/modules/map/components/contextMenu/MapContextMenu.test.js
@@ -4,6 +4,7 @@ import { initialState, mapContextMenuReducer } from '../../../../../src/modules/
 import { TestUtils } from '../../../../test-utils.js';
 import { close, open } from '../../../../../src/modules/map/store/mapContextMenu.action';
 import { $injector } from '../../../../../src/injection';
+import { html } from 'lit-html';
 window.customElements.define(MapContextMenu.tag, MapContextMenu);
 
 describe('MapContextMenu', () => {
@@ -20,32 +21,37 @@ describe('MapContextMenu', () => {
 	};
 
 	describe('when initialized', () => {
-		it('renders nothing', async () => {
-			const element = await setup();
-			const container = element.shadowRoot.querySelector('.context-menu');
 
-			expect(container).toBeFalsy();
+		it('renders nothing', async () => {
+
+			const element = await setup();
+
+			expect(element.childElementCount).toBe(0);
 		});
 	});
 
 	describe('store changed', () => {
-		it('shows/hides the context menu', async () => {
+
+		it('shows/hides the context menu and its content', async () => {
 			const element = await setup();
 
-			open([10, 10], 'unknownId');
+			open([10, 10], html`<span class="foo">bar</span>`);
 
 			const container = element.shadowRoot.querySelector('.context-menu');
+			const content = element.shadowRoot.querySelector('.foo');
 			expect(window.getComputedStyle(container).display).toBe('block');
+			expect(content.innerText).toBe('bar');
 
 			close();
 
 			expect(element.shadowRoot.querySelector('.context-menu')).toBeFalsy();
 		});
 	});
+
 	describe('when opened', () => {
 
 		it('shows a header and a close button which closes the menu', async () => {
-			const element = await setup({ coordinate: [10, 20], id: 'someId' });
+			const element = await setup({ coordinate: [10, 20], content: 'someId' });
 
 			const header = element.shadowRoot.querySelector('.header');
 			expect(header).toBeTruthy();
@@ -62,19 +68,19 @@ describe('MapContextMenu', () => {
 		});
 
 
-		it('renders a content html element', async () => {
-			const element = await setup();
-			const contentElementId = 'mockContentId';
-			const mockContent = document.createElement('div');
-			mockContent.innerText = 'mockContentText';
-			mockContent.id = contentElementId;
-			document.body.appendChild(mockContent);
+		// it('renders a content html element', async () => {
+		// 	const element = await setup();
+		// 	const contentElementId = 'mockContentId';
+		// 	const mockContent = document.createElement('div');
+		// 	mockContent.innerText = 'mockContentText';
+		// 	mockContent.id = contentElementId;
+		// 	document.body.appendChild(mockContent);
 
-			open([10, 20], contentElementId);
+		// 	open([10, 20], contentElementId);
 
-			const container = element.shadowRoot.querySelector('.context-menu');
-			expect(element.shadowRoot.querySelector('#' + contentElementId).parentElement).toEqual(container);
-		});
+		// 	const container = element.shadowRoot.querySelector('.context-menu');
+		// 	expect(element.shadowRoot.querySelector('#' + contentElementId).parentElement).toEqual(container);
+		// });
 
 		it('calls the _calculateSector() method', async () => {
 			const element = await setup();

--- a/test/modules/map/components/contextMenu/MapContextMenu.test.js
+++ b/test/modules/map/components/contextMenu/MapContextMenu.test.js
@@ -67,21 +67,6 @@ describe('MapContextMenu', () => {
 			expect(element.shadowRoot.querySelector('.context-menu')).toBeFalsy();
 		});
 
-
-		// it('renders a content html element', async () => {
-		// 	const element = await setup();
-		// 	const contentElementId = 'mockContentId';
-		// 	const mockContent = document.createElement('div');
-		// 	mockContent.innerText = 'mockContentText';
-		// 	mockContent.id = contentElementId;
-		// 	document.body.appendChild(mockContent);
-
-		// 	open([10, 20], contentElementId);
-
-		// 	const container = element.shadowRoot.querySelector('.context-menu');
-		// 	expect(element.shadowRoot.querySelector('#' + contentElementId).parentElement).toEqual(container);
-		// });
-
 		it('calls the _calculateSector() method', async () => {
 			const element = await setup();
 			const clickEvent = [10, 20];

--- a/test/modules/map/components/contextMenu/MapContextMenuContent.test.js
+++ b/test/modules/map/components/contextMenu/MapContextMenuContent.test.js
@@ -19,7 +19,7 @@ describe('OlMapContextMenuContent', () => {
 		copyToClipboard() { }
 	};
 	const altitudeServiceMock = {
-		getAltitude() {	}
+		getAltitude() { }
 	};
 	const administrationServiceMock = {
 		getAdministration() { }
@@ -59,12 +59,9 @@ describe('OlMapContextMenuContent', () => {
 			const element = await setup();
 
 			element.coordinate = coordinateMock;
-			//after we set the coordinate, we need to trigger rendering manually in this case
-			element.render();
 
 			expect(element.shadowRoot.querySelector('.container')).toBeTruthy();
 			expect(element.shadowRoot.querySelector('.content')).toBeTruthy();
-
 			expect(element.shadowRoot.querySelectorAll('.label')[0].innerText).toBe('map_contextMenuContent_community_label');
 			expect(element.shadowRoot.querySelectorAll('.label')[1].innerText).toBe('map_contextMenuContent_district_label');
 			expect(element.shadowRoot.querySelectorAll('.label')[2].innerText).toBe('code42');
@@ -84,25 +81,27 @@ describe('OlMapContextMenuContent', () => {
 
 
 			expect(copyToClipboardMock).toHaveBeenCalledWith('21, 21');
-			expect(getSridDefinitionsForViewMock).toHaveBeenCalledOnceWith([1000, 2000]);
-			expect(transformMock).toHaveBeenCalledOnceWith([1000, 2000], 3857, 42);
-			expect(stringifyMock).toHaveBeenCalledOnceWith([21, 21], 42, { digits: 7 });
+			expect(getSridDefinitionsForViewMock).toHaveBeenCalledWith([1000, 2000]);
+			expect(transformMock).toHaveBeenCalledWith([1000, 2000], 3857, 42);
+			expect(stringifyMock).toHaveBeenCalledWith([21, 21], 42, { digits: 7 });
 			expect(altitudeMock).toHaveBeenCalledOnceWith(coordinateMock);
 			expect(administrationMock).toHaveBeenCalledOnceWith(coordinateMock);
 
 		});
 
 		it('copies a coordinate to the clipboard', async () => {
+			const coordinateMock = [1000, 2000];
 			spyOn(mapServiceMock, 'getSridDefinitionsForView').and.returnValue([{ label: 'code42', code: 42 }]);
 			spyOn(mapServiceMock, 'getSrid').and.returnValue(3857);
 			const copyToClipboardMock = spyOn(shareServiceMock, 'copyToClipboard').and.returnValue(Promise.resolve());
 			spyOn(coordinateServiceMock, 'transform').and.returnValue([21, 21]);
 			spyOn(coordinateServiceMock, 'stringify').and.returnValue('stringified coordinate');
+			spyOn(altitudeServiceMock, 'getAltitude').withArgs(coordinateMock).and.returnValue(42);
+			spyOn(administrationServiceMock, 'getAdministration').withArgs(coordinateMock).and.returnValue({ community: 'LDBV', district: 'Ref42' });
 			const element = await setup();
 
-			element.coordinate = [1000, 2000];
-			//after we set the coordinate, we need to trigger rendering manually in this case
-			element.render();
+			element.coordinate = coordinateMock;
+
 			const copyIcon = element.shadowRoot.querySelector('ba-icon');
 			expect(copyIcon).toBeTruthy();
 			copyIcon.click();
@@ -121,8 +120,7 @@ describe('OlMapContextMenuContent', () => {
 			const element = await setup();
 
 			element.coordinate = [1000, 2000];
-			//after we set the coordinate, we need to trigger rendering manually in this case
-			element.render();
+
 			const copyIcon = element.shadowRoot.querySelector('ba-icon');
 			expect(copyIcon).toBeTruthy();
 			copyIcon.click();

--- a/test/modules/map/i18n/contextMenu.provider.test.js
+++ b/test/modules/map/i18n/contextMenu.provider.test.js
@@ -13,6 +13,7 @@ describe('i18n for context menu', () => {
 		expect(map.map_contextMenuContent_community_label).toBe('Community');
 		expect(map.map_contextMenuContent_district_label).toBe('District');
 		expect(map.map_contextMenuContent_copy_icon).toBe('Copy to clipboard');
+		expect(map.map_contextMenuContent_clipboard_error).toBe('"Copy to clipboard" is not available');
 	});
 
 
@@ -26,10 +27,11 @@ describe('i18n for context menu', () => {
 		expect(map.map_contextMenuContent_community_label).toBe('Gemeinde');
 		expect(map.map_contextMenuContent_district_label).toBe('Gemarkung');
 		expect(map.map_contextMenuContent_copy_icon).toBe('In die Zwischenablage kopieren');
+		expect(map.map_contextMenuContent_clipboard_error).toBe('"In die Zwischenablage kopieren" steht nicht zur Verfügung');
 	});
 
 	it('have the expected amount of translations', () => {
-		const expectedSize = 6;
+		const expectedSize = 7;
 		const deMap = provide('de');
 		const enMap = provide('en');
 

--- a/test/modules/map/store/ContextClickPlugin.test.js
+++ b/test/modules/map/store/ContextClickPlugin.test.js
@@ -4,8 +4,8 @@ import { mapReducer } from '../../../../src/modules/map/store/map.reducer';
 import { setClick, setContextClick } from '../../../../src/modules/map/store/pointer.action';
 import { setMoveStart } from '../../../../src/modules/map/store/map.action';
 import { mapContextMenuReducer } from '../../../../src/modules/map/store/mapContextMenu.reducer';
-import { MapContextMenu } from '../../../../src/modules/map/components/contextMenu/MapContextMenu';
 import { ContextClickPlugin } from '../../../../src/modules/map/store/ContextClickPlugin.js';
+import { TemplateResult } from 'lit-html';
 
 
 
@@ -21,17 +21,6 @@ describe('ContextClickPlugin', () => {
 		return store;
 	};
 
-	describe('on register', () => {
-		it('inserts the mapcontextmenu container', async () => {
-			const store = setup();
-
-			await new ContextClickPlugin().register(store);
-
-			const element = document.querySelector(MapContextMenu.tag);
-			expect(element).toBeTruthy();
-		});
-	});
-
 	describe('when context-click state changed', () => {
 
 		it('updates the mapContextMenu store section', () => {
@@ -41,12 +30,9 @@ describe('ContextClickPlugin', () => {
 
 			setContextClick({ coordinate: [2121, 4242], screenCoordinate: [21, 42] });
 
-			const { coordinate, id } = store.getState().mapContextMenu;
+			const { coordinate, content } = store.getState().mapContextMenu;
 			expect(coordinate).toEqual([21, 42]);
-			expect(id).toEqual('ba-map-context-menu-content_generatedByContextMenuEventHandler');
-			const element = document.querySelector('ba-map-context-menu-content');
-			expect(element).toBeTruthy();
-			expect(element.id).toBe('ba-map-context-menu-content_generatedByContextMenuEventHandler');
+			expect(content).toBeInstanceOf(TemplateResult);
 		});
 	});
 


### PR DESCRIPTION
Similar to our Modal window, the content of our ContextMenu should be submitted by the payload of the corresponding action.

Bonus: The copy-to-clipboard icons change their layout on success. 