### PR TITLE
Default-Style use layer-based color

### DIFF
--- a/src/modules/map/components/olMap/handler/draw/OlDrawHandler.js
+++ b/src/modules/map/components/olMap/handler/draw/OlDrawHandler.js
@@ -147,7 +147,7 @@ export class OlDrawHandler extends OlLayerHandler {
 						f.getGeometry().transform('EPSG:' + vgr.srid, 'EPSG:' + this._mapService.getSrid());
 						f.set('srid', this._mapService.getSrid(), true);
 						this._styleService.removeStyle(f, olMap);
-						this._styleService.addStyle(f, olMap);
+						this._styleService.addStyle(f, olMap, layer);
 						layer.getSource().addFeature(f);
 						f.on('change', onFeatureChange);
 					});

--- a/src/modules/map/components/olMap/handler/measure/OlMeasurementHandler.js
+++ b/src/modules/map/components/olMap/handler/measure/OlMeasurementHandler.js
@@ -128,7 +128,7 @@ export class OlMeasurementHandler extends OlLayerHandler {
 						f.set('srid', this._mapService.getSrid(), true);
 						layer.getSource().addFeature(f);
 						this._styleService.removeStyle(f, olMap);
-						this._styleService.addStyle(f, olMap);
+						this._styleService.addStyle(f, olMap, layer);
 						f.on('change', onFeatureChange);
 					});
 					removeLayer(oldLayer.get('id'));
