### PR TITLE
Prevent overlapping MeasurementOverlays

### DIFF
--- a/src/modules/map/components/olMap/handler/measure/MeasurementOverlayStyle.js
+++ b/src/modules/map/components/olMap/handler/measure/MeasurementOverlayStyle.js
@@ -190,13 +190,8 @@ export class MeasurementOverlayStyle extends OverlayStyle {
 		}
 
 		const resolution = olMap.getView().getResolution();
-		let delta;
-		if (partitions.length === 0) {
-			delta = parseFloat(olFeature.get('partition_delta')) || getPartitionDelta(simplifiedGeometry, resolution, this._projectionHints);
-		}
-		else {
-			delta = getPartitionDelta(simplifiedGeometry, resolution, this._projectionHints);
-		}
+		const delta = getPartitionDelta(simplifiedGeometry, resolution, this._projectionHints);
+
 		let partitionIndex = 0;
 		for (let i = delta; i < 1; i += delta, partitionIndex++) {
 			let partition = partitions[partitionIndex] || false;
@@ -207,7 +202,6 @@ export class MeasurementOverlayStyle extends OverlayStyle {
 			}
 			this._updateOlOverlay(partition, simplifiedGeometry, i);
 		}
-
 		if (partitionIndex < partitions.length) {
 			for (let j = partitions.length - 1; j >= partitionIndex; j--) {
 				const removablePartition = partitions[j];

--- a/src/modules/map/components/olMap/olGeometryUtils.js
+++ b/src/modules/map/components/olMap/olGeometryUtils.js
@@ -148,7 +148,7 @@ export const getAzimuth = (geometry) => {
 export const getPartitionDelta = (geometry, resolution = 1, calculationHints = {}) => {
 	const length = getGeometryLength(geometry, calculationHints);
 
-	const minLengthResolution = 20;
+	const minLengthResolution = 40;
 	const isValidForResolution = (partition) => {
 		const partitionResolution = partition / resolution;
 		return partitionResolution > minLengthResolution && length > partition;

--- a/test/modules/map/components/olMap/handler/measure/MeasurementOverlayStyle.test.js
+++ b/test/modules/map/components/olMap/handler/measure/MeasurementOverlayStyle.test.js
@@ -284,7 +284,7 @@ describe('MeasurementOverlayStyle', () => {
 		geometry.setCoordinates([[0, 0], [12345, 0]]);
 		classUnderTest._createOrRemovePartitionOverlays(feature, mapMock);
 
-		expect(feature.get('partitions').length).toBe(12);
+		expect(feature.get('partitions').length).toBe(1);
 	});
 
 	it('removes area overlay after change from polygon to line', () => {

--- a/test/modules/map/components/olMap/handler/measure/OlMeasurementHandler.test.js
+++ b/test/modules/map/components/olMap/handler/measure/OlMeasurementHandler.test.js
@@ -821,7 +821,7 @@ describe('OlMeasurementHandler', () => {
 		it('removes partition tooltips after zoom out', () => {
 			setup();
 			const classUnderTest = new OlMeasurementHandler();
-			const map = setupMap(15);
+			const map = setupMap(16);
 			const geometry = new LineString([[0, 0], [1234, 0]]);
 			const feature = new Feature({ geometry: geometry });
 


### PR DESCRIPTION
Under some circumstances the measurement-overlays overlapping each other...
With this enhancement, the calculation is updated to prevent the overlap.