### PR TITLE
fix button-focus on measurement state-changes

### DIFF
--- a/test/modules/toolbox/components/measureToolContent/MeasureToolContent.test.js
+++ b/test/modules/toolbox/components/measureToolContent/MeasureToolContent.test.js
@@ -218,7 +218,7 @@ describe('MeasureToolContent', () => {
 			};
 			const element = await setup(state);
 
-			expect(element.shadowRoot.querySelectorAll(`[${TEST_ID_ATTRIBUTE_NAME}]`)).toHaveSize(5);
+			expect(element.shadowRoot.querySelectorAll(`[${TEST_ID_ATTRIBUTE_NAME}]`)).toHaveSize(6);
 			expect(element.shadowRoot.querySelector('#span-distance-value').hasAttribute(TEST_ID_ATTRIBUTE_NAME)).toBeTrue();
 			expect(element.shadowRoot.querySelector('#span-distance-unit').hasAttribute(TEST_ID_ATTRIBUTE_NAME)).toBeTrue();
 			expect(element.shadowRoot.querySelector('#span-area-value').hasAttribute(TEST_ID_ATTRIBUTE_NAME)).toBeTrue();


### PR DESCRIPTION
update creation of action-buttons to circumvent the behavior, that a changed measure state, initiated by a button-click, does not reflect in losing focus for a new button on the same position. Switching from a Array of TemplateResult to a single TemplateResult.

fixes #835 