### PR TITLE
fix observer-registration

### DIFF
--- a/src/modules/map/components/olMap/handler/draw/OlDrawHandler.js
+++ b/src/modules/map/components/olMap/handler/draw/OlDrawHandler.js
@@ -212,8 +212,8 @@ export class OlDrawHandler extends OlLayerHandler {
 			this._listeners.push(olMap.on(MapBrowserEventType.POINTERMOVE, pointerMoveHandler));
 			this._listeners.push(olMap.on(MapBrowserEventType.DBLCLICK, () => false));
 			this._listeners.push(document.addEventListener('keyup', (e) => this._removeLast(e)));
-			this._registeredObservers = this._register(this._storeService.getStore());
 		}
+		this._registeredObservers = this._register(this._storeService.getStore());
 		this._map.addInteraction(this._select);
 		this._map.addInteraction(this._modify);
 		this._map.addInteraction(this._snap);

--- a/src/modules/map/components/olMap/handler/measure/OlMeasurementHandler.js
+++ b/src/modules/map/components/olMap/handler/measure/OlMeasurementHandler.js
@@ -69,7 +69,7 @@ export class OlMeasurementHandler extends OlLayerHandler {
 		this._helpTooltip = new HelpTooltip();
 		this._helpTooltip.messageProvideFunction = messageProvide;
 		this._measureStateChangedListeners = [];
-		this._registeredObservers = this._register(this._storeService.getStore());
+		this._registeredObservers = [];
 	}
 
 	/**
@@ -212,6 +212,7 @@ export class OlMeasurementHandler extends OlLayerHandler {
 			this._listeners.push(olMap.on(MapBrowserEventType.POINTERUP, pointerUpHandler));
 			this._listeners.push(olMap.on(MapBrowserEventType.DBLCLICK, () => false));
 			this._listeners.push(document.addEventListener('keyup', (e) => this._removeLast(e)));
+			this._registeredObservers = this._register(this._storeService.getStore());
 
 			olMap.addInteraction(this._select);
 			olMap.addInteraction(this._modify);

--- a/test/modules/map/components/olMap/handler/draw/OlDrawHandler.test.js
+++ b/test/modules/map/components/olMap/handler/draw/OlDrawHandler.test.js
@@ -357,6 +357,21 @@ describe('OlDrawHandler', () => {
 			});
 
 
+			it('register observer for reset-request again, after deactivate', () => {
+				setup();
+				const classUnderTest = new OlDrawHandler();
+				const map = setupMap();
+				map.addInteraction = jasmine.createSpy();
+				const resetSpy = spyOn(classUnderTest, '_reset').and.callThrough();
+
+				classUnderTest.activate(map);
+				reset();
+				classUnderTest.deactivate(map);
+				classUnderTest.activate(map);
+				reset();
+				expect(resetSpy).toHaveBeenCalledTimes(2);
+			});
+
 			it('register observer for remove-request', () => {
 				setup();
 				const classUnderTest = new OlDrawHandler();

--- a/test/modules/map/components/olMap/handler/measure/OlMeasurementHandler.test.js
+++ b/test/modules/map/components/olMap/handler/measure/OlMeasurementHandler.test.js
@@ -305,6 +305,21 @@ describe('OlMeasurementHandler', () => {
 				expect(startNewSpy).toHaveBeenCalled();
 			});
 
+			it('register observer for reset-request again, after deactivate', () => {
+				setup();
+				const classUnderTest = new OlMeasurementHandler();
+				const map = setupMap();
+				map.addInteraction = jasmine.createSpy();
+				const startNewSpy = spyOn(classUnderTest, '_startNew').and.callThrough();
+
+				classUnderTest.activate(map);
+				reset();
+				classUnderTest.deactivate(map);
+				classUnderTest.activate(map);
+				reset();
+				expect(startNewSpy).toHaveBeenCalledTimes(2);
+			});
+
 
 			it('register observer for remove-request', () => {
 				setup();


### PR DESCRIPTION
OlMeasurementHandler - move registration for store-changes
from ctor() to activate()

OlDrawHandler - move registration for store-changes within activate()

add tests for activate->reset->deactivate->activate-behavior

fixes #600 