### PR TITLE
move from es9 to es11

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Next-generation web-map viewer based on web standards.
 ## Concept
 
 - Use of web standards as far as possible
-  - Modern Js (ES9), no transpiler
+  - Modern JavaScript (ES11), no transpiler
   - Web Components
   - Vanilla CSS 
 - Built-in dependency injection

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "test:debug": "karma start --single-run --browsers ChromeDebugging",
     "test:gha": "karma start karma.conf.gha.js --single-run",
     "e2e": "npx playwright install; env URL=$npm_config_url npx playwright test --browser=${npm_config_browser:-all} --retries=3",
-    "es-check": "es-check es9 \"./src/**/*.js\" --module",
+    "es-check": "es-check es11 \"./src/**/*.js\" --module",
     "analyze-bundle": "webpack --stats=detailed --json > stats.json && webpack-bundle-analyzer ./stats.json"
   }
 }


### PR DESCRIPTION
We can safely use es10 and es11 language features from now on
- https://caniuse.com/?search=es10
- https://caniuse.com/?search=es11
