### PR TITLE
Fix order of statements in  OlDrawHandler.onDeactivate

### DIFF
--- a/src/modules/map/components/olMap/handler/draw/OlDrawHandler.js
+++ b/src/modules/map/components/olMap/handler/draw/OlDrawHandler.js
@@ -232,10 +232,11 @@ export class OlDrawHandler extends OlLayerHandler {
 	 *  @override
 	 *  @param {Map} olMap
 	 */
-	// eslint-disable-next-line no-unused-vars
 	onDeactivate(olMap) {
 		//use the map to unregister event listener, interactions, etc
 		//olLayer currently undefined, will be fixed later
+		setStyle(null);
+		setSelectedStyle(null);
 		olMap.removeInteraction(this._modify);
 		olMap.removeInteraction(this._snap);
 		olMap.removeInteraction(this._select);
@@ -252,8 +253,6 @@ export class OlDrawHandler extends OlLayerHandler {
 
 		this._convertToPermanentLayer();
 		this._vectorLayer.getSource().getFeatures().forEach(f => this._overlayService.remove(f, this._map));
-		setStyle(null);
-		setSelectedStyle(null);
 		this._draw = null;
 		this._modify = false;
 		this._select = false;

--- a/test/modules/map/components/olMap/handler/draw/OlDrawHandler.test.js
+++ b/test/modules/map/components/olMap/handler/draw/OlDrawHandler.test.js
@@ -912,6 +912,24 @@ describe('OlDrawHandler', () => {
 
 		});
 
+		it('left no active draw-interaction', (done) => {
+			setup();
+			const classUnderTest = new OlDrawHandler();
+			const map = setupMap();
+
+
+			classUnderTest.activate(map);
+			setType('marker');
+			classUnderTest.deactivate(map);
+
+			setTimeout(() => {
+				const draw = map.getInteractions().getArray().find(i => i instanceof Draw);
+				expect(draw == null).toBeTrue();
+				expect(classUnderTest._draw).toBeNull();
+				done();
+			});
+		});
+
 	});
 
 	describe('when draw a line', () => {


### PR DESCRIPTION
fixes #560

update OlDrawHandler.onDeactivate() by moving reset-statements
for styles upwards, to prevent reinitializing of draw-interactions