### PR TITLE
fix updatestyle-behavior

### DIFF
--- a/src/modules/map/components/olMap/handler/draw/OlDrawHandler.js
+++ b/src/modules/map/components/olMap/handler/draw/OlDrawHandler.js
@@ -627,7 +627,7 @@ export class OlDrawHandler extends OlLayerHandler {
 			const styleFunction = this._getStyleFunctionFrom(feature);
 			const newStyles = styleFunction(feature);
 
-			feature.setStyle([newStyles[0], ...feature.getStyle()]);
+			feature.setStyle([newStyles[0], ...feature.getStyle().slice(1)]);
 			this._setSelected(feature);
 		}
 

--- a/test/modules/map/components/olMap/handler/draw/OlDrawHandler.test.js
+++ b/test/modules/map/components/olMap/handler/draw/OlDrawHandler.test.js
@@ -756,8 +756,22 @@ describe('OlDrawHandler', () => {
 				const map = setupMap();
 				const style = { symbolSrc: null, color: '#ff0000', scale: 0.5 };
 				const feature = new Feature({ geometry: new Point([0, 0]) });
+
+				const oldStyle1 = new Style(new Stroke({
+					color: [0, 0, 0, 1],
+					width: 3
+				}));
+				const oldStyle2 = new Style(new Stroke({
+					color: [42, 0, 0, 1],
+					width: 3
+				}));
+				const newStyle = new Style(new Stroke({
+					color: [255, 255, 255, 1],
+					width: 12
+				}));
+				spyOn(classUnderTest, '_getStyleFunctionFrom').withArgs(feature).and.callFake(() => () => [newStyle]);
 				feature.setId('draw_Symbol_1234');
-				feature.setStyle([new Style(), new Style()]);
+				feature.setStyle([oldStyle1, oldStyle2]);
 				const drawStateFake = {
 					type: InteractionStateType.MODIFY
 				};
@@ -770,6 +784,7 @@ describe('OlDrawHandler', () => {
 				setStyle(style);
 
 				expect(styleSpy).toHaveBeenCalledTimes(1);
+				expect(styleSpy).toHaveBeenCalledWith([newStyle, oldStyle2]);
 			});
 
 


### PR DESCRIPTION
Corrects the updateStyle-behavior by merging correctly the new, changed style, with the current style-array.
This results in a replacement of the first entry in the style-array.

update test; reflecting the changed expectations setStyle should be called with [newStyle, oldStyle2]

fixes #881 