### PR TITLE
MeasureToolContent: add test-ids for acceptance-tests

### DIFF
--- a/src/modules/toolbox/components/measureToolContent/MeasureToolContent.js
+++ b/src/modules/toolbox/components/measureToolContent/MeasureToolContent.js
@@ -86,8 +86,8 @@ export class MeasureToolContent extends AbstractToolContent {
 						<span>
 						${translate('toolbox_measureTool_stats_length')}:						
 						</span>						
-						<span class='prime-text-value'>${formattedDistancePackage.value}</span>		
-						<span class='prime-text-unit'>${formattedDistancePackage.unit}</span>									
+						<span id='span-distance-value' data-test-id class='prime-text-value'>${formattedDistancePackage.value}</span>		
+						<span id='span-distance-unit' data-test-id class='prime-text-unit'>${formattedDistancePackage.unit}</span>									
 						<span class='copy'>
 							<ba-icon class='close' .icon='${clipboardIcon}' .title=${translate('toolbox_copy_icon')} .size=${1.5} @click=${onCopyDistanceToClipboard}>
 							</ba-icon>
@@ -97,8 +97,8 @@ export class MeasureToolContent extends AbstractToolContent {
 						<span>
 							${translate('toolbox_measureTool_stats_area')}:		
 						</span>						
-						<span class='prime-text-value'>${formattedAreaPackage.value}</span>
-						<span class='prime-text-unit'>${unsafeHTML(formattedAreaPackage.unit)}</span>
+						<span id='span-area-value' data-test-id class='prime-text-value'>${formattedAreaPackage.value}</span>
+						<span id='span-area-unit' data-test-id class='prime-text-unit'>${unsafeHTML(formattedAreaPackage.unit)}</span>
 						<span class='copy'>
 							<ba-icon class='close' .icon='${clipboardIcon}' .title=${translate('toolbox_copy_icon')} .size=${1.5} @click=${onCopyAreaToClipboard}>
 							</ba-icon>
@@ -123,7 +123,7 @@ export class MeasureToolContent extends AbstractToolContent {
 		const { statistic, mode } = model;
 
 		const getButton = (id, title, onClick) => {
-			return html`<ba-button id=${id} 
+			return html`<ba-button id=${id} data-test-id
 								class="tool-container__button" 
 								.label=${title}
 								@click=${onClick}></ba-button>`;

--- a/test/modules/toolbox/components/measureToolContent/MeasureToolContent.test.js
+++ b/test/modules/toolbox/components/measureToolContent/MeasureToolContent.test.js
@@ -12,6 +12,7 @@ import { ShareButton } from '../../../../../src/modules/toolbox/components/share
 import { notificationReducer } from '../../../../../src/store/notifications/notifications.reducer';
 import { LevelTypes } from '../../../../../src/store/notifications/notifications.action';
 import { isString } from '../../../../../src/utils/checks';
+import { TEST_ID_ATTRIBUTE_NAME } from '../../../../../src/utils/markup';
 
 window.customElements.define(ShareButton.tag, ShareButton);
 window.customElements.define(MeasureToolContent.tag, MeasureToolContent);
@@ -206,6 +207,26 @@ describe('MeasureToolContent', () => {
 			expect(valueSpans[1].textContent).toBe('0');
 			expect(unitSpans[1].textContent).toBe('m²');
 		});
+
+		it('contains test-id attributes', async () => {
+			const state = {
+				measurement: {
+					statistic: { length: 42, area: 0 },
+					reset: null,
+					remove: null
+				}
+			};
+			const element = await setup(state);
+
+			expect(element.shadowRoot.querySelectorAll(`[${TEST_ID_ATTRIBUTE_NAME}]`)).toHaveSize(5);
+			expect(element.shadowRoot.querySelector('#span-distance-value').hasAttribute(TEST_ID_ATTRIBUTE_NAME)).toBeTrue();
+			expect(element.shadowRoot.querySelector('#span-distance-unit').hasAttribute(TEST_ID_ATTRIBUTE_NAME)).toBeTrue();
+			expect(element.shadowRoot.querySelector('#span-area-value').hasAttribute(TEST_ID_ATTRIBUTE_NAME)).toBeTrue();
+			expect(element.shadowRoot.querySelector('#span-area-unit').hasAttribute(TEST_ID_ATTRIBUTE_NAME)).toBeTrue();
+			expect(element.shadowRoot.querySelector('#span-area-unit').hasAttribute(TEST_ID_ATTRIBUTE_NAME)).toBeTrue();
+			expect(element.shadowRoot.querySelector('#remove').hasAttribute(TEST_ID_ATTRIBUTE_NAME)).toBeTrue();
+		});
+
 
 		it('shows only the lenght measurement statistics', async () => {
 			const state = {


### PR DESCRIPTION
creating test ids on elements for:

- distance-value and -unit
- area-value and -unit
- action-buttons ('startNew','remove', 'finish')