### PR TITLE
update styling-behavior by using Input-Event

### DIFF
--- a/src/modules/toolbox/components/drawToolContent/DrawToolContent.js
+++ b/src/modules/toolbox/components/drawToolContent/DrawToolContent.js
@@ -312,7 +312,7 @@ export class DrawToolContent extends AbstractToolContent {
 							title='Symbol'>							
 							<div class="tool-container__style_color" title="${translate('toolbox_drawTool_style_color')}">
 								<label for="style_color">${translate('toolbox_drawTool_style_color')}</label>	
-								<input type="color" id="style_color" name="${translate('toolbox_drawTool_style_color')}" .value=${style.color} @change=${onChangeColor}>						
+								<input type="color" id="style_color" name="${translate('toolbox_drawTool_style_color')}" .value=${style.color} @input=${onChangeColor}>						
 							</div>					
 							<div class="tool-container__style_size" title="${translate('toolbox_drawTool_style_size')}">
 								<label for="style_size">${translate('toolbox_drawTool_style_size')}</label>									
@@ -333,7 +333,7 @@ export class DrawToolContent extends AbstractToolContent {
 							title='Text'>
 							<div class="tool-container__style_color" title="${translate('toolbox_drawTool_style_color')}">
 								<label for="style_color">${translate('toolbox_drawTool_style_color')}</label>	
-								<input type="color" id="style_color" name="${translate('toolbox_drawTool_style_color')}" .value=${style.color} @change=${onChangeColor}>						
+								<input type="color" id="style_color" name="${translate('toolbox_drawTool_style_color')}" .value=${style.color} @input=${onChangeColor}>						
 							</div>	
 							<div class="tool-container__style_heigth" title="${translate('toolbox_drawTool_style_size')}">
 								<label for="style_size">${translate('toolbox_drawTool_style_size')}</label>	
@@ -343,7 +343,7 @@ export class DrawToolContent extends AbstractToolContent {
 							</div>				
 							<div class="tool-container__style_text" title="${translate('toolbox_drawTool_style_text')}">
 								<label for="style_text">${translate('toolbox_drawTool_style_text')}</label>	
-								<input type="string" id="style_text" name="${translate('toolbox_drawTool_style_text')}" .value=${style.text} @change=${onChangeText}>
+								<input type="string" id="style_text" name="${translate('toolbox_drawTool_style_text')}" .value=${style.text} @input=${onChangeText}>
 							</div>							
 						</div>
 						`;
@@ -354,7 +354,7 @@ export class DrawToolContent extends AbstractToolContent {
 							title='Line'>
 							<div class="tool-container__style_color" title="${translate('toolbox_drawTool_style_color')}">
 								<label for="style_color">${translate('toolbox_drawTool_style_color')}</label>	
-								<input type="color" id="style_color" name="${translate('toolbox_drawTool_style_color')}" .value=${style.color} @change=${onChangeColor}>						
+								<input type="color" id="style_color" name="${translate('toolbox_drawTool_style_color')}" .value=${style.color} @input=${onChangeColor}>						
 							</div>					
 						</div>
 						`;
@@ -365,7 +365,7 @@ export class DrawToolContent extends AbstractToolContent {
 								title='Polygon'>
 								<div class="tool-container__style_color" title="${translate('toolbox_drawTool_style_color')}">
 									<label for="style_color">${translate('toolbox_drawTool_style_color')}</label>	
-									<input type="color" id="style_color" name="${translate('toolbox_drawTool_style_color')}" .value=${style.color} @change=${onChangeColor}>						
+									<input type="color" id="style_color" name="${translate('toolbox_drawTool_style_color')}" .value=${style.color} @input=${onChangeColor}>						
 								</div>				
 							</div>
 							`;

--- a/test/modules/toolbox/components/drawToolContent/DrawToolContent.test.js
+++ b/test/modules/toolbox/components/drawToolContent/DrawToolContent.test.js
@@ -199,7 +199,7 @@ describe('DrawToolContent', () => {
 			expect(colorInput.value).toBe('#f00ba3');
 
 			colorInput.value = newColor;
-			colorInput.dispatchEvent(new Event('change'));
+			colorInput.dispatchEvent(new Event('input'));
 
 			expect(store.getState().draw.style.color).toBe(newColor);
 		});
@@ -220,7 +220,7 @@ describe('DrawToolContent', () => {
 			expect(colorInput.value).toBe('#f00ba3');
 
 			colorInput.value = newColor;
-			colorInput.dispatchEvent(new Event('change'));
+			colorInput.dispatchEvent(new Event('input'));
 
 			expect(getIconResultSpy).toHaveBeenCalledWith('https://some.url/foo/bar/0,0,0/foobar');
 			expect(store.getState().draw.style.symbolSrc).toBe('https://some.url/foo/bar/1,2,3/foobarbaz');
@@ -253,7 +253,7 @@ describe('DrawToolContent', () => {
 			expect(textInput.value).toBe('foo');
 
 			textInput.value = newText;
-			textInput.dispatchEvent(new Event('change'));
+			textInput.dispatchEvent(new Event('input'));
 
 			expect(store.getState().draw.style.text).toBe(newText);
 		});


### PR DESCRIPTION
In the DrawToolContent the user can change the style of the drawing.
Changes on Color- and Text-Style are made with Input-elements.
Switching to listen to input-events  leads to a more
responsive behavior of the DrawToolContent