### PR TITLE
change feature highlight for long-press results

### DIFF
--- a/src/modules/map/components/olMap/handler/featureInfo/OlFeatureInfoHandler.js
+++ b/src/modules/map/components/olMap/handler/featureInfo/OlFeatureInfoHandler.js
@@ -5,7 +5,7 @@ import { getLayerById } from '../../olMapUtils';
 import { OlMapHandler } from '../OlMapHandler';
 import { getBvvFeatureInfo } from './featureInfoItem.provider';
 import { addHighlightFeatures, HighlightFeatureType, HighlightGeometryType, removeHighlightFeaturesById } from '../../../../../../store/highlight/highlight.action';
-import { FEATURE_INFO_HIGHLIGHT_FEATURE_ID } from '../../../../../../plugins/HighlightPlugin';
+import { QUERY_RUNNING_HIGHLIGHT_FEATURE_ID } from '../../../../../../plugins/HighlightPlugin';
 import { createUniqueId } from '../../../../../../utils/numberUtils';
 
 /**
@@ -48,7 +48,7 @@ export class OlFeatureInfoHandler extends OlMapHandler {
 		observe(this._storeService.getStore(), state => state.featureInfo.coordinate, (coordinate, state) => {
 
 			//remove previous HighlightFeature items
-			removeHighlightFeaturesById(FEATURE_INFO_HIGHLIGHT_FEATURE_ID);
+			removeHighlightFeaturesById(QUERY_RUNNING_HIGHLIGHT_FEATURE_ID);
 			registerQuery(queryId);
 
 			const featureInfoItems = [...state.layers.active]
@@ -76,7 +76,7 @@ export class OlFeatureInfoHandler extends OlMapHandler {
 			const highlightFeatures = featureInfoItems
 				.filter(featureInfo => featureInfo.geometry)
 				.map(featureInfo => ({
-					id: FEATURE_INFO_HIGHLIGHT_FEATURE_ID,
+					id: QUERY_RUNNING_HIGHLIGHT_FEATURE_ID,
 					type: HighlightFeatureType.DEFAULT,
 					data: { geometry: featureInfo.geometry.data, geometryType: HighlightGeometryType.GEOJSON }
 				}));

--- a/src/modules/map/components/olMap/handler/highlight/OlHighlightLayerHandler.js
+++ b/src/modules/map/components/olMap/handler/highlight/OlHighlightLayerHandler.js
@@ -98,7 +98,7 @@ export class OlHighlightLayerHandler extends OlLayerHandler {
 				case HighlightFeatureType.TEMPORARY:
 					olFeature.setStyle(highlightTemporaryCoordinateFeatureStyleFunction);
 					break;
-				case HighlightFeatureType.FEATURE_INFO_RUNNING:
+				case HighlightFeatureType.QUERY_RUNNING:
 					this._animatePointFeature(olFeature);
 					break;
 				case HighlightFeatureType.FEATURE_INFO_SUCCESS:

--- a/src/modules/map/components/olMap/handler/highlight/OlHighlightLayerHandler.js
+++ b/src/modules/map/components/olMap/handler/highlight/OlHighlightLayerHandler.js
@@ -101,7 +101,7 @@ export class OlHighlightLayerHandler extends OlLayerHandler {
 				case HighlightFeatureType.QUERY_RUNNING:
 					this._animatePointFeature(olFeature);
 					break;
-				case HighlightFeatureType.FEATURE_INFO_SUCCESS:
+				case HighlightFeatureType.QUERY_SUCCESS:
 					olFeature.setStyle(highlightAnimatedCoordinateFeatureStyleFunction);
 			}
 		}

--- a/src/plugins/ContextClickPlugin.js
+++ b/src/plugins/ContextClickPlugin.js
@@ -31,7 +31,7 @@ export class ContextClickPlugin extends BaPlugin {
 			if (environmentService.isTouch()) {
 				removeHighlightFeaturesById(highlightFeatureId);
 				addHighlightFeatures(
-					{ id: highlightFeatureId, data: { coordinate: coordinate }, type: HighlightFeatureType.DEFAULT }
+					{ id: highlightFeatureId, data: { coordinate: coordinate }, type: HighlightFeatureType.QUERY_SUCCESS }
 				);
 				emitFixedNotification(content);
 			}

--- a/src/plugins/HighlightPlugin.js
+++ b/src/plugins/HighlightPlugin.js
@@ -12,14 +12,14 @@ import { createUniqueId } from '../utils/numberUtils';
 export const HIGHLIGHT_LAYER_ID = 'highlight_layer';
 
 /**
- *ID for FeatureInfo related highlight features
+ *ID for a highlight feature a query is running
  */
