### PR TITLE
fix for drawing/measurement-store

### DIFF
--- a/src/modules/map/components/olMap/services/MeasurementStorageService.js
+++ b/src/modules/map/components/olMap/services/MeasurementStorageService.js
@@ -99,7 +99,7 @@ export class MeasurementStorageService {
 			else {
 				try {
 					const fileSaveResult = await fileStorageService.save(null, content, type);
-					setMeasurementFileSaveResult(fileSaveResult);
+					this._setFileSaveResult(fileSaveResult);
 				}
 				catch (error) {
 					console.warn('Could not store content initially:', error);

--- a/src/modules/map/components/olMap/services/MeasurementStorageService.js
+++ b/src/modules/map/components/olMap/services/MeasurementStorageService.js
@@ -1,5 +1,6 @@
 import { $injector } from '../../../../../injection';
-import { setFileSaveResult } from '../../../../../store/measurement/measurement.action';
+import { setFileSaveResult as setMeasurementFileSaveResult } from '../../../../../store/measurement/measurement.action';
+import { setFileSaveResult as setDrawingFileSaveResult } from '../../../../../store/draw/draw.action';
 
 
 /**
@@ -20,10 +21,10 @@ export class MeasurementStorageService {
 	setStorageId(value) {
 		const { FileStorageService: fileStorageService } = $injector.inject('FileStorageService');
 		if (fileStorageService.isAdminId(value)) {
-			setFileSaveResult({ adminId: value, fileId: null });
+			this._setFileSaveResult({ adminId: value, fileId: null });
 		}
 		if (fileStorageService.isFileId(value)) {
-			setFileSaveResult({ fileId: value, adminId: null });
+			this._setFileSaveResult({ fileId: value, adminId: null });
 		}
 	}
 
@@ -57,6 +58,11 @@ export class MeasurementStorageService {
 		return this._isValidFileSaveResult(this._getLastFileSaveResult()) && this.isStorageId(this.getStorageId());
 	}
 
+	_setFileSaveResult(fileSaveResult) {
+		setMeasurementFileSaveResult(fileSaveResult);
+		setDrawingFileSaveResult(fileSaveResult);
+	}
+
 	_getLastFileSaveResult() {
 		const { StoreService: storeService } = $injector.inject('StoreService');
 		const { measurement } = storeService.getStore().getState();
@@ -84,7 +90,7 @@ export class MeasurementStorageService {
 			if (measurement.fileSaveResult) {
 				try {
 					const fileSaveResult = await fileStorageService.save(measurement.fileSaveResult.adminId, content, type);
-					setFileSaveResult(fileSaveResult);
+					this._setFileSaveResult(fileSaveResult);
 				}
 				catch (error) {
 					console.warn('Could not store content:', error);
@@ -93,16 +99,16 @@ export class MeasurementStorageService {
 			else {
 				try {
 					const fileSaveResult = await fileStorageService.save(null, content, type);
-					setFileSaveResult(fileSaveResult);
+					setMeasurementFileSaveResult(fileSaveResult);
 				}
 				catch (error) {
 					console.warn('Could not store content initially:', error);
-					setFileSaveResult(null);
+					this._setFileSaveResult(null);
 				}
 			}
 		}
 		else {
-			setFileSaveResult(null);
+			this._setFileSaveResult(null);
 		}
 	}
 }

--- a/test/modules/map/components/olMap/services/MeasurementStorageService.test.js
+++ b/test/modules/map/components/olMap/services/MeasurementStorageService.test.js
@@ -1,6 +1,7 @@
 import { $injector } from '../../../../../../src/injection';
 import { MeasurementStorageService } from '../../../../../../src/modules/map/components/olMap/services/MeasurementStorageService';
 import { FileStorageServiceDataTypes } from '../../../../../../src/services/FileStorageService';
+import { drawReducer } from '../../../../../../src/store/draw/draw.reducer';
 import { setFileSaveResult } from '../../../../../../src/store/measurement/measurement.action';
 import { measurementReducer } from '../../../../../../src/store/measurement/measurement.reducer';
 import { TestUtils } from '../../../../../test-utils.js';
@@ -30,8 +31,10 @@ describe('MeasurementStorageService', () => {
 
 	const setup = (state = initialState) => {
 		const measurementState = {
-			measurement: state };
-		const store = TestUtils.setupStoreAndDi(measurementState, { measurement: measurementReducer });
+			measurement: state,
+			draw: state
+		};
+		const store = TestUtils.setupStoreAndDi(measurementState, { measurement: measurementReducer, draw: drawReducer });
 		$injector.registerSingleton('TranslationService', { translate: (key) => key })
 			.registerSingleton('FileStorageService', fileStorageServiceMock);
 		return store;
@@ -55,8 +58,10 @@ describe('MeasurementStorageService', () => {
 
 		classUnderTest.setStorageId('f_someId');
 		expect(store.getState().measurement.fileSaveResult).toEqual({ fileId: 'f_someId', adminId: null });
+		expect(store.getState().draw.fileSaveResult).toEqual({ fileId: 'f_someId', adminId: null });
 		classUnderTest.setStorageId('a_someId');
 		expect(store.getState().measurement.fileSaveResult).toEqual({ fileId: null, adminId: 'a_someId' });
+		expect(store.getState().draw.fileSaveResult).toEqual({ fileId: null, adminId: 'a_someId' });
 	});
 
 	it('returns valid Id or null', () => {
@@ -66,6 +71,7 @@ describe('MeasurementStorageService', () => {
 		expect(classUnderTest.getStorageId()).toBe('init');
 		classUnderTest.setStorageId('a_someId');
 		expect(store.getState().measurement.fileSaveResult).toEqual({ fileId: null, adminId: 'a_someId' });
+		expect(store.getState().draw.fileSaveResult).toEqual({ fileId: null, adminId: 'a_someId' });
 		expect(classUnderTest.getStorageId()).toBeNull();
 		setFileSaveResult(null);
 		expect(classUnderTest.getStorageId()).toBeNull();
@@ -111,6 +117,7 @@ describe('MeasurementStorageService', () => {
 		await classUnderTest.store(content, FileStorageServiceDataTypes.KML);
 
 		expect(store.getState().measurement.fileSaveResult).toEqual({ fileId: 'fooBarId', adminId: 'barBazId' });
+		expect(store.getState().draw.fileSaveResult).toEqual({ fileId: 'fooBarId', adminId: 'barBazId' });
 		expect(saveSpy).toHaveBeenCalledTimes(1);
 		expect(saveSpy).toHaveBeenCalledWith(null, content, FileStorageServiceDataTypes.KML);
 
@@ -127,6 +134,7 @@ describe('MeasurementStorageService', () => {
 		await classUnderTest.store(content, FileStorageServiceDataTypes.KML);
 
 		expect(store.getState().measurement.fileSaveResult).toEqual({ fileId: 'fooBarId', adminId: 'barBazId' });
+		expect(store.getState().draw.fileSaveResult).toEqual({ fileId: 'fooBarId', adminId: 'barBazId' });
 		expect(saveSpy).toHaveBeenCalledTimes(1);
 		expect(saveSpy).toHaveBeenCalledWith('a_someId', content, FileStorageServiceDataTypes.KML);
 
@@ -140,6 +148,7 @@ describe('MeasurementStorageService', () => {
 		await classUnderTest.store(emptyContent, FileStorageServiceDataTypes.KML);
 
 		expect(store.getState().measurement.fileSaveResult).toBeNull();
+		expect(store.getState().draw.fileSaveResult).toBeNull();
 	});
 
 	it('logs a warning on initial store', async () => {
@@ -154,6 +163,7 @@ describe('MeasurementStorageService', () => {
 		await classUnderTest.store(content, FileStorageServiceDataTypes.KML);
 
 		expect(store.getState().measurement.fileSaveResult).toBeNull();
+		expect(store.getState().draw.fileSaveResult).toBeNull();
 		expect(warnSpy).toHaveBeenCalledWith('Could not store content initially:', jasmine.any(Error));
 	});
 
@@ -169,6 +179,7 @@ describe('MeasurementStorageService', () => {
 		await classUnderTest.store(content, FileStorageServiceDataTypes.KML);
 
 		expect(store.getState().measurement.fileSaveResult).toEqual({ fileId: 'f_someId', adminId: 'a_someId' });
+		expect(store.getState().draw.fileSaveResult).toEqual({ fileId: 'f_someId', adminId: 'a_someId' });
 		expect(warnSpy).toHaveBeenCalledWith('Could not store content:', jasmine.any(Error));
 	});
 


### PR DESCRIPTION
Fixing the behavior of MeasurementStorageService, to write the received FileSaveResult to both, draw- and measurement-store.

@taulinger : the fix writes currently in both slices (draw and measure) the same fileSaveResult, should we cut the store at this point into a extra data-slice (i could'nt find a good name ...storage?data? whatsoever...) in the store?

Instead of:  

- store/measurement/fileSaveResult
- store/draw/fileSaveResult

seperated in only:

- store/[data-slice]
