### PR TITLE
update creation of  MeasurementOverlays

### DIFF
--- a/src/modules/map/components/olMap/handler/measure/MeasurementOverlayStyle.js
+++ b/src/modules/map/components/olMap/handler/measure/MeasurementOverlayStyle.js
@@ -38,9 +38,10 @@ export class MeasurementOverlayStyle extends OverlayStyle {
 
 	constructor() {
 		super();
-		const { MapService, EnvironmentService } = $injector.inject('MapService', 'EnvironmentService');
+		const { MapService, EnvironmentService, StoreService } = $injector.inject('MapService', 'EnvironmentService', 'StoreService');
 		this._mapService = MapService;
 		this._environmentService = EnvironmentService;
+		this._storeService = StoreService;
 		this._projectionHints = { fromProjection: 'EPSG:' + this._mapService.getSrid(), toProjection: 'EPSG:' + this._mapService.getDefaultGeodeticSrid() };
 	}
 
@@ -122,9 +123,14 @@ export class MeasurementOverlayStyle extends OverlayStyle {
 		olFeature.set('overlays', []);
 	}
 
+	_isActiveMeasurement() {
+		const { measurement } = this._storeService.getStore().getState();
+		return measurement.active;
+	}
+
 	_createDistanceOverlay(olFeature, olMap) {
 		const createNew = () => {
-			const isDraggable = !this._environmentService.isTouch();
+			const isDraggable = !this._environmentService.isTouch() && this._isActiveMeasurement();
 			const overlay = this._createOlOverlay(olMap, { offset: [0, -15], positioning: 'bottom-center' }, MeasurementOverlayTypes.DISTANCE, this._projectionHints, isDraggable);
 			olFeature.set('measurement', overlay);
 			this._add(overlay, olFeature, olMap);

--- a/test/modules/map/components/olMap/handler/measure/MeasurementOverlayStyle.test.js
+++ b/test/modules/map/components/olMap/handler/measure/MeasurementOverlayStyle.test.js
@@ -5,6 +5,7 @@ import { LineString, Polygon } from 'ol/geom';
 import { $injector } from '../../../../../../../src/injection';
 import proj4 from 'proj4';
 import { register } from 'ol/proj/proj4';
+import { measurementReducer } from '../../../../../../../src/store/measurement/measurement.reducer';
 
 
 
@@ -13,8 +14,18 @@ register(proj4);
 
 describe('MeasurementOverlayStyle', () => {
 	const environmentServiceMock = { isTouch: () => false };
-	const setup = () => {
-		TestUtils.setupStoreAndDi({});
+	const initialState = {
+		active: false,
+		statistic: { length: 0, area: 0 },
+		selection: [],
+		reset: null,
+		fileSaveResult: { adminId: 'init', fileId: 'init' }
+	};
+	const setup = (state = initialState) => {
+		const measurementState = {
+			measurement: state
+		};
+		TestUtils.setupStoreAndDi(measurementState, { measurement: measurementReducer });
 		$injector.registerSingleton('TranslationService', { translate: (key) => key })
 			.registerSingleton('MapService', { getSrid: () => 3857, getDefaultGeodeticSrid: () => 25832 })
 			.registerSingleton('EnvironmentService', environmentServiceMock)

--- a/test/modules/map/components/olMap/handler/measure/OlMeasurementHandler.test.js
+++ b/test/modules/map/components/olMap/handler/measure/OlMeasurementHandler.test.js
@@ -1505,7 +1505,8 @@ describe('OlMeasurementHandler', () => {
 		describe('drags overlays', () => {
 
 			it('change overlay-property on pointerdown', () => {
-				setup();
+				const state = { ...initialState, active: true };
+				setup(state);
 				const classUnderTest = new OlMeasurementHandler();
 				const map = setupMap();
 				classUnderTest.activate(map);
@@ -1524,7 +1525,8 @@ describe('OlMeasurementHandler', () => {
 			});
 
 			it('changes position of overlay on pointermove', () => {
-				setup();
+				const state = { ...initialState, active: true };
+				setup(state);
 				const classUnderTest = new OlMeasurementHandler();
 				const map = setupMap();
 				classUnderTest.activate(map);
@@ -1556,7 +1558,8 @@ describe('OlMeasurementHandler', () => {
 			});
 
 			it('triggers overlay as dragable', () => {
-				setup();
+				const state = { ...initialState, active: true };
+				setup(state);
 				const classUnderTest = new OlMeasurementHandler();
 				const map = setupMap();
 				classUnderTest.activate(map);

--- a/test/modules/map/components/olMap/services/OverlayService.test.js
+++ b/test/modules/map/components/olMap/services/OverlayService.test.js
@@ -6,11 +6,19 @@ import { Polygon } from 'ol/geom';
 import { StyleTypes } from '../../../../../../src/modules/map/components/olMap/services/StyleService';
 import proj4 from 'proj4';
 import { register } from 'ol/proj/proj4';
+import { measurementReducer } from '../../../../../../src/store/measurement/measurement.reducer';
 
 proj4.defs('EPSG:25832', '+proj=utm +zone=32 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +axis=neu');
 register(proj4);
 
 describe('OverlayService', () => {
+	const initialState = {
+		active: false,
+		statistic: { length: 0, area: 0 },
+		selection: [],
+		reset: null,
+		fileSaveResult: { adminId: 'init', fileId: 'init' }
+	};
 	const mapServiceMock = {
 		getSrid: () => 3857,
 		getDefaultGeodeticSrid: () => 25832
@@ -31,7 +39,10 @@ describe('OverlayService', () => {
 		}
 	};
 	beforeAll(() => {
-		TestUtils.setupStoreAndDi();
+		const measurementState = {
+			measurement: initialState
+		};
+		TestUtils.setupStoreAndDi(measurementState, { measurement: measurementReducer });
 		$injector
 			.registerSingleton('MapService', mapServiceMock)
 			.registerSingleton('EnvironmentService', environmentServiceMock)

--- a/test/modules/map/components/olMap/services/StyleService.test.js
+++ b/test/modules/map/components/olMap/services/StyleService.test.js
@@ -7,11 +7,18 @@ import { Polygon, Point } from 'ol/geom';
 import proj4 from 'proj4';
 import { register } from 'ol/proj/proj4';
 import { Icon, Style, Text } from 'ol/style';
+import { measurementReducer } from '../../../../../../src/store/measurement/measurement.reducer';
 
 proj4.defs('EPSG:25832', '+proj=utm +zone=32 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +axis=neu');
 register(proj4);
 describe('StyleService', () => {
-
+	const initialState = {
+		active: false,
+		statistic: { length: 0, area: 0 },
+		selection: [],
+		reset: null,
+		fileSaveResult: { adminId: 'init', fileId: 'init' }
+	};
 	const mapServiceMock = { getSrid: () => 3857, getDefaultGeodeticSrid: () => 25832 };
 
 	const environmentServiceMock = {
@@ -35,7 +42,10 @@ describe('StyleService', () => {
 
 
 	beforeAll(() => {
-		TestUtils.setupStoreAndDi();
+		const measurementState = {
+			measurement: initialState
+		};
+		TestUtils.setupStoreAndDi(measurementState, { measurement: measurementReducer });
 		$injector
 			.registerSingleton('MapService', mapServiceMock)
 			.registerSingleton('EnvironmentService', environmentServiceMock)


### PR DESCRIPTION
update the process of creating measurement-overlays. The draggable-behavior of a MeasurementOverlay now depends whether there is a touch-environment detected and an active measurement-session or not.

fixes #922 