@@ -420,7 +420,7 @@ export class OlMeasurementHandler extends OlLayerHandler {
 
 		draw.on('drawend', event => {
 			finishDistanceOverlay(event);
-			this._styleService.addStyle(event.feature, this._map);
+			this._styleService.addStyle(event.feature, this._map, this._vectorLayer);
 			this._activateModify(event.feature);
 		}
 		);

--- a/src/modules/map/components/olMap/services/StyleService.js
+++ b/src/modules/map/components/olMap/services/StyleService.js
@@ -76,9 +76,6 @@ export class StyleService {
 			case StyleTypes.MEASURE:
 				this._addMeasureStyle(olFeature, olMap);
 				break;
-			case StyleTypes.DRAW:
-				this._addBaseStyle(olFeature);
-				break;
 			case StyleTypes.TEXT:
 				this._addTextStyle(olFeature);
 				break;
@@ -241,10 +238,6 @@ export class StyleService {
 		const newStyle = markerStyleFunction(getStyleOption(olFeature));
 
 		olFeature.setStyle(() => newStyle);
-	}
-
-	_addBaseStyle(olFeature) {
-		olFeature.setStyle(nullStyleFunction);
 	}
 
 	_addDefaultStyle(olFeature, olLayer = null) {

--- a/src/modules/map/components/olMap/services/StyleService.js
+++ b/src/modules/map/components/olMap/services/StyleService.js
@@ -66,13 +66,10 @@ export class StyleService {
 	 * @param {ol.Feature} olFeature the feature to be styled
 	 * @param {ol.Map} olMap the map, where overlays related to the feature-style will be added
 	 * @param {ol.Layer} olLayer the layer of the feature, used for layer-wide color in the default style
-	 * @param {StyleType|null} styleType the styletype, if not explicit specified (styletype==null|undefined),
-	 * the styleType will be implicitly detect by the feature-id. If no matching to known styleTypes exists,
-	 * no styles or overlays will be added.
 	 */
-	addStyle(olFeature, olMap, olLayer, styleType = null) {
-		const usingStyleType = styleType ? styleType : this._detectStyleType(olFeature);
-		switch (usingStyleType) {
+	addStyle(olFeature, olMap, olLayer) {
+		const styleType = this._detectStyleType(olFeature);
+		switch (styleType) {
 			case StyleTypes.MEASURE:
 				this._addMeasureStyle(olFeature, olMap);
 				break;
@@ -93,7 +90,7 @@ export class StyleService {
 				this._addDefaultStyle(olFeature, olLayer);
 				break;
 			default:
-				console.warn('Could not provide a style for unknown style-type:', usingStyleType);
+				console.warn('Could not provide a style for unknown style-type');
 				break;
 		}
 	}

--- a/src/modules/map/components/olMap/services/StyleService.js
+++ b/src/modules/map/components/olMap/services/StyleService.js
@@ -238,17 +238,17 @@ export class StyleService {
 		olFeature.setStyle(nullStyleFunction);
 	}
 
-	_addDefaultStyle(olFeature, olLayer) {
-		const id = getUid(olLayer);
-		const getDefaultColorByLayerId = (id) => {
-
+	_addDefaultStyle(olFeature, olLayer = null) {
+		const getColorByLayerId = (layer) => {
+			const id = getUid(layer);
 			if (this._defaultColorByLayerId[id] === undefined) {
 				this._defaultColorByLayerId[id] = this._nextColor();
 			}
 			return [...this._defaultColorByLayerId[id]];
 		};
 
-		olFeature.setStyle(defaultStyleFunction(getDefaultColorByLayerId(id)));
+		const color = olLayer ? getColorByLayerId(olLayer) : this._nextColor();
+		olFeature.setStyle(defaultStyleFunction(color));
 	}
 
 	_detectStyleType(olFeature) {

--- a/src/modules/map/components/olMap/services/VectorLayerService.js
+++ b/src/modules/map/components/olMap/services/VectorLayerService.js
@@ -55,7 +55,7 @@ export class VectorLayerService {
 
 
 		const addFeatureListenerKey = olVectorSource.on('addfeature', event => {
-			styleService.addStyle(event.feature, olMap);
+			styleService.addStyle(event.feature, olMap, olLayer);
 			this._updateStyle(event.feature, olLayer, olMap);
 		});
 		const removeFeatureListenerKey = olVectorSource.on('removefeature', event => {
@@ -101,7 +101,7 @@ export class VectorLayerService {
 			this._registerStyleEventListeners(olVectorSource, olVectorLayer, olMap);
 			olVectorSource.getFeatures().forEach(feature => {
 				if (styleService.isStyleRequired(feature)) {
-					styleService.addStyle(feature, olMap);
+					styleService.addStyle(feature, olMap, olVectorLayer);
 					this._updateStyle(feature, olVectorLayer, olMap);
 				}
 			});

--- a/test/modules/map/components/olMap/handler/draw/OlDrawHandler.test.js
+++ b/test/modules/map/components/olMap/handler/draw/OlDrawHandler.test.js
@@ -846,6 +846,32 @@ describe('OlDrawHandler', () => {
 			});
 		});
 
+
+		it('adds style on old features', (done) => {
+			setup();
+			const classUnderTest = new OlDrawHandler();
+			const lastData = '<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/kml/2.2 https://developers.google.com/kml/schema/kml22gx.xsd"><Placemark id="measurement_1620710146878"><Style><LineStyle><color>ff0000ff</color><width>3</width></LineStyle><PolyStyle><color>660000ff</color></PolyStyle></Style><ExtendedData><Data name="area"/><Data name="measurement"/><Data name="partitions"/></ExtendedData><Polygon><outerBoundaryIs><LinearRing><coordinates>10.66758401,50.09310529 11.77182103,50.08964948 10.57062661,49.66616988 10.66758401,50.09310529</coordinates></LinearRing></outerBoundaryIs></Polygon></Placemark></kml>';
+			const map = setupMap();
+			const vectorGeoResource = new VectorGeoResource('a_lastId', 'foo', VectorSourceType.KML).setSource(lastData, 4326);
+
+			spyOn(map, 'getLayers').and.returnValue({ getArray: () => [{ get: () => 'a_lastId' }] });
+			spyOn(interactionStorageServiceMock, 'isStorageId').and.callFake(() => true);
+			spyOn(classUnderTest._overlayService, 'add').and.callFake(() => { });
+			spyOn(geoResourceServiceMock, 'byId').and.returnValue(vectorGeoResource);
+			const addStyleSpy = spyOn(classUnderTest._styleService, 'addStyle');
+			let oldFeature;
+
+			classUnderTest.activate(map);
+			spyOn(classUnderTest._vectorLayer.getSource(), 'addFeature').and.callFake((f) => {
+				oldFeature = f;
+			});
+
+			setTimeout(() => {
+				expect(addStyleSpy).toHaveBeenCalledWith(oldFeature, map, classUnderTest._vectorLayer);
+				done();
+			});
+		});
+
 		it('updates style of old features onChange', (done) => {
 			setup();
 			const classUnderTest = new OlDrawHandler();

--- a/test/modules/map/components/olMap/handler/measure/OlMeasurementHandler.test.js
+++ b/test/modules/map/components/olMap/handler/measure/OlMeasurementHandler.test.js
@@ -482,6 +482,32 @@ describe('OlMeasurementHandler', () => {
 			});
 		});
 
+		it('adds style on old features', (done) => {
+			setup();
+			const classUnderTest = new OlMeasurementHandler();
+			const lastData = '<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/kml/2.2 https://developers.google.com/kml/schema/kml22gx.xsd"><Placemark id="measurement_1620710146878"><Style><LineStyle><color>ff0000ff</color><width>3</width></LineStyle><PolyStyle><color>660000ff</color></PolyStyle></Style><ExtendedData><Data name="area"/><Data name="measurement"/><Data name="partitions"/></ExtendedData><Polygon><outerBoundaryIs><LinearRing><coordinates>10.66758401,50.09310529 11.77182103,50.08964948 10.57062661,49.66616988 10.66758401,50.09310529</coordinates></LinearRing></outerBoundaryIs></Polygon></Placemark></kml>';
+			const map = setupMap();
+			const vectorGeoResource = new VectorGeoResource('a_lastId', 'foo', VectorSourceType.KML).setSource(lastData, 4326);
+
+
+			spyOn(map, 'getLayers').and.returnValue({ getArray: () => [{ get: () => 'a_lastId' }] });
+			spyOn(interactionStorageServiceMock, 'isStorageId').and.callFake(() => true);
+			spyOn(classUnderTest._overlayService, 'add').and.callFake(() => { });
+			spyOn(geoResourceServiceMock, 'byId').and.returnValue(vectorGeoResource);
+			const addStyleSpy = spyOn(classUnderTest._styleService, 'addStyle');
+			let oldFeature;
+
+			classUnderTest.activate(map);
+			spyOn(classUnderTest._vectorLayer.getSource(), 'addFeature').and.callFake((f) => {
+				oldFeature = f;
+			});
+
+			setTimeout(() => {
+				expect(addStyleSpy).toHaveBeenCalledWith(oldFeature, map, classUnderTest._vectorLayer);
+				done();
+			});
+		});
+
 
 		it('updates overlays of old features onChange', (done) => {
 			setup();

--- a/test/modules/map/components/olMap/services/StyleService.test.js
+++ b/test/modules/map/components/olMap/services/StyleService.test.js
@@ -112,8 +112,9 @@ describe('StyleService', () => {
 					return { getArray: () => [] };
 				}
 			};
+			const layerMock = {};
 
-			instanceUnderTest.addStyle(feature, mapMock);
+			instanceUnderTest.addStyle(feature, mapMock, layerMock);
 
 			expect(styleSetterSpy).toHaveBeenCalledWith(jasmine.any(Function));
 			expect(propertySetterSpy).toHaveBeenCalledWith('overlays', jasmine.any(Object));
@@ -143,7 +144,9 @@ describe('StyleService', () => {
 				}
 			};
 
-			instanceUnderTest.addStyle(feature, mapMock, StyleTypes.MEASURE);
+			const layerMock = {};
+
+			instanceUnderTest.addStyle(feature, mapMock, layerMock, StyleTypes.MEASURE);
 
 			expect(styleSetterSpy).toHaveBeenCalledWith(jasmine.any(Function));
 			expect(propertySetterSpy).toHaveBeenCalledWith('overlays', jasmine.any(Object));
@@ -172,14 +175,16 @@ describe('StyleService', () => {
 					return { getArray: () => [] };
 				}
 			};
+			const layerMock = {};
+
 			let textStyle = null;
 			const styleSetterArraySpy = spyOn(featureWithStyleArray, 'setStyle').and.callFake((f => textStyle = f()));
-			instanceUnderTest.addStyle(featureWithStyleArray, mapMock, StyleTypes.TEXT);
+			instanceUnderTest.addStyle(featureWithStyleArray, mapMock, layerMock, StyleTypes.TEXT);
 			expect(styleSetterArraySpy).toHaveBeenCalledWith(jasmine.any(Function));
 			expect(textStyle).toContain(jasmine.any(Style));
 
 			const styleSetterFunctionSpy = spyOn(featureWithStyleFunction, 'setStyle').and.callFake((f => textStyle = f()));
-			instanceUnderTest.addStyle(featureWithStyleFunction, mapMock, StyleTypes.TEXT);
+			instanceUnderTest.addStyle(featureWithStyleFunction, mapMock, layerMock, StyleTypes.TEXT);
 			expect(styleSetterFunctionSpy).toHaveBeenCalledWith(jasmine.any(Function));
 			expect(textStyle).toContain(jasmine.any(Style));
 		});
@@ -206,14 +211,16 @@ describe('StyleService', () => {
 					return { getArray: () => [] };
 				}
 			};
+			const layerMock = {};
+
 			let markerStyle = null;
 			const styleSetterArraySpy = spyOn(featureWithStyleArray, 'setStyle').and.callFake((f => markerStyle = f()));
-			instanceUnderTest.addStyle(featureWithStyleArray, mapMock, StyleTypes.MARKER);
+			instanceUnderTest.addStyle(featureWithStyleArray, mapMock, layerMock, StyleTypes.MARKER);
 			expect(styleSetterArraySpy).toHaveBeenCalledWith(jasmine.any(Function));
 			expect(markerStyle).toContain(jasmine.any(Style));
 
 			const styleSetterFunctionSpy = spyOn(featureWithStyleFunction, 'setStyle').and.callFake((f => markerStyle = f()));
-			instanceUnderTest.addStyle(featureWithStyleFunction, mapMock, StyleTypes.MARKER);
+			instanceUnderTest.addStyle(featureWithStyleFunction, mapMock, layerMock, StyleTypes.MARKER);
 			expect(styleSetterFunctionSpy).toHaveBeenCalledWith(jasmine.any(Function));
 			expect(markerStyle).toContain(jasmine.any(Style));
 		});
@@ -235,8 +242,10 @@ describe('StyleService', () => {
 				}
 			};
 
-			instanceUnderTest.addStyle(feature, mapMock, StyleTypes.LINE);
-			instanceUnderTest.addStyle(feature, mapMock, StyleTypes.POLYGON);
+			const layerMock = {};
+
+			instanceUnderTest.addStyle(feature, mapMock, layerMock, StyleTypes.LINE);
+			instanceUnderTest.addStyle(feature, mapMock, layerMock, StyleTypes.POLYGON);
 
 			expect(styleSetterSpy).not.toHaveBeenCalled();
 		});
@@ -258,7 +267,9 @@ describe('StyleService', () => {
 				}
 			};
 
-			instanceUnderTest.addStyle(feature, mapMock, 'draw');
+			const layerMock = {};
+
+			instanceUnderTest.addStyle(feature, mapMock, layerMock, 'draw');
 
 			expect(styleSetterSpy).toHaveBeenCalledWith(jasmine.any(Function));
 		});
@@ -280,7 +291,9 @@ describe('StyleService', () => {
 				}
 			};
 
-			instanceUnderTest.addStyle(feature, mapMock);
+			const layerMock = { ol_uid: 1 };
+
+			instanceUnderTest.addStyle(feature, mapMock, layerMock);
 
 			expect(styleSetterSpy).toHaveBeenCalledWith(jasmine.any(Function));
 		});
@@ -303,7 +316,9 @@ describe('StyleService', () => {
 				}
 			};
 
-			instanceUnderTest.addStyle(feature, mapMock, 'unknown');
+			const layerMock = {};
+
+			instanceUnderTest.addStyle(feature, mapMock, layerMock, 'unknown');
 
 			expect(styleSetterSpy).not.toHaveBeenCalledWith(jasmine.any(Array));
 			expect(propertySetterSpy).not.toHaveBeenCalledWith('overlays', jasmine.any(Object));
@@ -339,10 +354,12 @@ describe('StyleService', () => {
 				},
 				once() { }
 			};
+
+			const layerMock = { };
 			const eventMock = { map: mapMock };
 			const onceOnMapSpy = spyOn(mapMock, 'once').and.callFake((eventName, callback) => callback(eventMock));
 
-			instanceUnderTest.addStyle(feature, mapMock, 'measure');
+			instanceUnderTest.addStyle(feature, mapMock, layerMock, 'measure');
 
 			expect(styleSetterSpy).toHaveBeenCalledWith(jasmine.any(Function));
 			expect(propertySetterSpy).toHaveBeenCalledWith('overlays', jasmine.any(Object));
@@ -375,8 +392,9 @@ describe('StyleService', () => {
 					return { getArray: () => [] };
 				}
 			};
+			const layerMock = { };
 
-			instanceUnderTest.addStyle(feature, mapMock, 'measure');
+			instanceUnderTest.addStyle(feature, mapMock, layerMock, 'measure');
 
 			expect(styleSetterSpy).toHaveBeenCalledWith(jasmine.any(Function));
 			expect(propertySetterSpy).toHaveBeenCalledWith('overlays', jasmine.any(Object));

--- a/test/modules/map/components/olMap/services/StyleService.test.js
+++ b/test/modules/map/components/olMap/services/StyleService.test.js
@@ -89,7 +89,7 @@ describe('StyleService', () => {
 	});
 
 	describe('add style', () => {
-		it('adds measure-style to feature with implicit style-type', () => {
+		it('adds measure-style to feature', () => {
 			const feature = new Feature({ geometry: new Polygon([[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]) });
 			feature.setId('measure_123');
 			const addOverlaySpy = jasmine.createSpy();
@@ -121,39 +121,7 @@ describe('StyleService', () => {
 			expect(addOverlaySpy).toHaveBeenCalledTimes(2);
 		});
 
-		it('adds measure-style to feature with explicit style-type', () => {
-			const feature = new Feature({ geometry: new Polygon([[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]) });
-			const addOverlaySpy = jasmine.createSpy();
-			const styleSetterSpy = spyOn(feature, 'setStyle');
-			const propertySetterSpy = spyOn(feature, 'set');
-			const viewMock = {
-				getResolution() {
-					return 50;
-				},
-				once() { }
-			};
-
-			const mapMock = {
-				getView: () => viewMock,
-				addOverlay: addOverlaySpy,
-				getOverlays() {
-					return [];
-				},
-				getInteractions() {
-					return { getArray: () => [] };
-				}
-			};
-
-			const layerMock = {};
-
-			instanceUnderTest.addStyle(feature, mapMock, layerMock, StyleTypes.MEASURE);
-
-			expect(styleSetterSpy).toHaveBeenCalledWith(jasmine.any(Function));
-			expect(propertySetterSpy).toHaveBeenCalledWith('overlays', jasmine.any(Object));
-			expect(addOverlaySpy).toHaveBeenCalledTimes(2);
-		});
-
-		it('adds text-style to feature with explicit style-type', () => {
+		it('adds text-style to feature', () => {
 			const featureWithStyleArray = new Feature({ geometry: new Point([0, 0]) });
 			const featureWithStyleFunction = new Feature({ geometry: new Point([0, 0]) });
 			const style = new Style({ text: new Text({ text: 'foo' }) });
@@ -179,17 +147,17 @@ describe('StyleService', () => {
 
 			let textStyle = null;
 			const styleSetterArraySpy = spyOn(featureWithStyleArray, 'setStyle').and.callFake((f => textStyle = f()));
-			instanceUnderTest.addStyle(featureWithStyleArray, mapMock, layerMock, StyleTypes.TEXT);
+			instanceUnderTest.addStyle(featureWithStyleArray, mapMock, layerMock);
 			expect(styleSetterArraySpy).toHaveBeenCalledWith(jasmine.any(Function));
 			expect(textStyle).toContain(jasmine.any(Style));
 
 			const styleSetterFunctionSpy = spyOn(featureWithStyleFunction, 'setStyle').and.callFake((f => textStyle = f()));
-			instanceUnderTest.addStyle(featureWithStyleFunction, mapMock, layerMock, StyleTypes.TEXT);
+			instanceUnderTest.addStyle(featureWithStyleFunction, mapMock, layerMock);
 			expect(styleSetterFunctionSpy).toHaveBeenCalledWith(jasmine.any(Function));
 			expect(textStyle).toContain(jasmine.any(Style));
 		});
 
-		it('adds marker-style to feature with explicit style-type', () => {
+		it('adds marker-style to feature', () => {
 			const featureWithStyleArray = new Feature({ geometry: new Point([0, 0]) });
 			const featureWithStyleFunction = new Feature({ geometry: new Point([0, 0]) });
 			const style = new Style({ image: new Icon({ src: 'http://foo.bar/icon.png', anchor: [0.5, 1], anchorXUnits: 'fraction', anchorYUnits: 'fraction', color: '#ff0000' }), text: new Text({ text: 'foo' }) });
@@ -215,19 +183,23 @@ describe('StyleService', () => {
 
 			let markerStyle = null;
 			const styleSetterArraySpy = spyOn(featureWithStyleArray, 'setStyle').and.callFake((f => markerStyle = f()));
-			instanceUnderTest.addStyle(featureWithStyleArray, mapMock, layerMock, StyleTypes.MARKER);
+			instanceUnderTest.addStyle(featureWithStyleArray, mapMock, layerMock);
 			expect(styleSetterArraySpy).toHaveBeenCalledWith(jasmine.any(Function));
 			expect(markerStyle).toContain(jasmine.any(Style));
 
 			const styleSetterFunctionSpy = spyOn(featureWithStyleFunction, 'setStyle').and.callFake((f => markerStyle = f()));
-			instanceUnderTest.addStyle(featureWithStyleFunction, mapMock, layerMock, StyleTypes.MARKER);
+			instanceUnderTest.addStyle(featureWithStyleFunction, mapMock, layerMock);
 			expect(styleSetterFunctionSpy).toHaveBeenCalledWith(jasmine.any(Function));
 			expect(markerStyle).toContain(jasmine.any(Style));
 		});
 
-		it('adds NO style to feature with explicit style-type of LINE or POLYGON', () => {
-			const feature = new Feature({ geometry: new Polygon([[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]) });
-			const styleSetterSpy = spyOn(feature, 'setStyle');
+		it('adds NO style to feature with style-type of LINE or POLYGON', () => {
+			const lineFeature = new Feature({ geometry: new Polygon([[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]) });
+			const polygonFeature = new Feature({ geometry: new Polygon([[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]) });
+			lineFeature.setId('draw_line_12345678');
+			polygonFeature.setId('draw_polygon_9876543');
+			const lineStyleSetterSpy = spyOn(lineFeature, 'setStyle');
+			const polygonStyleSetterSpy = spyOn(polygonFeature, 'setStyle');
 			const viewMock = {
 				getResolution() {
 					return 50;
@@ -244,34 +216,11 @@ describe('StyleService', () => {
 
 			const layerMock = {};
 
-			instanceUnderTest.addStyle(feature, mapMock, layerMock, StyleTypes.LINE);
-			instanceUnderTest.addStyle(feature, mapMock, layerMock, StyleTypes.POLYGON);
+			instanceUnderTest.addStyle(lineFeature, mapMock, layerMock, StyleTypes.LINE);
+			instanceUnderTest.addStyle(polygonFeature, mapMock, layerMock, StyleTypes.POLYGON);
 
-			expect(styleSetterSpy).not.toHaveBeenCalled();
-		});
-
-		it('adds draw-style to feature with explicit style-type', () => {
-			const feature = new Feature({ geometry: new Polygon([[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]) });
-			const styleSetterSpy = spyOn(feature, 'setStyle');
-			const viewMock = {
-				getResolution() {
-					return 50;
-				},
-				once() { }
-			};
-
-			const mapMock = {
-				getView: () => viewMock,
-				getInteractions() {
-					return { getArray: () => [] };
-				}
-			};
-
-			const layerMock = {};
-
-			instanceUnderTest.addStyle(feature, mapMock, layerMock, 'draw');
-
-			expect(styleSetterSpy).toHaveBeenCalledWith(jasmine.any(Function));
+			expect(lineStyleSetterSpy).not.toHaveBeenCalled();
+			expect(polygonStyleSetterSpy).not.toHaveBeenCalled();
 		});
 
 		it('adds default-style to feature without initial style', () => {
@@ -300,6 +249,7 @@ describe('StyleService', () => {
 
 		it('adding style to feature with unknown style-type fails', () => {
 			const feature = new Feature({ geometry: new Polygon([[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]) });
+			feature.setStyle(new Style());
 			const addOverlaySpy = jasmine.createSpy();
 			const warnSpy = spyOn(console, 'warn');
 			const styleSetterSpy = spyOn(feature, 'setStyle');
@@ -318,17 +268,18 @@ describe('StyleService', () => {
 
 			const layerMock = {};
 
-			instanceUnderTest.addStyle(feature, mapMock, layerMock, 'unknown');
+			instanceUnderTest.addStyle(feature, mapMock, layerMock);
 
 			expect(styleSetterSpy).not.toHaveBeenCalledWith(jasmine.any(Array));
 			expect(propertySetterSpy).not.toHaveBeenCalledWith('overlays', jasmine.any(Object));
 			expect(addOverlaySpy).not.toHaveBeenCalled();
-			expect(warnSpy).toHaveBeenCalledWith('Could not provide a style for unknown style-type:', 'unknown');
+			expect(warnSpy).toHaveBeenCalledWith('Could not provide a style for unknown style-type');
 		});
 
 
 		it('registers initial styling events for measure-feature without partition-delta property', () => {
 			const feature = new Feature({ geometry: new Polygon([[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]) });
+			feature.setId('measure_12345678');
 			const addOverlaySpy = jasmine.createSpy();
 			const styleSetterSpy = spyOn(feature, 'setStyle');
 			const propertySetterSpy = spyOn(feature, 'set');
@@ -359,7 +310,7 @@ describe('StyleService', () => {
 			const eventMock = { map: mapMock };
 			const onceOnMapSpy = spyOn(mapMock, 'once').and.callFake((eventName, callback) => callback(eventMock));
 
-			instanceUnderTest.addStyle(feature, mapMock, layerMock, 'measure');
+			instanceUnderTest.addStyle(feature, mapMock, layerMock);
 
 			expect(styleSetterSpy).toHaveBeenCalledWith(jasmine.any(Function));
 			expect(propertySetterSpy).toHaveBeenCalledWith('overlays', jasmine.any(Object));
@@ -370,6 +321,7 @@ describe('StyleService', () => {
 
 		it('registers NOT initial styling events for measure-feature without partition-delta property', () => {
 			const feature = new Feature({ geometry: new Polygon([[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]) });
+			feature.setId('measure_12345678');
 			feature.set('partition_delta', 'something');
 			const addOverlaySpy = jasmine.createSpy();
 			const styleSetterSpy = spyOn(feature, 'setStyle');
@@ -394,7 +346,7 @@ describe('StyleService', () => {
 			};
 			const layerMock = { };
 
-			instanceUnderTest.addStyle(feature, mapMock, layerMock, 'measure');
+			instanceUnderTest.addStyle(feature, mapMock, layerMock);
 
 			expect(styleSetterSpy).toHaveBeenCalledWith(jasmine.any(Function));
 			expect(propertySetterSpy).toHaveBeenCalledWith('overlays', jasmine.any(Object));

--- a/test/modules/map/components/olMap/services/StyleService.test.js
+++ b/test/modules/map/components/olMap/services/StyleService.test.js
@@ -275,9 +275,61 @@ describe('StyleService', () => {
 			};
 
 			const layerMock = { ol_uid: 1 };
-
+			const addSpy = spyOn(instanceUnderTest, '_addDefaultStyle').and.callThrough();
 			instanceUnderTest.addStyle(feature, mapMock, layerMock);
 
+			expect(addSpy).toHaveBeenCalledWith(feature, layerMock);
+			expect(styleSetterSpy).toHaveBeenCalledWith(jasmine.any(Function));
+		});
+
+		it('adds default-style to feature without initial style and existing layer-color', () => {
+			const feature = new Feature({ geometry: new Polygon([[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]) });
+			const styleSetterSpy = spyOn(feature, 'setStyle').and.callThrough();
+			const viewMock = {
+				getResolution() {
+					return 50;
+				},
+				once() { }
+			};
+
+			const mapMock = {
+				getView: () => viewMock,
+				getInteractions() {
+					return { getArray: () => [] };
+				}
+			};
+
+			const layerMock = { ol_uid: 'some' };
+			instanceUnderTest._defaultColorByLayerId['some'] = [0, 0, 0, 1];
+			const addSpy = spyOn(instanceUnderTest, '_addDefaultStyle').and.callThrough();
+			instanceUnderTest.addStyle(feature, mapMock, layerMock);
+
+			expect(addSpy).toHaveBeenCalledWith(feature, layerMock);
+			expect(styleSetterSpy).toHaveBeenCalledWith(jasmine.any(Function));
+			expect(feature.getStyle()(feature)[0].getFill().getColor()).toEqual([0, 0, 0, 1]);
+		});
+
+		it('adds default-style to feature without initial style and layer', () => {
+			const feature = new Feature({ geometry: new Polygon([[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]) });
+			const styleSetterSpy = spyOn(feature, 'setStyle');
+			const viewMock = {
+				getResolution() {
+					return 50;
+				},
+				once() { }
+			};
+
+			const mapMock = {
+				getView: () => viewMock,
+				getInteractions() {
+					return { getArray: () => [] };
+				}
+			};
+
+			const addSpy = spyOn(instanceUnderTest, '_addDefaultStyle').and.callThrough();
+			instanceUnderTest.addStyle(feature, mapMock);
+
+			expect(addSpy).toHaveBeenCalledWith(feature, undefined);
 			expect(styleSetterSpy).toHaveBeenCalledWith(jasmine.any(Function));
 		});
 
@@ -340,7 +392,7 @@ describe('StyleService', () => {
 				once() { }
 			};
 
-			const layerMock = { };
+			const layerMock = {};
 			const eventMock = { map: mapMock };
 			const onceOnMapSpy = spyOn(mapMock, 'once').and.callFake((eventName, callback) => callback(eventMock));
 
@@ -378,7 +430,7 @@ describe('StyleService', () => {
 					return { getArray: () => [] };
 				}
 			};
-			const layerMock = { };
+			const layerMock = {};
 
 			instanceUnderTest.addStyle(feature, mapMock, layerMock);
 

--- a/test/modules/map/components/olMap/services/VectorLayerService.test.js
+++ b/test/modules/map/components/olMap/services/VectorLayerService.test.js
@@ -236,7 +236,7 @@ describe('VectorLayerService', () => {
 
 				olSource.dispatchEvent(new VectorSourceEvent('addfeature', olFeature));
 
-				expect(styleServiceSpy).toHaveBeenCalledWith(olFeature, olMap);
+				expect(styleServiceSpy).toHaveBeenCalledWith(olFeature, olMap, olLayer);
 			});
 
 			it('calls StyleService#updateStyle on "addFeature" when layer is attached', () => {
@@ -250,7 +250,7 @@ describe('VectorLayerService', () => {
 
 				olSource.dispatchEvent(new VectorSourceEvent('addfeature', olFeature));
 
-				expect(styleServiceAddSpy).toHaveBeenCalledWith(olFeature, olMap);
+				expect(styleServiceAddSpy).toHaveBeenCalledWith(olFeature, olMap, olLayer);
 				expect(styleServiceUpdateSpy).toHaveBeenCalledWith(olFeature, olLayer, olMap);
 			});
 
@@ -351,7 +351,7 @@ describe('VectorLayerService', () => {
 					instanceUnderTest._applyStyles(olLayer, olMap);
 					olSource.dispatchEvent(new VectorSourceEvent('addfeature', olFeature));
 
-					expect(styleServiceAddSpy).not.toHaveBeenCalledWith(olFeature, olMap);
+					expect(styleServiceAddSpy).not.toHaveBeenCalledWith(olFeature, olMap, olLayer);
 					expect(registerStyleEventListenersSpy).not.toHaveBeenCalledWith(olSource, olMap);
 				});
 			});
@@ -371,8 +371,8 @@ describe('VectorLayerService', () => {
 
 					instanceUnderTest._applyStyles(olLayer, olMap);
 
-					expect(styleServiceAddSpy).toHaveBeenCalledWith(olFeature0, olMap);
-					expect(styleServiceAddSpy).toHaveBeenCalledWith(olFeature1, olMap);
+					expect(styleServiceAddSpy).toHaveBeenCalledWith(olFeature0, olMap, olLayer);
+					expect(styleServiceAddSpy).toHaveBeenCalledWith(olFeature1, olMap, olLayer);
 					expect(updateStyleSpy).toHaveBeenCalledWith(olFeature0, olLayer, olMap);
 					expect(updateStyleSpy).toHaveBeenCalledWith(olFeature1, olLayer, olMap);
 					expect(registerStyleEventListenersSpy).toHaveBeenCalledOnceWith(olSource, olLayer, olMap);


### PR DESCRIPTION
Features without style-information are provided with a default style. 

The current implementation sets a default style with a different color for each feature, regardless of whether the objects all belong to the same layer or not. 

With this enhancement we try to establish a reliable way to set a default style for unstyled features per layer, as it is a standard behavior in desktop gis.