### PR TITLE
adjust theme-colors

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -7,8 +7,8 @@
     <meta charset="utf-8" />
     <meta name="google" content="notranslate">
     <meta name="description" content="<%= description %>"/>
-    <meta name="theme-color" content="#2f6a94" media="(prefers-color-scheme: light)">
-    <meta name="theme-color" content="#2f6a94" media="(prefers-color-scheme: dark)">
+    <meta name="theme-color" content="#fcfdfd" media="(prefers-color-scheme: light)">
+    <meta name="theme-color" content="#2e3538" media="(prefers-color-scheme: dark)">
     <link rel="icon" href="assets/favicon.ico" sizes="any">
     <link rel="icon" type="image/svg+xml" href="assets/icon.svg">
     <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">

--- a/test/e2e/page.spec.js
+++ b/test/e2e/page.spec.js
@@ -27,9 +27,9 @@ test.describe('page', () => {
 
 		test('should contain theme-color meta tags', async ({ page }) => {
 			expect(await page.getAttribute('head > meta[media=\'(prefers-color-scheme: light)\']', 'name')).toBe('theme-color');
-			expect(await page.getAttribute('head > meta[media=\'(prefers-color-scheme: light)\']', 'content')).toBe('#2f6a94');
+			expect(await page.getAttribute('head > meta[media=\'(prefers-color-scheme: light)\']', 'content')).toBe('#fcfdfd');
 			expect(await page.getAttribute('head > meta[media=\'(prefers-color-scheme: dark)\']', 'name')).toBe('theme-color');
-			expect(await page.getAttribute('head > meta[media=\'(prefers-color-scheme: dark)\']', 'content')).toBe('#2f6a94');
+			expect(await page.getAttribute('head > meta[media=\'(prefers-color-scheme: dark)\']', 'content')).toBe('#2e3538');
 		});
 
 		test('should contain correct translate attribute', async ({ page }) => {


### PR DESCRIPTION
Android notification bar should have the same color as our header depending on the current theme:

![signal-2022-04-02-165544](https://user-images.githubusercontent.com/49945713/161389008-bf020d19-9729-4a9b-8164-58546e90606e.png)

![signal-2022-04-02-165338](https://user-images.githubusercontent.com/49945713/161388947-01d7a586-345f-4985-8f71-6bc4794302e1.png)
