### PR TITLE
enhancement; clear input value, before import

### DIFF
--- a/src/modules/toolbox/components/importToolContent/ImportToolContent.js
+++ b/src/modules/toolbox/components/importToolContent/ImportToolContent.js
@@ -27,10 +27,13 @@ export class ImportToolContent extends AbstractToolContent {
 	createView() {
 		const translate = (key) => this._translationService.translate(key);
 
+		const onClear = () => {
+			const inputElement = this._root.querySelector('input');
+			inputElement.value = null;
+		};
 		const onUpload = () => {
 			const inputElement = this._root.querySelector('input');
 			const files = inputElement?.files;
-
 			const importData = async (blob, sourceType) => {
 				const text = await blob.text();
 				setData(text, sourceType);
@@ -77,7 +80,7 @@ export class ImportToolContent extends AbstractToolContent {
 							<div class="tool-container__button-text" >
 								${translate('toolbox_import_data_button')}							
 							</div>
-							<input id='fileupload' type='file' @change=${onUpload}></input>
+							<input id='fileupload' type='file' @change=${onUpload} @click=${onClear} ></input>
 						</label>
 					</div>
 					<div  class='drag-drop-preview ${getIsTouchHide()}'>


### PR DESCRIPTION
after successfully import a file, selecting the same file with file-chooser does not results in a change-event and therefore prevents a second import.

Clearing the value of the input-element triggers the change-event in the case of the same file also.

fixes #904 