### PR TITLE
optionally load external config

### DIFF
--- a/src/assets/config.js
+++ b/src/assets/config.js
@@ -1,0 +1,5 @@
+/**
+ * Placeholder file for delivering config properties.
+ * This could be done here by appointing a global config object.
+ * window.config = { FOO: 'bar'}
+ */

--- a/src/assets/config.js
+++ b/src/assets/config.js
@@ -1,5 +1,5 @@
 /**
  * Placeholder file for delivering config properties.
- * This could be done here by appointing a global config object.
+ * This should be done here by appointing a global config object, e.g.
  * window.config = { FOO: 'bar'}
  */

--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,6 @@ if (process.env.LOAD_EXTERNAL_CONFIG === 'true') {
 	//load external config, that set a global config object
 	const configScript = document.createElement('script');
 	configScript.src = './config.js';
-	configScript.defer = true;
 	document.head.appendChild(configScript);
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,14 @@ const style = document.createElement('style');
 style.innerHTML = globalCss;
 document.head.appendChild(style);
 
+if (process.env.LOAD_EXTERNAL_CONFIG === 'true') {
+	//load external config, that set a global config object
+	const configScript = document.createElement('script');
+	configScript.src = './config.js';
+	configScript.defer = true;
+	document.head.appendChild(configScript);
+}
+
 window.enableTestIds = new URLSearchParams(window.location.search).get(QueryParameters.T_ENABLE_TEST_IDS) === 'true';
 
 // eslint-disable-next-line no-unused-vars

--- a/src/main.js
+++ b/src/main.js
@@ -5,13 +5,6 @@ const style = document.createElement('style');
 style.innerHTML = globalCss;
 document.head.appendChild(style);
 
-if (process.env.LOAD_EXTERNAL_CONFIG === 'true') {
-	//load external config that sets a global config object
-	const configScript = document.createElement('script');
-	configScript.src = './config.js';
-	document.head.appendChild(configScript);
-}
-
 window.enableTestIds = new URLSearchParams(window.location.search).get(QueryParameters.T_ENABLE_TEST_IDS) === 'true';
 
 // eslint-disable-next-line no-unused-vars

--- a/src/services/ProcessEnvConfigService.js
+++ b/src/services/ProcessEnvConfigService.js
@@ -1,6 +1,8 @@
 
 /**
- * Service for external configuration properties.
+ * Service provides all configuration properties.
+ * Properties are loaded from the process.env object,
+ * optionally from a global config object.
  * @class
  * @author taulinger
  */
@@ -9,18 +11,19 @@ export class ProcessEnvConfigService {
 	constructor() {
 
 		this._properties = new Map();
+		// We cannot use the EnvironmentService for accessing the window object. It is not yet initialized at this moment.
 		// eslint-disable-next-line no-undef
-		this._properties.set('RUNTIME_MODE', process.env.NODE_ENV);
+		this._properties.set('RUNTIME_MODE', window?.config?.NODE_ENV ?? process.env.NODE_ENV);
 		// eslint-disable-next-line no-undef
-		this._properties.set('SOFTWARE_INFO', process.env.SOFTWARE_INFO);
+		this._properties.set('SOFTWARE_INFO', window?.config?.SOFTWARE_INFO ?? process.env.SOFTWARE_INFO);
 		// eslint-disable-next-line no-undef
-		this._properties.set('DEFAULT_LANG', process.env.DEFAULT_LANG);
+		this._properties.set('DEFAULT_LANG', window?.config?.DEFAULT_LANG ?? process.env.DEFAULT_LANG);
 		// eslint-disable-next-line no-undef
-		this._properties.set('PROXY_URL', process.env.PROXY_URL);
+		this._properties.set('PROXY_URL', window?.config?.PROXY_URL ?? process.env.PROXY_URL);
 		// eslint-disable-next-line no-undef
-		this._properties.set('BACKEND_URL', process.env.BACKEND_URL);
+		this._properties.set('BACKEND_URL', window?.config?.BACKEND_URL ?? process.env.BACKEND_URL);
 		// eslint-disable-next-line no-undef
-		this._properties.set('SHORTENING_SERVICE_URL', process.env.SHORTENING_SERVICE_URL);
+		this._properties.set('SHORTENING_SERVICE_URL', window?.config?.SHORTENING_SERVICE_URL ?? process.env.SHORTENING_SERVICE_URL);
 
 		this._properties.forEach((value, key) => {
 			if (value === undefined) {

--- a/src/services/ProcessEnvConfigService.js
+++ b/src/services/ProcessEnvConfigService.js
@@ -2,7 +2,7 @@
 /**
  * Service provides all configuration properties.
  * Properties are loaded from the process.env object,
- * optionally from a global config object.
+ * optionally from a global config object (see `/src/assets/conig.js`).
  * @class
  * @author taulinger
  */

--- a/test/e2e/entryPoints.spec.js
+++ b/test/e2e/entryPoints.spec.js
@@ -1,6 +1,6 @@
 const { test, expect } = require('@playwright/test');
 
-const BASE_URL = process.env.URL || 'http://localhost:8080';
+const BASE_URL = (process.env.URL || 'http://localhost:8080').replace(/\/$/, '');
 
 test.describe('entry points', () => {
 

--- a/test/e2e/entryPoints.spec.js
+++ b/test/e2e/entryPoints.spec.js
@@ -1,0 +1,18 @@
+const { test, expect } = require('@playwright/test');
+
+const BASE_URL = process.env.URL || 'http://localhost:8080';
+
+test.describe('entry points', () => {
+
+	test('should provide the bundle.js', async ({ request }) => {
+
+		const response = await request.get(`${BASE_URL}/bundle.js`);
+		expect(response.ok()).toBeTruthy();
+	});
+
+	test('should provide the config.js', async ({ request }) => {
+
+		const response = await request.get(`${BASE_URL}/config.js`);
+		expect(response.ok()).toBeTruthy();
+	});
+});

--- a/test/service/ProcessEnvConfigService.test.js
+++ b/test/service/ProcessEnvConfigService.test.js
@@ -42,10 +42,34 @@ describe('tests for ProcessEnvConfigService', () => {
 
 	describe('getValue()', () => {
 
-		it('provides a value for required keys', () => {
+		it('provides a value for required keys from process.env', () => {
 			const warnSpy = spyOn(console, 'warn');
 			// eslint-disable-next-line no-undef
 			process.env = {
+				'SOFTWARE_INFO': 'SOFTWARE_INFO_value',
+				'DEFAULT_LANG': 'DEFAULT_LANG_value',
+				'PROXY_URL': 'PROXY_URL_value',
+				'BACKEND_URL': 'BACKEND_URL_value',
+				'SHORTENING_SERVICE_URL': 'SHORTENING_SERVICE_URL_value'
+			};
+
+			const configService = new ProcessEnvConfigService();
+
+			expect(configService._properties.size).toBe(6);
+			expect(configService.getValue('RUNTIME_MODE')).toBe('development');
+			expect(configService.getValue('SOFTWARE_INFO')).toBe('SOFTWARE_INFO_value');
+			expect(configService.getValue('DEFAULT_LANG')).toBe('DEFAULT_LANG_value');
+			expect(configService.getValue('PROXY_URL')).toBe('PROXY_URL_value');
+			expect(configService.getValue('BACKEND_URL')).toBe('BACKEND_URL_value');
+			expect(configService.getValue('SHORTENING_SERVICE_URL')).toBe('SHORTENING_SERVICE_URL_value');
+
+			expect(warnSpy).not.toHaveBeenCalled();
+		});
+
+		it('provides a value for required keys from window.config', () => {
+			const warnSpy = spyOn(console, 'warn');
+			// eslint-disable-next-line no-undef
+			window.config = {
 				'SOFTWARE_INFO': 'SOFTWARE_INFO_value',
 				'DEFAULT_LANG': 'DEFAULT_LANG_value',
 				'PROXY_URL': 'PROXY_URL_value',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,11 +7,13 @@ const port = portFinderSync.getPort(8080);
 
 module.exports = {
 	mode: 'development',
-	entry: './src/main.js',
+	entry: {
+		config: './src/assets/config.js',
+		bundle: './src/main.js'
+	},
 	output: {
 		path: path.resolve(__dirname, 'dist'),
-		filename: 'bundle.js',
-		clean: true
+		filename: '[name].js'
 	},
 	module: {
 		rules: [


### PR DESCRIPTION
Config parameters are set within the `.env` file and loaded from the `process.env` object by the ProcessEnvConfigService.

Additionally, config parameters can be also set now via a `window.config` object, appointed within a script provided from `/config.js`.