### PR TITLE
alter BaseLayerSwitcher behavior

### DIFF
--- a/src/modules/baseLayer/components/switcher/BaseLayerSwitcher.js
+++ b/src/modules/baseLayer/components/switcher/BaseLayerSwitcher.js
@@ -56,7 +56,9 @@ export class BaseLayerSwitcher extends MvuElement {
 
 		if (layersStoreReady) {
 
-			// Carefully differentiate between layer ids and geoResource ids!
+			/**
+			 * carefully differentiate between layer ids and geoResource ids!
+			 */
 
 			const { baseGeoRs: baseGeoRIds } = this._topicsService.byId(currentTopicId);
 			const currentBaseLayerGeoResourceId = activeLayers[0] ? activeLayers[0].geoResourceId : null;
@@ -67,18 +69,18 @@ export class BaseLayerSwitcher extends MvuElement {
 			const onClick = (geoR) => {
 
 				const add = () => {
-					//we create always a unique layer id
+					// we create always a unique layer id
 					addLayer(`${geoR.id}_${createUniqueId()}`, { label: geoR.label, zIndex: 0, geoResourceId: geoR.id });
 				};
 
 				if (activeLayers.length > 0) {
-					//noting todo when requested base GeoResource already on index=0
+					// noting todo when requested base GeoResource already on index=0
 					if (activeLayers[0].geoResourceId !== geoR.id) {
-						//if we have a layer referencing a base GeoResource on index=0, we remove it
+						// if we have a layer referencing a base GeoResource on index=0, we remove it
 						if (baseGeoRIds.includes(activeLayers[0].geoResourceId)) {
 							removeLayer(activeLayers[0].id);
 						}
-						//add selected layer
+						// add selected layer
 						add();
 					}
 				}
@@ -104,7 +106,7 @@ export class BaseLayerSwitcher extends MvuElement {
 				</div>
 			`;
 		}
-		//Todo: in this case we should render a placeholder
+		// should we render a placeholder for that case?
 		return nothing;
 	}
 

--- a/src/modules/baseLayer/components/switcher/BaseLayerSwitcher.js
+++ b/src/modules/baseLayer/components/switcher/BaseLayerSwitcher.js
@@ -56,14 +56,13 @@ export class BaseLayerSwitcher extends MvuElement {
 
 		if (layersStoreReady) {
 
+			// Carefully differentiate between layer ids and geoResource ids!
+
 			const { baseGeoRs: baseGeoRIds } = this._topicsService.byId(currentTopicId);
 			const currentBaseLayerGeoResourceId = activeLayers[0] ? activeLayers[0].geoResourceId : null;
-
-
 			const geoRs = baseGeoRIds
 				.map(grId => this._geoResourceService.byId(grId))
 				.filter(geoR => !!geoR);
-
 
 			const onClick = (geoR) => {
 
@@ -75,9 +74,8 @@ export class BaseLayerSwitcher extends MvuElement {
 				if (activeLayers.length > 0) {
 					//noting todo when requested base GeoResource already on index=0
 					if (activeLayers[0].geoResourceId !== geoR.id) {
-						//if we have a base GeoResource on index=0, we remove it
+						//if we have a layer referencing a base GeoResource on index=0, we remove it
 						if (baseGeoRIds.includes(activeLayers[0].geoResourceId)) {
-							//Remove existing
 							removeLayer(activeLayers[0].id);
 						}
 						//add selected layer

--- a/src/modules/baseLayer/components/switcher/BaseLayerSwitcher.js
+++ b/src/modules/baseLayer/components/switcher/BaseLayerSwitcher.js
@@ -3,13 +3,14 @@ import { $injector } from '../../../../injection';
 import { addLayer, removeLayer } from '../../../../store/layers/layers.action';
 import css from './baseLayerSwitcher.css';
 import { MvuElement } from '../../../MvuElement';
+import { createUniqueId } from '../../../../utils/numberUtils';
 
 
 const Update_Topic_Id = 'update_topic_id';
 const Update_Layers = 'update_layers';
 const Update_Is_Layers_Store_Ready = 'update_is_layers_store_ready';
 /**
- * Component for managing base layers.
+ * Displays and handles GeoResources defined to act as base layers.
  * @class
  * @author taulinger
  */
@@ -56,7 +57,7 @@ export class BaseLayerSwitcher extends MvuElement {
 		if (layersStoreReady) {
 
 			const { baseGeoRs: baseGeoRIds } = this._topicsService.byId(currentTopicId);
-			const currentBaseLayerId = activeLayers[0] ? activeLayers[0].geoResourceId : null;
+			const currentBaseLayerGeoResourceId = activeLayers[0] ? activeLayers[0].geoResourceId : null;
 
 
 			const geoRs = baseGeoRIds
@@ -67,27 +68,29 @@ export class BaseLayerSwitcher extends MvuElement {
 			const onClick = (geoR) => {
 
 				const add = () => {
-					addLayer(geoR.id, { label: geoR.label, zIndex: 0 });
+					//we create always a unique layer id
+					addLayer(`${geoR.id}_${createUniqueId()}`, { label: geoR.label, zIndex: 0, geoResourceId: geoR.id });
 				};
 
 				if (activeLayers.length > 0) {
+					//noting todo when requested base GeoResource already on index=0
 					if (activeLayers[0].geoResourceId !== geoR.id) {
-						//Remove existing
-						geoRs.forEach(geoR => {
-							removeLayer(geoR.id);
-						});
+						//if we have a base GeoResource on index=0, we remove it
+						if (baseGeoRIds.includes(activeLayers[0].geoResourceId)) {
+							//Remove existing
+							removeLayer(activeLayers[0].id);
+						}
 						//add selected layer
 						add();
 					}
 				}
 				else {
-					//add selected layer
 					add();
 				}
 			};
 
 			const getType = (geoR) => {
-				return (geoR.id === currentBaseLayerId) ? 'primary' : 'secondary';
+				return (geoR.id === currentBaseLayerGeoResourceId) ? 'primary' : 'secondary';
 			};
 
 			return html`

--- a/test/modules/baseLayer/components/BaseLayerSwitcher.test.js
+++ b/test/modules/baseLayer/components/BaseLayerSwitcher.test.js
@@ -132,39 +132,80 @@ describe('BaseLayerSwitcher', () => {
 
 	describe('when element clicked ', () => {
 
-		describe('and some layer are active ', () => {
+		describe('and some layers are active ', () => {
 
-			it('removes the current base layer and adds the new layer on index 0', async () => {
+			describe('base layer on index=0', () => {
 
-				const topicsId = 'topicId';
-				const geoResoureceId0 = 'geoRsId0';
-				const geoResoureceId1 = 'geoRsId1';
-				const geoResoureceId2 = 'geoRsId2';
-				const baseLayer0 = createDefaultLayer(geoResoureceId0);
-				const otherLayer = createDefaultLayer(geoResoureceId1);
-				const state = {
-					topics: {
-						current: topicsId
-					},
-					layers: {
-						ready: true,
-						active: [baseLayer0, otherLayer]
-					}
-				};
-				spyOn(topicsServiceMock, 'byId').and.returnValue(new Topic(topicsId, 'label', 'description', [geoResoureceId0, geoResoureceId2]));
-				spyOn(geoResourceServiceMock, 'byId').and.callFake((id) => {
-					return new WMTSGeoResource(id, `${id}Label`, 'someUrl');
+				it('removes the current base layer on index=0 and adds the new layer on index=0', async () => {
+
+					const topicsId = 'topicId';
+					const geoResoureceId0 = 'geoRsId0';
+					const geoResoureceId1 = 'geoRsId1';
+					const geoResoureceId2 = 'geoRsId2';
+					const baseLayer0 = createDefaultLayer(geoResoureceId0);
+					const otherLayer = createDefaultLayer(geoResoureceId1);
+					const state = {
+						topics: {
+							current: topicsId
+						},
+						layers: {
+							ready: true,
+							active: [baseLayer0, otherLayer]
+						}
+					};
+					spyOn(topicsServiceMock, 'byId').and.returnValue(new Topic(topicsId, 'label', 'description', [geoResoureceId0, geoResoureceId2]));
+					spyOn(geoResourceServiceMock, 'byId').and.callFake((id) => {
+						return new WMTSGeoResource(id, `${id}Label`, 'someUrl');
+					});
+					const element = await setup(state);
+					const buttons = element.shadowRoot.querySelectorAll('.baselayer__button');
+
+					//let's add the second baseLayer
+					buttons[1].click();
+
+					expect(store.getState().layers.active.length).toBe(2);
+					expect(store.getState().layers.active[0].id).toContain(geoResoureceId2);
+					expect(store.getState().layers.active[0].geoResourceId).toBe(geoResoureceId2);
+					expect(store.getState().layers.active[0].label).toBe(geoResoureceId2 + 'Label');
+					expect(store.getState().layers.active[0].zIndex).toBe(0);
 				});
-				const element = await setup(state);
-				const buttons = element.shadowRoot.querySelectorAll('.baselayer__button');
+			});
 
-				//let's add the second baseLayer
-				buttons[1].click();
+			describe('base layer on index > 0', () => {
 
-				expect(store.getState().layers.active.length).toBe(2);
-				expect(store.getState().layers.active[0].id).toBe(geoResoureceId2);
-				expect(store.getState().layers.active[0].label).toBe(geoResoureceId2 + 'Label');
-				expect(store.getState().layers.active[0].zIndex).toBe(0);
+				it('adds the new layer on index=0', async () => {
+
+					const topicsId = 'topicId';
+					const geoResoureceId0 = 'geoRsId0';
+					const geoResoureceId1 = 'geoRsId1';
+					const geoResoureceId2 = 'geoRsId2';
+					const baseLayer0 = createDefaultLayer(geoResoureceId0);
+					const otherLayer = createDefaultLayer(geoResoureceId1);
+					const state = {
+						topics: {
+							current: topicsId
+						},
+						layers: {
+							ready: true,
+							active: [otherLayer, baseLayer0]
+						}
+					};
+					spyOn(topicsServiceMock, 'byId').and.returnValue(new Topic(topicsId, 'label', 'description', [geoResoureceId0, geoResoureceId2]));
+					spyOn(geoResourceServiceMock, 'byId').and.callFake((id) => {
+						return new WMTSGeoResource(id, `${id}Label`, 'someUrl');
+					});
+					const element = await setup(state);
+					const buttons = element.shadowRoot.querySelectorAll('.baselayer__button');
+
+					//let's add the second baseLayer
+					buttons[1].click();
+
+					expect(store.getState().layers.active.length).toBe(3);
+					expect(store.getState().layers.active[0].id).toContain(geoResoureceId2);
+					expect(store.getState().layers.active[0].geoResourceId).toBe(geoResoureceId2);
+					expect(store.getState().layers.active[0].label).toBe(geoResoureceId2 + 'Label');
+					expect(store.getState().layers.active[0].zIndex).toBe(0);
+				});
 			});
 
 			it('does nothing when layer is already on map', async () => {
@@ -226,7 +267,8 @@ describe('BaseLayerSwitcher', () => {
 				buttons[0].click();
 
 				expect(store.getState().layers.active.length).toBe(1);
-				expect(store.getState().layers.active[0].id).toBe(geoResoureceId0);
+				expect(store.getState().layers.active[0].id).toContain(geoResoureceId0);
+				expect(store.getState().layers.active[0].geoResourceId).toBe(geoResoureceId0);
 				expect(store.getState().layers.active[0].label).toBe(geoResoureceId0 + 'Label');
 				expect(store.getState().layers.active[0].zIndex).toBe(0);
 			});

--- a/test/modules/baseLayer/components/BaseLayerSwitcher.test.js
+++ b/test/modules/baseLayer/components/BaseLayerSwitcher.test.js
@@ -35,6 +35,20 @@ describe('BaseLayerSwitcher', () => {
 		return TestUtils.render(BaseLayerSwitcher.tag);
 	};
 
+	describe('when instantiated', () => {
+
+		it('has a model containing default values', async () => {
+			await setup();
+			const model = new BaseLayerSwitcher().getModel();
+
+			expect(model).toEqual({
+				currentTopicId: null,
+				activeLayers: [],
+				layersStoreReady: false
+			});
+		});
+	});
+
 	describe('when initialized ', () => {
 
 		it('renders nothing when layers state not yet set ready', async () => {


### PR DESCRIPTION
Allow multiple layers for the same GeoResource.
When a layer referencing a base GeoResource is not on index = 0, a second layer for that GeoResource can be added.

Fixes #705