### PR TITLE
georesources: assign optional properties by method

### DIFF
--- a/src/modules/map/components/olMap/services/VectorLayerService.js
+++ b/src/modules/map/components/olMap/services/VectorLayerService.js
@@ -149,7 +149,7 @@ export class VectorLayerService {
 		// If we know a better name for the geoResource now, we update the label
 		switch (geoResource.sourceType) {
 			case VectorSourceType.KML:
-				geoResource.label = format.readName(data) || geoResource.label;
+				geoResource.setLabel(format.readName(data) ?? geoResource.label);
 				break;
 		}
 		features.forEach(f => {

--- a/src/services/GeoResourceService.js
+++ b/src/services/GeoResourceService.js
@@ -149,8 +149,7 @@ export class GeoResourceService {
 			new WMTSGeoResource(FALLBACK_GEORESOURCE_ID_0, FALLBACK_GEORESOURCE_LABEL_0, 'https://intergeo{31-37}.bayernwolke.de/betty/g_atkis/{z}/{x}/{y}'),
 			new WMTSGeoResource(FALLBACK_GEORESOURCE_ID_1, FALLBACK_GEORESOURCE_LABEL_1, 'https://intergeo{31-37}.bayernwolke.de/betty/g_atkisgray/{z}/{x}/{y}')
 		].map(gr => {
-			gr.attribution = 'Bayerische Vermessungsverwaltung';
-			return gr;
+			return gr.setAttribution('Bayerische Vermessungsverwaltung');
 		});
 	}
 }

--- a/src/services/domain/geoResources.js
+++ b/src/services/domain/geoResources.js
@@ -30,6 +30,9 @@ export const GeoResourceTypes = Object.freeze({
 });
 
 /**
+* Parent class of all GeoResource types.
+* Obligatory fields are set in the constructor.
+* Optional fields have a setter method which returns the GeoResource instance for chaining.
 * @abstract
 * @class
 */
@@ -81,20 +84,24 @@ export class GeoResource {
 		return this._attribution;
 	}
 
-	set label(label) {
+	setLabel(label) {
 		this._label = label;
+		return this;
 	}
 
-	set background(background) {
+	setBackground(background) {
 		this._background = background;
+		return this;
 	}
 
-	set opacity(opacity) {
+	setOpacity(opacity) {
 		this._opacity = opacity;
+		return this;
 	}
 
-	set attribution(attribution) {
+	setAttribution(attribution) {
 		this._attribution = attribution;
+		return this;
 	}
 
 	/**

--- a/src/services/provider/geoResource.provider.js
+++ b/src/services/provider/geoResource.provider.js
@@ -30,8 +30,8 @@ export const _definitionToGeoResource = definition => {
 		geoResource.setAttributionProvider(getBvvAttribution);
 		geoResource.setAttribution(_parseBvvAttributionDefinition(definition));
 		//set optional values
-		geoResource.setBackground(definition.background);
-		geoResource.setOpacity(definition.opacity);
+		geoResource.setBackground(definition.background ?? geoResource.background);
+		geoResource.setOpacity(definition.opacity ?? geoResource.opacity);
 		return geoResource;
 	}
 	return null;

--- a/src/services/provider/geoResource.provider.js
+++ b/src/services/provider/geoResource.provider.js
@@ -28,9 +28,10 @@ export const _definitionToGeoResource = definition => {
 	const geoResource = toGeoResource(definition);
 	if (geoResource) {
 		geoResource.setAttributionProvider(getBvvAttribution);
-		geoResource.attribution = _parseBvvAttributionDefinition(definition);
-		geoResource.background = definition.background;
-		geoResource.opacity = definition.opacity;
+		geoResource.setAttribution(_parseBvvAttributionDefinition(definition));
+		//set optional values
+		geoResource.setBackground(definition.background);
+		geoResource.setOpacity(definition.opacity);
 		return geoResource;
 	}
 	return null;

--- a/test/modules/map/components/attributionInfo/AttributionInfo.test.js
+++ b/test/modules/map/components/attributionInfo/AttributionInfo.test.js
@@ -43,7 +43,7 @@ describe('AttributionInfo', () => {
 
 			const wmts = new WMTSGeoResource('someId', 'LDBV42', 'https://some{1-2}/layer/{z}/{x}/{y}');
 			const attribution = [42, 21];
-			wmts.attribution = attribution;
+			wmts.setAttribution(attribution);
 
 			const geoServiceMock = spyOn(geoResourceServiceMock, 'byId').withArgs(layer.id).and.returnValue(wmts);
 
@@ -149,9 +149,9 @@ describe('AttributionInfo', () => {
 			const arrayAttribution2 = ['foo', 'baz'];
 
 			const wmts = new WMTSGeoResource('someId', 'someLabel', 'https://some{1-2}/layer/{z}/{x}/{y}');
-			wmts.attribution = arrayAttribution1;
+			wmts.setAttribution(arrayAttribution1);
 			const wmts2 = new WMTSGeoResource('someId2', 'someLabel2', 'https://some{1-2}/layer/{z}/{x}/{y}');
-			wmts2.attribution = arrayAttribution2;
+			wmts2.setAttribution(arrayAttribution2);
 
 			const geoServiceMock = spyOn(geoResourceServiceMock, 'byId');
 			geoServiceMock.withArgs(layer.id).and.returnValue(wmts);
@@ -202,7 +202,7 @@ describe('AttributionInfo', () => {
 			const arrayAttribution = ['LDBV', 'Ref42'];
 
 			const wmts = new WMTSGeoResource('someId', 'someLabel', 'https://some{1-2}/layer/{z}/{x}/{y}');
-			wmts.attribution = arrayAttribution;
+			wmts.setAttribution(arrayAttribution);
 
 			const geoServiceMock = spyOn(geoResourceServiceMock, 'byId');
 			geoServiceMock.withArgs(layer.id).and.returnValue(wmts);
@@ -369,7 +369,7 @@ describe('AttributionInfo', () => {
 			};
 			const wmts = new WMTSGeoResource('someId', 'LDBV42', 'https://some{1-2}/layer/{z}/{x}/{y}');
 			const attribution = [42, 21];
-			wmts.attribution = attribution;
+			wmts.setAttribution(attribution);
 			const element = await setup(state);
 
 			expect(element.shadowRoot.querySelector('.attribution-container')).toBeTruthy();

--- a/test/plugins/LayersPlugin.test.js
+++ b/test/plugins/LayersPlugin.test.js
@@ -320,7 +320,7 @@ describe('LayersPlugin', () => {
 				const labelAfter = 'labelAfter';
 				const geoResource0 = new WMTSGeoResource(id, labelAfter, 'someUrl0');
 				const future0 = new GeoResourceFuture('some0', async () => geoResource0);
-				future0.label = labelBefore;
+				future0.setLabel(labelBefore);
 				spyOnProperty(windowMock.location, 'search').and.returnValue(queryParam);
 				spyOn(geoResourceServiceMock, 'asyncById').and.returnValue(future0);
 

--- a/test/service/ImportVectorDataService.test.js
+++ b/test/service/ImportVectorDataService.test.js
@@ -112,9 +112,9 @@ describe('ImportVectorDataService', () => {
 				const layer = { label: options.label };
 				addLayer(options.id, layer);
 
-				vgr.opacity = .5;
+				vgr.setOpacity(.5);
 				expect(store.getState().layers.active[0].label).toBe(options.label);
-				vgr.label = changedLabel;
+				vgr.setLabel(changedLabel);
 				expect(store.getState().layers.active[0].label).toBe(changedLabel);
 			});
 
@@ -268,9 +268,9 @@ describe('ImportVectorDataService', () => {
 			addLayer(options.id, layer);
 			const vgr = instanceUnderTest.importVectorData(data, options);
 
-			vgr.opacity = .5;
+			vgr.setOpacity(.5);
 			expect(store.getState().layers.active[0].label).toBe(options.label);
-			vgr.label = changedLabel;
+			vgr.setLabel(changedLabel);
 			expect(store.getState().layers.active[0].label).toBe(changedLabel);
 		});
 

--- a/test/service/domain/geoResources.test.js
+++ b/test/service/domain/geoResources.test.js
@@ -60,7 +60,7 @@ describe('GeoResource', () => {
 				const minimalAttribution = getMinimalAttribution();
 				const spy = jasmine.createSpy().and.returnValue(minimalAttribution);
 				const grs = new GeoResourceImpl('id');
-				grs.attribution = 'foo';
+				grs.setAttribution('foo');
 				grs._attributionProvider = spy;
 
 				const result = grs.getAttribution(42);
@@ -73,7 +73,7 @@ describe('GeoResource', () => {
 				const minimalAttribution = getMinimalAttribution();
 				const spy = jasmine.createSpy().and.returnValue([minimalAttribution]);
 				const grs = new GeoResourceImpl('id');
-				grs.attribution = 'foo';
+				grs.setAttribution ('foo');
 				grs._attributionProvider = spy;
 
 				const result = grs.getAttribution(42);
@@ -85,7 +85,7 @@ describe('GeoResource', () => {
 			it('returns null when provider returns null', () => {
 				const spy = jasmine.createSpy().and.returnValue(null);
 				const grs = new GeoResourceImpl('id');
-				grs.attribution = 'foo';
+				grs.setAttribution ('foo');
 				grs._attributionProvider = spy;
 
 				const result = grs.getAttribution(42);
@@ -97,7 +97,7 @@ describe('GeoResource', () => {
 			it('returns null when provider returns an empyt array', () => {
 				const spy = jasmine.createSpy().and.returnValue([]);
 				const grs = new GeoResourceImpl('id');
-				grs.attribution = 'foo';
+				grs.setAttribution ('foo');
 				grs._attributionProvider = spy;
 
 				const result = grs.getAttribution(42);
@@ -108,7 +108,7 @@ describe('GeoResource', () => {
 
 			it('throws an error when no provider found', () => {
 				const grs = new GeoResourceImpl('id');
-				grs.attribution = 'foo';
+				grs.setAttribution ('foo');
 				grs._attributionProvider = null;
 
 				expect(() => {
@@ -128,14 +128,15 @@ describe('GeoResource', () => {
 				expect(georesource._attributionProvider).toBe(getDefaultAttribution);
 			});
 
-			it('provides setter and getters', () => {
+			it('provides set methods and getters', () => {
 				const georesource = new GeoResourceNoImpl('id');
 
-				georesource.opacity = .5;
-				georesource.background = true;
-				georesource.label = 'some label';
-				georesource.label = 'some label';
-				georesource.attribution = 'some attribution';
+				georesource
+					.setOpacity(.5)
+					.setBackground(true)
+					.setLabel('some label')
+					.setAttribution('some attribution');
+
 
 				expect(georesource.background).toBeTrue();
 				expect(georesource.opacity).toBe(.5);
@@ -313,8 +314,8 @@ describe('GeoResource', () => {
 			const callback = jasmine.createSpy();
 			const wmtsGeoResource = observable(new WMTSGeoResource('wmtsId', 'label', 'url'), callback);
 
-			wmtsGeoResource.label = modifiedLabel;
-			wmtsGeoResource.label = modifiedLabel;
+			wmtsGeoResource.setLabel(modifiedLabel);
+			wmtsGeoResource.setLabel(modifiedLabel);
 			wmtsGeoResource.unknown = modifiedLabel;
 
 			expect(callback).toHaveBeenCalledOnceWith('_label', modifiedLabel);

--- a/test/service/provider/geoResource.provider.test.js
+++ b/test/service/provider/geoResource.provider.test.js
@@ -22,16 +22,20 @@ describe('BVV GeoResource provider', () => {
 		copyright: 'copyright'
 	};
 
-	const wmsDefinition = { id: 'wmsId', label: 'wmsLabel', background: false, opacity: 0.5, url: 'wmsUrl', layers: 'wmsLayer', format: 'image/png', type: 'wms', attribution: basicAttribution };
-	const wmtsDefinition = { id: 'wmtsId', label: 'wmtsLabel', background: true, opacity: 1.0, url: 'wmtsUrl', type: 'wmts', attribution: basicAttribution };
-	const vectorDefinition = { id: 'wmtsId', label: 'vectorLabel', background: false, opacity: 1.0, url: 'vectorUrl', sourceType: 'kml', type: 'vector', attribution: basicAttribution };
-	const aggregateDefinition = { id: 'wmtsId', label: 'aggregateLabel', background: true, opacity: 1.0, geoResourceIds: ['wmtsId', 'wmsId'], type: 'aggregate', attribution: basicAttribution };
+	const wmsDefinition = { id: 'wmsId', label: 'wmsLabel', url: 'wmsUrl', layers: 'wmsLayer', format: 'image/png', type: 'wms', attribution: basicAttribution };
+	const wmsDefinitionOptionalProperties = { id: 'wmsId', label: 'wmsLabel', background: true, opacity: 0.5, url: 'wmsUrl', layers: 'wmsLayer', format: 'image/png', type: 'wms', attribution: basicAttribution };
+	const wmtsDefinition = { id: 'wmtsId', label: 'wmtsLabel', url: 'wmtsUrl', type: 'wmts', attribution: basicAttribution };
+	const wmtsDefinitionOptionalProperties = { id: 'wmtsId', label: 'wmtsLabel', background: true, opacity: 0.5, url: 'wmtsUrl', type: 'wmts', attribution: basicAttribution };
+	const vectorDefinition = { id: 'wmtsId', label: 'vectorLabel', url: 'vectorUrl', sourceType: 'kml', type: 'vector', attribution: basicAttribution };
+	const vectorDefinitionOptionaProperties = { id: 'wmtsId', label: 'vectorLabel', background: true, opacity: 0.5, url: 'vectorUrl', sourceType: 'kml', type: 'vector', attribution: basicAttribution };
+	const aggregateDefinition = { id: 'wmtsId', label: 'aggregateLabel', geoResourceIds: ['wmtsId', 'wmsId'], type: 'aggregate', attribution: basicAttribution };
+	const aggregateDefinitionOptionalProperties = { id: 'wmtsId', label: 'aggregateLabel', background: true, opacity: 0.5, geoResourceIds: ['wmtsId', 'wmsId'], type: 'aggregate', attribution: basicAttribution };
 
 	const vadlidateGeoResourceProperties = (georesource, definition) => {
 		expect(georesource.id).toBe(definition.id);
 		expect(georesource.label).toBe(definition.label);
-		expect(georesource.background).toBe(definition.background);
-		expect(georesource.opacity).toBe(definition.opacity);
+		expect(georesource.background).toBeFalse();
+		expect(georesource.opacity).toBe(1.0);
 		expect(Symbol.keyFor(georesource.getType())).toBe(definition.type);
 	};
 
@@ -53,6 +57,13 @@ describe('BVV GeoResource provider', () => {
 			expect(wmsGeoResource._attribution).not.toBeNull();
 		});
 
+		it('maps a WMS BVV definition with optional properties to a corresponding GeoResource instance', () => {
+			const wmsGeoResource = _definitionToGeoResource(wmsDefinitionOptionalProperties);
+
+			expect(wmsGeoResource.background).toBeTrue();
+			expect(wmsGeoResource.opacity).toBe(0.5);
+		});
+
 		it('maps a WMTS BVV definition to a corresponding GeoResource instance', () => {
 			const wmtsGeoResource = _definitionToGeoResource(wmtsDefinition);
 
@@ -60,6 +71,13 @@ describe('BVV GeoResource provider', () => {
 			expect(wmtsGeoResource.url).toBe(wmtsGeoResource.url);
 			expect(wmtsGeoResource._attributionProvider).toBe(getBvvAttribution);
 			expect(wmtsGeoResource._attribution).not.toBeNull();
+		});
+
+		it('maps a WMTS BVV definition with optional properties to a corresponding GeoResource instance', () => {
+			const wmtsGeoResource = _definitionToGeoResource(wmtsDefinitionOptionalProperties);
+
+			expect(wmtsGeoResource.background).toBeTrue();
+			expect(wmtsGeoResource.opacity).toBe(0.5);
 		});
 
 		it('maps a VectorFile BVV definition to a corresponding GeoResource instance', () => {
@@ -72,6 +90,13 @@ describe('BVV GeoResource provider', () => {
 			expect(vectorGeoResource._attribution).not.toBeNull();
 		});
 
+		it('maps a VectorFile BVV definition with optional properties to a corresponding GeoResource instance', () => {
+			const vectorGeoResource = _definitionToGeoResource(vectorDefinitionOptionaProperties);
+
+			expect(vectorGeoResource.background).toBeTrue();
+			expect(vectorGeoResource.opacity).toBe(0.5);
+		});
+
 		it('maps a aggregate BVV definition to a corresponding GeoResource instance', () => {
 			const aggregateGeoResource = _definitionToGeoResource(aggregateDefinition);
 
@@ -79,6 +104,13 @@ describe('BVV GeoResource provider', () => {
 			expect(aggregateGeoResource.geoResourceIds).toEqual(aggregateDefinition.geoResourceIds);
 			expect(aggregateGeoResource._attributionProvider).toBe(getBvvAttribution);
 			expect(aggregateGeoResource._attribution).not.toBeNull();
+		});
+
+		it('maps a aggregate BVV definition with optional properties to a corresponding GeoResource instance', () => {
+			const aggregateGeoResource = _definitionToGeoResource(aggregateDefinitionOptionalProperties);
+
+			expect(aggregateGeoResource.background).toBeTrue();
+			expect(aggregateGeoResource.opacity).toBe(0.5);
 		});
 	});
 


### PR DESCRIPTION
Improves and unifies handling of optional properties for GeoResources and provides a basis for adding further optional properties for all kinds of GeoResources.