-export const FEATURE_INFO_HIGHLIGHT_FEATURE_ID = 'featureInfoHighlightFeatureId';
+export const QUERY_RUNNING_HIGHLIGHT_FEATURE_ID = 'queryRunningHighlightFeatureId';
 
 /**
- *ID for FeatureInfo related highlight features
+ *ID for a highlight feature a query was successful
  */
-export const FEATURE_INFO_SUCCESS_HIGHLIGHT_FEATURE_ID = 'featureInfoSuccessHighlightFeatureId';
+export const QUERY_SUCCESS_HIGHLIGHT_FEATURE_ID = 'querySuccessHighlightFeatureId';
 /**
  *ID for SearchResult related highlight features
  */
@@ -54,12 +54,12 @@ export class HighlightPlugin extends BaPlugin {
 		};
 
 		const onPointerClick = () => {
-			removeHighlightFeaturesById(FEATURE_INFO_HIGHLIGHT_FEATURE_ID);
+			removeHighlightFeaturesById(QUERY_RUNNING_HIGHLIGHT_FEATURE_ID);
 		};
 
 		const onTabChanged = (tab) => {
 			if (tab !== TabId.FEATUREINFO) {
-				removeHighlightFeaturesById([FEATURE_INFO_HIGHLIGHT_FEATURE_ID, FEATURE_INFO_SUCCESS_HIGHLIGHT_FEATURE_ID]);
+				removeHighlightFeaturesById([QUERY_RUNNING_HIGHLIGHT_FEATURE_ID, QUERY_SUCCESS_HIGHLIGHT_FEATURE_ID]);
 			}
 		};
 
@@ -73,13 +73,13 @@ export class HighlightPlugin extends BaPlugin {
 			if (querying) {
 				const coordinate = state.featureInfo.coordinate.payload;
 				addHighlightFeatures({ id: highlightFeatureId, data: { coordinate: coordinate }, type: HighlightFeatureType.QUERY_RUNNING });
-				removeHighlightFeaturesById(FEATURE_INFO_SUCCESS_HIGHLIGHT_FEATURE_ID);
+				removeHighlightFeaturesById(QUERY_SUCCESS_HIGHLIGHT_FEATURE_ID);
 			}
 			else {
 				const coordinate = state.featureInfo.coordinate.payload;
 				removeHighlightFeaturesById(highlightFeatureId);
 				if (state.featureInfo.current.length > 0) {
-					addHighlightFeatures({ id: FEATURE_INFO_SUCCESS_HIGHLIGHT_FEATURE_ID, data: { coordinate: coordinate }, type: HighlightFeatureType.QUERY_SUCCESS });
+					addHighlightFeatures({ id: QUERY_SUCCESS_HIGHLIGHT_FEATURE_ID, data: { coordinate: coordinate }, type: HighlightFeatureType.QUERY_SUCCESS });
 				}
 			}
 		};

