### PR TITLE
increase delay time

### DIFF
--- a/test/modules/map/components/olMap/handler/featureInfo/OlFeatureInfoHandler.test.js
+++ b/test/modules/map/components/olMap/handler/featureInfo/OlFeatureInfoHandler.test.js
@@ -25,7 +25,7 @@ describe('OlFeatureInfoHandler_Query_Resolution_Delay', () => {
 
 describe('OlFeatureInfoHandler', () => {
 
-	const TestDelay = OlFeatureInfoHandler_Query_Resolution_Delay_Ms + 100;
+	const TestDelay = OlFeatureInfoHandler_Query_Resolution_Delay_Ms + 200;
 
 	const mockFeatureInfoProvider = (olFeature, layer) => {
 		const geometry = { data: new GeoJSON().writeGeometry(olFeature.getGeometry()), geometryType: FeatureInfoGeometryTypes.GEOJSON };


### PR DESCRIPTION
to prevent flaky tests in `OlFeatureInfoHandler.test.js` (see https://github.com/ldbv-by/bav4-nomigration/runs/4350856533)
