### PR TITLE
fix unintended activation of Dropzone

### DIFF
--- a/src/modules/dndImport/components/DndImportPanel.js
+++ b/src/modules/dndImport/components/DndImportPanel.js
@@ -51,8 +51,12 @@ export class DndImportPanel extends MvuElement {
 		const onDragEnter = (e) => {
 			stopRedirectAndDefaultHandler(e);
 			const types = e.dataTransfer.types || [];
-			const importType = types.find(t => /(files|text\/plain)/i.test(t));
 
+			if (types.length === 0) {
+				return;
+			}
+
+			const importType = types.find(t => /(files|text\/plain)/i.test(t));
 			const signalImport = (importType) => {
 				const content = importType === MediaType.TEXT_PLAIN ? translate('dndImport_import_textcontent') : translate('dndImport_import_filecontent');
 				this.signal(Update_DropZone_Content, content);
@@ -60,7 +64,6 @@ export class DndImportPanel extends MvuElement {
 			const signalNoImport = () => {
 				this.signal(Update_DropZone_Content, translate('dndImport_import_unknown'));
 			};
-
 			const importAction = importType ? signalImport : signalNoImport;
 			importAction(importType);
 		};

--- a/test/modules/dndImport/components/DndImportPanel.test.js
+++ b/test/modules/dndImport/components/DndImportPanel.test.js
@@ -10,7 +10,7 @@ import { TestUtils } from '../../../test-utils';
 
 window.customElements.define(DndImportPanel.tag, DndImportPanel);
 
-describe('FeatureInfoPanel', () => {
+describe('DndImportPanel', () => {
 	let store;
 	const setup = (state) => {
 
@@ -131,24 +131,24 @@ describe('FeatureInfoPanel', () => {
 				expect(element.getModel().isActive).toBeTrue();
 			});
 
-			it('updates the model for a dragged but empty type', async () => {
+			it('updates NOT the model for a dragged but empty type', async () => {
 				const dataTransferMock = { ...defaultDataTransferMock };
 				const element = await setup();
 
 				simulateDragDropEvent('dragenter', dataTransferMock);
 
-				expect(element.getModel().dropzoneContent).toBe('dndImport_import_unknown');
-				expect(element.getModel().isActive).toBeTrue();
+				expect(element.getModel().dropzoneContent).toBeNull();
+				expect(element.getModel().isActive).toBeFalse();
 			});
 
-			it('updates the model for a dragged but undefined types', async () => {
+			it('updates NOT the model for a dragged but undefined types', async () => {
 				const dataTransferMock = { ...defaultDataTransferMock, types: undefined };
 				const element = await setup();
 
 				simulateDragDropEvent('dragenter', dataTransferMock);
 
-				expect(element.getModel().dropzoneContent).toBe('dndImport_import_unknown');
-				expect(element.getModel().isActive).toBeTrue();
+				expect(element.getModel().dropzoneContent).toBeNull();
+				expect(element.getModel().isActive).toBeFalse();
 			});
 		});
 
@@ -394,7 +394,7 @@ describe('FeatureInfoPanel', () => {
 			});
 
 			it('updates the model', async () => {
-				const dataTransferMock = { ...defaultDataTransferMock };
+				const dataTransferMock = { ...defaultDataTransferMock, types: ['some'] };
 				const element = await setup();
 				const dropZone = element.shadowRoot.querySelector('#dropzone');
 

--- a/test/modules/dndImport/components/DndImportPanel.test.js
+++ b/test/modules/dndImport/components/DndImportPanel.test.js
@@ -131,7 +131,7 @@ describe('DndImportPanel', () => {
 				expect(element.getModel().isActive).toBeTrue();
 			});
 
-			it('updates NOT the model for a dragged but empty type', async () => {
+			it('does NOT update the model for a dragged but empty type', async () => {
 				const dataTransferMock = { ...defaultDataTransferMock };
 				const element = await setup();
 
@@ -141,7 +141,7 @@ describe('DndImportPanel', () => {
 				expect(element.getModel().isActive).toBeFalse();
 			});
 
-			it('updates NOT the model for a dragged but undefined types', async () => {
+			it('does NOT update the model for a dragged but undefined types', async () => {
 				const dataTransferMock = { ...defaultDataTransferMock, types: undefined };
 				const element = await setup();
 


### PR DESCRIPTION
update of the drag&drop-behavior in DndImportPanel, where a
unintended activation of the dropzone by dragged LayerItems is
prevented by checking for emptyness of the dataTransfer.types-Array.
Any other type than the known importTypes (File, text/plain) will
still result in a message being displayed.