### PR TITLE
prevent flakiness in OlFeatureInfoHandler

### DIFF
--- a/test/modules/map/components/olMap/handler/featureInfo/OlFeatureInfoHandler.test.js
+++ b/test/modules/map/components/olMap/handler/featureInfo/OlFeatureInfoHandler.test.js
@@ -59,16 +59,6 @@ describe('OlFeatureInfoHandler', () => {
 		});
 	};
 
-	const delay = (fn) => {
-		/**
-		 * Although tests on map are wrapped within a map.once('postcompose'), we still have flaky tests.
-		 * Therefore we have to delay them a bit (200ms seems to be enough)
-		 */
-		return () => setTimeout(() => {
-			fn();
-		}, 200);
-	};
-
 	describe('constructor', () => {
 
 		it('initializes the service with custom provider', async () => {
@@ -144,7 +134,7 @@ describe('OlFeatureInfoHandler', () => {
 
 			handler.register(map);
 
-			map.once('postcompose', delay(() => {
+			map.once('rendercomplete', () => {
 				// safe to call map.getPixelFromCoordinate from now on
 				startRequest(matchingCoordinate);
 
@@ -161,7 +151,7 @@ describe('OlFeatureInfoHandler', () => {
 					expect(store.getState().highlight.features).toHaveSize(0);
 					done();
 				}, TestDelay);
-			}));
+			});
 		});
 
 		it('removes outdated HighlightFeature items', (done) => {
@@ -176,7 +166,7 @@ describe('OlFeatureInfoHandler', () => {
 			const map = setupMap();
 			handler.register(map);
 
-			map.once('postcompose', delay(() => {
+			map.once('rendercomplete', () => {
 				// safe to call map.getPixelFromCoordinate from now on
 				startRequest(notMatchingCoordinate);
 
@@ -187,10 +177,10 @@ describe('OlFeatureInfoHandler', () => {
 
 					done();
 				}, TestDelay);
-			}));
+			});
 		});
 
-		xit('adds one FeatureInfo and HighlightFeature from each suitable layer', (done) => {
+		it('adds one FeatureInfo and HighlightFeature from each suitable layer', (done) => {
 			const handler = setup({
 				layers: {
 					active: [
@@ -221,7 +211,7 @@ describe('OlFeatureInfoHandler', () => {
 
 			handler.register(map);
 
-			map.once('postcompose', delay(() => {
+			map.once('rendercomplete', () => {
 				// safe to call map.getPixelFromCoordinate from now on
 				startRequest(matchingCoordinate);
 
@@ -287,7 +277,7 @@ describe('OlFeatureInfoHandler', () => {
 						}, TestDelay);
 					}, TestDelay);
 				}, TestDelay);
-			}));
+			});
 		});
 
 		it('adds \'Not_Available\' FeatureInfo items and NO HighlightFeatures when FeatureInfoProvider returns null', (done) => {
@@ -300,6 +290,7 @@ describe('OlFeatureInfoHandler', () => {
 				}
 			}, mockNullFeatureInfoProvider);
 			const map = setupMap();
+
 			const geometry = new Point(matchingCoordinate);
 			const olVectorSource0 = new VectorSource();
 			const feature0 = new Feature({ geometry: geometry });
@@ -317,7 +308,7 @@ describe('OlFeatureInfoHandler', () => {
 
 			handler.register(map);
 
-			map.once('postcompose', delay(() => {
+			map.once('rendercomplete', () => {
 				// safe to call map.getPixelFromCoordinate from now on
 				startRequest(matchingCoordinate);
 
@@ -327,7 +318,7 @@ describe('OlFeatureInfoHandler', () => {
 				expect(store.getState().highlight.features).toHaveSize(0);
 
 				done();
-			}));
+			});
 		});
 	});
 });

--- a/test/modules/map/components/olMap/handler/featureInfo/OlFeatureInfoHandler.test.js
+++ b/test/modules/map/components/olMap/handler/featureInfo/OlFeatureInfoHandler.test.js
@@ -25,7 +25,7 @@ describe('OlFeatureInfoHandler_Query_Resolution_Delay', () => {
 
 describe('OlFeatureInfoHandler', () => {
 
-	const TestDelay = OlFeatureInfoHandler_Query_Resolution_Delay_Ms + 200;
+	const TestDelay = OlFeatureInfoHandler_Query_Resolution_Delay_Ms + 500;
 
 	const mockFeatureInfoProvider = (olFeature, layer) => {
 		const geometry = { data: new GeoJSON().writeGeometry(olFeature.getGeometry()), geometryType: FeatureInfoGeometryTypes.GEOJSON };

--- a/test/modules/map/components/olMap/handler/featureInfo/OlFeatureInfoHandler.test.js
+++ b/test/modules/map/components/olMap/handler/featureInfo/OlFeatureInfoHandler.test.js
@@ -61,7 +61,7 @@ describe('OlFeatureInfoHandler', () => {
 
 	const delay = (fn) => {
 		/**
-		 * Although tests on map are wrapped within a map.once('postrender'), we still have flaky tests.
+		 * Although tests on map are wrapped within a map.once('postcompose'), we still have flaky tests.
 		 * Therefore we have to delay them a bit (200ms seems to be enough)
 		 */
 		return () => setTimeout(() => {
@@ -144,7 +144,7 @@ describe('OlFeatureInfoHandler', () => {
 
 			handler.register(map);
 
-			map.once('postrender', delay(() => {
+			map.once('postcompose', delay(() => {
 				// safe to call map.getPixelFromCoordinate from now on
 				startRequest(matchingCoordinate);
 
@@ -176,7 +176,7 @@ describe('OlFeatureInfoHandler', () => {
 			const map = setupMap();
 			handler.register(map);
 
-			map.once('postrender', delay(() => {
+			map.once('postcompose', delay(() => {
 				// safe to call map.getPixelFromCoordinate from now on
 				startRequest(notMatchingCoordinate);
 
@@ -221,7 +221,7 @@ describe('OlFeatureInfoHandler', () => {
 
 			handler.register(map);
 
-			map.once('postrender', delay(() => {
+			map.once('postcompose', delay(() => {
 				// safe to call map.getPixelFromCoordinate from now on
 				startRequest(matchingCoordinate);
 
@@ -317,7 +317,7 @@ describe('OlFeatureInfoHandler', () => {
 
 			handler.register(map);
 
-			map.once('postrender', delay(() => {
+			map.once('postcompose', delay(() => {
 				// safe to call map.getPixelFromCoordinate from now on
 				startRequest(matchingCoordinate);
 

--- a/test/modules/map/components/olMap/handler/featureInfo/OlFeatureInfoHandler.test.js
+++ b/test/modules/map/components/olMap/handler/featureInfo/OlFeatureInfoHandler.test.js
@@ -190,7 +190,7 @@ describe('OlFeatureInfoHandler', () => {
 			}));
 		});
 
-		it('adds one FeatureInfo and HighlightFeature from each suitable layer', (done) => {
+		xit('adds one FeatureInfo and HighlightFeature from each suitable layer', (done) => {
 			const handler = setup({
 				layers: {
 					active: [

--- a/test/modules/map/components/olMap/handler/featureInfo/OlFeatureInfoHandler.test.js
+++ b/test/modules/map/components/olMap/handler/featureInfo/OlFeatureInfoHandler.test.js
@@ -25,7 +25,7 @@ describe('OlFeatureInfoHandler_Query_Resolution_Delay', () => {
 
 describe('OlFeatureInfoHandler', () => {
 
-	const TestDelay = OlFeatureInfoHandler_Query_Resolution_Delay_Ms + 500;
+	const TestDelay = OlFeatureInfoHandler_Query_Resolution_Delay_Ms + 100;
 
 	const mockFeatureInfoProvider = (olFeature, layer) => {
 		const geometry = { data: new GeoJSON().writeGeometry(olFeature.getGeometry()), geometryType: FeatureInfoGeometryTypes.GEOJSON };


### PR DESCRIPTION
use `rendercomplete` instead of `postrender`
fixes #576 