### PR TITLE
improve deep comparision approach

### DIFF
--- a/src/modules/help/components/firststeps.css
+++ b/src/modules/help/components/firststeps.css
@@ -11,9 +11,9 @@
 	background: var(--info-color);
 	background: var(--primary-bg-color);
 	cursor: pointer;
-	border:0;
+	border: 0;
 }
-.first_steps__button:focus{
+.first_steps__button:focus {
 	box-shadow: 0 0 0 .2em var(--primary-color-lighter);
 }
 .first_steps__link {
@@ -54,7 +54,7 @@
 }
 .first_steps__notification-section {
 	display: flex;
-	margin-bottom:1em;
+	margin-bottom: 1em;
 
 }
 .first_steps__notification-icon {

--- a/src/utils/storeUtils.js
+++ b/src/utils/storeUtils.js
@@ -51,6 +51,13 @@ export const equals = (value0, value1) => {
 		return false;
 	}
 
+	if (
+		(Array.isArray(value0) && !Array.isArray(value1)) ||
+		(!Array.isArray(value0) && Array.isArray(value1))
+	) {
+		return false;
+	}
+
 	const keys0 = Object.keys(value0);
 	const keys1 = Object.keys(value1);
 

--- a/src/utils/storeUtils.js
+++ b/src/utils/storeUtils.js
@@ -38,11 +38,45 @@ export const observe = (store, extract, onChange, ignoreInitialState = true) => 
  * @returns {boolean} true if both values are equal
  */
 export const equals = (value0, value1) => {
-	if (typeof value0 === 'object' && typeof value1 === 'object') {
-		// maybe we should use Lo.isEqual later, but for now it does the job
-		return JSON.stringify(value0) === JSON.stringify(value1);
+	if (value0 === value1) {
+		return true;
 	}
-	return value0 === value1;
+
+	if (
+		typeof value0 !== 'object' ||
+		typeof value1 !== 'object' ||
+		value0 == null ||
+		value1 == null
+	) {
+		return false;
+	}
+
+	const keys0 = Object.keys(value0);
+	const keys1 = Object.keys(value1);
+
+	if (keys0.length !== keys1.length) {
+		return false;
+	}
+
+	return keys0.every((key) => {
+		if (!keys1.includes(key)) {
+			return false;
+		}
+
+		if (
+			typeof value0[key] === 'function' ||
+			typeof value1[key] === 'function'
+		) {
+			if (value0[key].toString() !== value1[key].toString()) {
+				return false;
+			}
+		}
+
+		if (!equals(value0[key], value1[key])) {
+			return false;
+		}
+		return true;
+	});
 };
 
 /**

--- a/src/utils/storeUtils.js
+++ b/src/utils/storeUtils.js
@@ -43,10 +43,17 @@ export const equals = (value0, value1) => {
 	}
 
 	if (
+		typeof value0 === 'function' &&
+		typeof value1 === 'function'
+	) {
+		return value0.toString() === value1.toString();
+	}
+
+	if (
 		typeof value0 !== 'object' ||
 		typeof value1 !== 'object' ||
-		value0 == null ||
-		value1 == null
+		!value0 ||
+		!value1
 	) {
 		return false;
 	}
@@ -69,20 +76,7 @@ export const equals = (value0, value1) => {
 		if (!keys1.includes(key)) {
 			return false;
 		}
-
-		if (
-			typeof value0[key] === 'function' ||
-			typeof value1[key] === 'function'
-		) {
-			if (value0[key].toString() !== value1[key].toString()) {
-				return false;
-			}
-		}
-
-		if (!equals(value0[key], value1[key])) {
-			return false;
-		}
-		return true;
+		return equals(value0[key], value1[key]);
 	});
 };
 

--- a/test/utils/storeUtils.test.js
+++ b/test/utils/storeUtils.test.js
@@ -126,7 +126,8 @@ describe('store utils', () => {
 		});
 
 		it('compares arrays and objects deeply', () => {
-			expect(equals({ some: 42 }, { some: 42 })).toBeTrue();
+			expect(equals({ some: 42, thing: 21 }, { some: 42, thing: 21 })).toBeTrue();
+			expect(equals({ some: 42, thing: 21 }, { thing: 21, some: 42 })).toBeTrue();
 			expect(equals(['some', 'foo'], ['some', 'foo'])).toBeTrue();
 			expect(equals([42, { value: 42 }, 'some'], [42, { value: 42 }, 'some'])).toBeTrue();
 

--- a/test/utils/storeUtils.test.js
+++ b/test/utils/storeUtils.test.js
@@ -115,8 +115,6 @@ describe('store utils', () => {
 			expect(equals('some', 'some')).toBeTrue();
 			const sym = Symbol('foo');
 			expect(equals(sym, sym)).toBeTrue();
-			const someF = () => { };
-			expect(equals(someF, someF)).toBeTrue();
 			expect(equals(undefined, null)).toBeFalse();
 			expect(equals(undefined, {})).toBeFalse();
 			expect(equals(null, {})).toBeFalse();
@@ -125,10 +123,19 @@ describe('store utils', () => {
 			expect(equals(true, false)).toBeFalse();
 			expect(equals('some', 'Some')).toBeFalse();
 			expect(equals(Symbol('foo'), Symbol('foo'))).toBeFalse();
-			expect(equals(() => { }, () => { })).toBeFalse();
 			expect(equals([], [])).toBeTrue();
 			expect(equals(null, null)).toBeTrue();
 			expect(equals(undefined, undefined)).toBeTrue();
+		});
+
+		it('compares functions', () => {
+
+			const someF = () => { };
+			const someOtherF = () => {
+				return;
+			};
+			expect(equals(someF, someF)).toBeTrue();
+			expect(equals(someF, someOtherF)).toBeFalse();
 		});
 
 		it('compares arrays and objects deeply', () => {
@@ -138,6 +145,13 @@ describe('store utils', () => {
 			expect(equals([42, { value: 42 }, 'some'], [42, { value: 42 }, 'some'])).toBeTrue();
 
 			expect(equals({ some: 42 }, { some: 21 })).toBeFalse();
+			expect(equals({ some: 42 }, { thing: 42 })).toBeFalse();
+			expect(equals({ some: () => { } }, { some: () => { } })).toBeTrue();
+			expect(equals({ some: () => { } }, {
+				some: () => {
+					return;
+				}
+			})).toBeFalse();
 			expect(equals(['some', 'foo'], ['foo', 'some'])).toBeFalse();
 			expect(equals([42, { value: 42 }, 'some'], [42, { value: 21 }, 'some'])).toBeFalse();
 			expect(equals([], {})).toBeFalse();

--- a/test/utils/storeUtils.test.js
+++ b/test/utils/storeUtils.test.js
@@ -117,12 +117,18 @@ describe('store utils', () => {
 			expect(equals(sym, sym)).toBeTrue();
 			const someF = () => { };
 			expect(equals(someF, someF)).toBeTrue();
+			expect(equals(undefined, null)).toBeFalse();
+			expect(equals(undefined, {})).toBeFalse();
+			expect(equals(null, {})).toBeFalse();
 
 			expect(equals(1, 2)).toBeFalse();
 			expect(equals(true, false)).toBeFalse();
 			expect(equals('some', 'Some')).toBeFalse();
 			expect(equals(Symbol('foo'), Symbol('foo'))).toBeFalse();
 			expect(equals(() => { }, () => { })).toBeFalse();
+			expect(equals([], [])).toBeTrue();
+			expect(equals(null, null)).toBeTrue();
+			expect(equals(undefined, undefined)).toBeTrue();
 		});
 
 		it('compares arrays and objects deeply', () => {
@@ -134,6 +140,8 @@ describe('store utils', () => {
 			expect(equals({ some: 42 }, { some: 21 })).toBeFalse();
 			expect(equals(['some', 'foo'], ['foo', 'some'])).toBeFalse();
 			expect(equals([42, { value: 42 }, 'some'], [42, { value: 21 }, 'some'])).toBeFalse();
+			expect(equals([], {})).toBeFalse();
+			expect(equals({}, [])).toBeFalse();
 		});
 	});
 


### PR DESCRIPTION
make `equal` generally valid including  `{ a:0, b:1 } === { b:1, a:0 } `