--- a/src/plugins/HighlightPlugin.js
+++ b/src/plugins/HighlightPlugin.js
@@ -72,7 +72,7 @@ export class HighlightPlugin extends BaPlugin {
 		const onFeatureInfoQueryingChange = (querying, state) => {
 			if (querying) {
 				const coordinate = state.featureInfo.coordinate.payload;
-				addHighlightFeatures({ id: highlightFeatureId, data: { coordinate: coordinate }, type: HighlightFeatureType.FEATURE_INFO_RUNNING });
+				addHighlightFeatures({ id: highlightFeatureId, data: { coordinate: coordinate }, type: HighlightFeatureType.QUERY_RUNNING });
 				removeHighlightFeaturesById(FEATURE_INFO_SUCCESS_HIGHLIGHT_FEATURE_ID);
 			}
 			else {

--- a/src/plugins/HighlightPlugin.js
+++ b/src/plugins/HighlightPlugin.js
@@ -79,7 +79,7 @@ export class HighlightPlugin extends BaPlugin {
 				const coordinate = state.featureInfo.coordinate.payload;
 				removeHighlightFeaturesById(highlightFeatureId);
 				if (state.featureInfo.current.length > 0) {
-					addHighlightFeatures({ id: FEATURE_INFO_SUCCESS_HIGHLIGHT_FEATURE_ID, data: { coordinate: coordinate }, type: HighlightFeatureType.FEATURE_INFO_SUCCESS });
+					addHighlightFeatures({ id: FEATURE_INFO_SUCCESS_HIGHLIGHT_FEATURE_ID, data: { coordinate: coordinate }, type: HighlightFeatureType.QUERY_SUCCESS });
 				}
 			}
 		};

--- a/src/store/highlight/highlight.action.js
+++ b/src/store/highlight/highlight.action.js
@@ -31,7 +31,7 @@ import { $injector } from '../../injection';
 export const HighlightFeatureType = Object.freeze({
 	DEFAULT: 0,
 	TEMPORARY: 1,
-	FEATURE_INFO_RUNNING: 2,
+	QUERY_RUNNING: 2,
 	FEATURE_INFO_SUCCESS: 3
 });
 

--- a/src/store/highlight/highlight.action.js
+++ b/src/store/highlight/highlight.action.js
@@ -32,7 +32,7 @@ export const HighlightFeatureType = Object.freeze({
 	DEFAULT: 0,
 	TEMPORARY: 1,
 	QUERY_RUNNING: 2,
-	FEATURE_INFO_SUCCESS: 3
+	QUERY_SUCCESS: 3
 });
 
 /**

--- a/test/modules/map/components/olMap/handler/featureInfo/OlFeatureInfoHandler.test.js
+++ b/test/modules/map/components/olMap/handler/featureInfo/OlFeatureInfoHandler.test.js
@@ -14,7 +14,7 @@ import { highlightReducer } from '../../../../../../../src/store/highlight/highl
 import { HighlightFeatureType, HighlightGeometryType } from '../../../../../../../src/store/highlight/highlight.action';
 import GeoJSON from 'ol/format/GeoJSON';
 import { $injector } from '../../../../../../../src/injection';
-import { FEATURE_INFO_HIGHLIGHT_FEATURE_ID } from '../../../../../../../src/plugins/HighlightPlugin';
+import { QUERY_RUNNING_HIGHLIGHT_FEATURE_ID } from '../../../../../../../src/plugins/HighlightPlugin';
 
 describe('OlFeatureInfoHandler_Query_Resolution_Delay', () => {
 
@@ -158,7 +158,7 @@ describe('OlFeatureInfoHandler', () => {
 			const handler = setup({
 				highlight: {
 					features: [
-						{ id: FEATURE_INFO_HIGHLIGHT_FEATURE_ID, type: HighlightFeatureType.DEFAULT, data: [21, 42] },
+						{ id: QUERY_RUNNING_HIGHLIGHT_FEATURE_ID, type: HighlightFeatureType.DEFAULT, data: [21, 42] },
 						{ id: 'foo', type: HighlightFeatureType.DEFAULT, data: [5, 55] }
 					]
 				}
@@ -231,12 +231,12 @@ describe('OlFeatureInfoHandler', () => {
 					});
 					expect(store.getState().highlight.features).toHaveSize(2);
 					expect(store.getState().highlight.features[0]).toEqual({
-						id: FEATURE_INFO_HIGHLIGHT_FEATURE_ID,
+						id: QUERY_RUNNING_HIGHLIGHT_FEATURE_ID,
 						type: HighlightFeatureType.DEFAULT,
 						data: expectedHighlightFeatureGeometry
 					});
 					expect(store.getState().highlight.features[1]).toEqual({
-						id: FEATURE_INFO_HIGHLIGHT_FEATURE_ID,
+						id: QUERY_RUNNING_HIGHLIGHT_FEATURE_ID,
 						type: HighlightFeatureType.DEFAULT,
 						data: expectedHighlightFeatureGeometry
 					});

--- a/test/modules/map/components/olMap/handler/highlight/OlHighlightLayerHandler.test.js
+++ b/test/modules/map/components/olMap/handler/highlight/OlHighlightLayerHandler.test.js
@@ -210,7 +210,7 @@ describe('OlHighlightLayerHandler', () => {
 			const highlightCoordinateFeature0 = { data: { coordinate: [1, 0] }, type: HighlightFeatureType.DEFAULT };
 			const highlightCoordinateFeature1 = { data: { coordinate: [1, 0] }, type: HighlightFeatureType.TEMPORARY };
 			const highlightCoordinateFeature2 = { data: { coordinate: [1, 0] }, type: HighlightFeatureType.QUERY_RUNNING };
-			const highlightCoordinateFeature3 = { data: { coordinate: [1, 0] }, type: HighlightFeatureType.FEATURE_INFO_SUCCESS };
+			const highlightCoordinateFeature3 = { data: { coordinate: [1, 0] }, type: HighlightFeatureType.QUERY_SUCCESS };
 
 			const styledFeature0 = handler._appendStyle(highlightCoordinateFeature0, new Feature(new Point([5, 10])));
 			const styledFeature1 = handler._appendStyle(highlightCoordinateFeature1, new Feature(new Point([5, 10])));

--- a/test/modules/map/components/olMap/handler/highlight/OlHighlightLayerHandler.test.js
+++ b/test/modules/map/components/olMap/handler/highlight/OlHighlightLayerHandler.test.js
@@ -85,7 +85,7 @@ describe('OlHighlightLayerHandler', () => {
 			it('adds ol features', () => {
 				const highlightFeatures = [{ type: HighlightFeatureType.DEFAULT, data: { coordinate: [1, 0] } }, { type: HighlightFeatureType.DEFAULT, data: { coordinate: [2, 1] } }];
 				const temporaryFeatures = [{ type: HighlightFeatureType.TEMPORARY, data: { coordinate: [3, 4] } }];
-				const animatedFeatures = [{ type: HighlightFeatureType.FEATURE_INFO_RUNNING, data: { coordinate: [5, 55] } }];
+				const animatedFeatures = [{ type: HighlightFeatureType.QUERY_RUNNING, data: { coordinate: [5, 55] } }];
 				const state = { ...initialState, active: true, features: [...highlightFeatures, ...temporaryFeatures, ...animatedFeatures] };
 				const map = setupMap();
 				setup(state);
@@ -110,7 +110,7 @@ describe('OlHighlightLayerHandler', () => {
 				addHighlightFeatures([
 					{ type: HighlightFeatureType.DEFAULT, data: { coordinate: [21, 42] } },
 					{ type: HighlightFeatureType.DEFAULT, data: { coordinate: [38, 57] } },
-					{ type: HighlightFeatureType.FEATURE_INFO_RUNNING, data: { coordinate: [5, 55] } }
+					{ type: HighlightFeatureType.QUERY_RUNNING, data: { coordinate: [5, 55] } }
 				]);
 
 				const olFeatures = olLayer.getSource().getFeatures();
@@ -122,7 +122,7 @@ describe('OlHighlightLayerHandler', () => {
 		describe('and highlight features are removed', () => {
 
 			it('removes ol features', () => {
-				const highlightFeature = { type: HighlightFeatureType.FEATURE_INFO_RUNNING, data: { coordinate: [1, 0] } };
+				const highlightFeature = { type: HighlightFeatureType.QUERY_RUNNING, data: { coordinate: [1, 0] } };
 				const state = { ...initialState, active: true, features: [highlightFeature], temporaryFeatures: [] };
 				const map = setupMap();
 				setup(state);
@@ -209,7 +209,7 @@ describe('OlHighlightLayerHandler', () => {
 			const animatePointFeatureSyp = spyOn(handler, '_animatePointFeature');
 			const highlightCoordinateFeature0 = { data: { coordinate: [1, 0] }, type: HighlightFeatureType.DEFAULT };
 			const highlightCoordinateFeature1 = { data: { coordinate: [1, 0] }, type: HighlightFeatureType.TEMPORARY };
-			const highlightCoordinateFeature2 = { data: { coordinate: [1, 0] }, type: HighlightFeatureType.FEATURE_INFO_RUNNING };
+			const highlightCoordinateFeature2 = { data: { coordinate: [1, 0] }, type: HighlightFeatureType.QUERY_RUNNING };
 			const highlightCoordinateFeature3 = { data: { coordinate: [1, 0] }, type: HighlightFeatureType.FEATURE_INFO_SUCCESS };
 
 			const styledFeature0 = handler._appendStyle(highlightCoordinateFeature0, new Feature(new Point([5, 10])));

--- a/test/plugins/ContextClickPlugin.test.js
+++ b/test/plugins/ContextClickPlugin.test.js
@@ -48,14 +48,14 @@ describe('ContextClickPlugin', () => {
 
 				expect(isTemplateResult(store.getState().notifications.latest.payload.content)).toBeTrue();
 				expect(store.getState().highlight.features).toHaveSize(1);
-				expect(store.getState().highlight.features[0].type).toEqual(HighlightFeatureType.DEFAULT);
+				expect(store.getState().highlight.features[0].type).toEqual(HighlightFeatureType.QUERY_SUCCESS);
 
 				//let's call it again
 				setContextClick({ coordinate: [21210, 42420], screenCoordinate: [210, 420] });
 
 				expect(isTemplateResult(store.getState().notifications.latest.payload.content)).toBeTrue();
 				expect(store.getState().highlight.features).toHaveSize(1);
-				expect(store.getState().highlight.features[0].type).toEqual(HighlightFeatureType.DEFAULT);
+				expect(store.getState().highlight.features[0].type).toEqual(HighlightFeatureType.QUERY_SUCCESS);
 			});
 
 			describe('when move-start state changed', () => {

--- a/test/plugins/HighlightPlugin.test.js
+++ b/test/plugins/HighlightPlugin.test.js
@@ -1,4 +1,4 @@
-import { FEATURE_INFO_HIGHLIGHT_FEATURE_ID, FEATURE_INFO_SUCCESS_HIGHLIGHT_FEATURE_ID, HighlightPlugin, HIGHLIGHT_LAYER_ID, SEARCH_RESULT_HIGHLIGHT_FEATURE_ID, SEARCH_RESULT_TEMPORARY_HIGHLIGHT_FEATURE_ID } from '../../src/plugins/HighlightPlugin';
+import { QUERY_RUNNING_HIGHLIGHT_FEATURE_ID, QUERY_SUCCESS_HIGHLIGHT_FEATURE_ID, HighlightPlugin, HIGHLIGHT_LAYER_ID, SEARCH_RESULT_HIGHLIGHT_FEATURE_ID, SEARCH_RESULT_TEMPORARY_HIGHLIGHT_FEATURE_ID } from '../../src/plugins/HighlightPlugin';
 import { TestUtils } from '../test-utils.js';
 import { highlightReducer } from '../../src/store/highlight/highlight.reducer';
 import { addHighlightFeatures, clearHighlightFeatures, HighlightFeatureType } from '../../src/store/highlight/highlight.action';
@@ -65,7 +65,7 @@ describe('HighlightPlugin', () => {
 
 		it('clears all featureInfo related highlight items', async () => {
 			const coordinate = [11, 22];
-			const highlightFeature0 = { type: HighlightFeatureType.DEFAULT, data: { coordinate: [21, 42] }, id: FEATURE_INFO_HIGHLIGHT_FEATURE_ID };
+			const highlightFeature0 = { type: HighlightFeatureType.DEFAULT, data: { coordinate: [21, 42] }, id: QUERY_RUNNING_HIGHLIGHT_FEATURE_ID };
 			const highlightFeature1 = { type: HighlightFeatureType.DEFAULT, data: { coordinate: [21, 42] }, id: 'foo' };
 			const store = setup({
 				highlight: {
@@ -85,9 +85,9 @@ describe('HighlightPlugin', () => {
 	describe('when mainMenu.tab changes', () => {
 
 		it('clears all featureInfo related highlight items (also initially)', async () => {
-			const highlightFeature0 = { type: HighlightFeatureType.DEFAULT, data: { coordinate: [21, 42] }, id: FEATURE_INFO_HIGHLIGHT_FEATURE_ID };
+			const highlightFeature0 = { type: HighlightFeatureType.DEFAULT, data: { coordinate: [21, 42] }, id: QUERY_RUNNING_HIGHLIGHT_FEATURE_ID };
 			const highlightFeature1 = { type: HighlightFeatureType.DEFAULT, data: { coordinate: [21, 42] }, id: 'foo' };
-			const highlightFeature2 = { type: HighlightFeatureType.DEFAULT, data: { coordinate: [21, 42] }, id: FEATURE_INFO_SUCCESS_HIGHLIGHT_FEATURE_ID };
+			const highlightFeature2 = { type: HighlightFeatureType.DEFAULT, data: { coordinate: [21, 42] }, id: QUERY_SUCCESS_HIGHLIGHT_FEATURE_ID };
 			const store = setup({
 				mainMenu: {
 					tab: TabId.TOPICS,
@@ -189,7 +189,7 @@ describe('HighlightPlugin', () => {
 
 		it('removes an existing success highlight feature', async () => {
 			const coordinate = [21, 42];
-			const highlightFeature = { type: HighlightFeatureType.QUERY_SUCCESS, data: { coordinate: coordinate }, id: FEATURE_INFO_SUCCESS_HIGHLIGHT_FEATURE_ID };
+			const highlightFeature = { type: HighlightFeatureType.QUERY_SUCCESS, data: { coordinate: coordinate }, id: QUERY_SUCCESS_HIGHLIGHT_FEATURE_ID };
 			const store = setup({
 				mainMenu: {
 					open: true,
@@ -202,13 +202,13 @@ describe('HighlightPlugin', () => {
 			const instanceUnderTest = new HighlightPlugin();
 			await instanceUnderTest.register(store);
 
-			expect(store.getState().highlight.features[0].id).toBe(FEATURE_INFO_SUCCESS_HIGHLIGHT_FEATURE_ID);
+			expect(store.getState().highlight.features[0].id).toBe(QUERY_SUCCESS_HIGHLIGHT_FEATURE_ID);
 			expect(store.getState().highlight.features).toHaveSize(1);
 
 			startRequest(coordinate);
 
 			expect(store.getState().highlight.features).toHaveSize(1);
-			expect(store.getState().highlight.features[0].id).not.toBe(FEATURE_INFO_SUCCESS_HIGHLIGHT_FEATURE_ID);
+			expect(store.getState().highlight.features[0].id).not.toBe(QUERY_SUCCESS_HIGHLIGHT_FEATURE_ID);
 		});
 
 		it('adds a success highlight feature', async () => {
@@ -225,7 +225,7 @@ describe('HighlightPlugin', () => {
 			resolveQuery(queryId);
 
 			expect(store.getState().highlight.features).toHaveSize(1);
-			expect(store.getState().highlight.features[0].id).toBe(FEATURE_INFO_SUCCESS_HIGHLIGHT_FEATURE_ID);
+			expect(store.getState().highlight.features[0].id).toBe(QUERY_SUCCESS_HIGHLIGHT_FEATURE_ID);
 		});
 	});
 });

--- a/test/plugins/HighlightPlugin.test.js
+++ b/test/plugins/HighlightPlugin.test.js
@@ -189,7 +189,7 @@ describe('HighlightPlugin', () => {
 
 		it('removes an existing success highlight feature', async () => {
 			const coordinate = [21, 42];
-			const highlightFeature = { type: HighlightFeatureType.FEATURE_INFO_SUCCESS, data: { coordinate: coordinate }, id: FEATURE_INFO_SUCCESS_HIGHLIGHT_FEATURE_ID };
+			const highlightFeature = { type: HighlightFeatureType.QUERY_SUCCESS, data: { coordinate: coordinate }, id: FEATURE_INFO_SUCCESS_HIGHLIGHT_FEATURE_ID };
 			const store = setup({
 				mainMenu: {
 					open: true,

--- a/test/plugins/HighlightPlugin.test.js
+++ b/test/plugins/HighlightPlugin.test.js
@@ -180,7 +180,7 @@ describe('HighlightPlugin', () => {
 
 			expect(store.getState().highlight.features).toHaveSize(1);
 			expect(store.getState().highlight.features[0].data.coordinate).toEqual(coordinate);
-			expect(store.getState().highlight.features[0].type).toEqual(HighlightFeatureType.FEATURE_INFO_RUNNING);
+			expect(store.getState().highlight.features[0].type).toEqual(HighlightFeatureType.QUERY_RUNNING);
 
 			resolveQuery(queryId);
 

--- a/test/store/highlight/highlight.action.test.js
+++ b/test/store/highlight/highlight.action.test.js
@@ -6,7 +6,7 @@ describe('highlightAction', () => {
 		expect(Object.keys(HighlightFeatureType).length).toBe(4);
 		expect(HighlightFeatureType.DEFAULT).toBe(0);
 		expect(HighlightFeatureType.TEMPORARY).toBe(1);
-		expect(HighlightFeatureType.FEATURE_INFO_RUNNING).toBe(2);
+		expect(HighlightFeatureType.QUERY_RUNNING).toBe(2);
 		expect(HighlightFeatureType.FEATURE_INFO_SUCCESS).toBe(3);
 	});
 

--- a/test/store/highlight/highlight.action.test.js
+++ b/test/store/highlight/highlight.action.test.js
@@ -7,7 +7,7 @@ describe('highlightAction', () => {
 		expect(HighlightFeatureType.DEFAULT).toBe(0);
 		expect(HighlightFeatureType.TEMPORARY).toBe(1);
 		expect(HighlightFeatureType.QUERY_RUNNING).toBe(2);
-		expect(HighlightFeatureType.FEATURE_INFO_SUCCESS).toBe(3);
+		expect(HighlightFeatureType.QUERY_SUCCESS).toBe(3);
 	});
 
 	it('exports a enum for HighlightGeometryTypes', () => {


### PR DESCRIPTION
Let's use the same symbol we use for a successful feature info indication
![grafik](https://user-images.githubusercontent.com/49945713/161397283-debb675c-2a97-4639-a552-12ae8fd00cf7.png)
