### PR TITLE
reactivate DragPan after dragging overlay

### DIFF
--- a/src/modules/map/components/olMap/handler/measure/MeasurementOverlayStyle.js
+++ b/src/modules/map/components/olMap/handler/measure/MeasurementOverlayStyle.js
@@ -290,6 +290,11 @@ export class MeasurementOverlayStyle extends OverlayStyle {
 				overlay.set('dragging', true);
 			};
 
+			const handleMouseUp = () => {
+				dragPanInteraction.setActive(true);
+				overlay.set('dragging', false);
+			};
+
 			const handleMouseEnter = () => {
 				overlay.set('dragable', true);
 			};
@@ -298,6 +303,7 @@ export class MeasurementOverlayStyle extends OverlayStyle {
 				overlay.set('dragable', false);
 			};
 			element.addEventListener(MapBrowserEventType.POINTERDOWN, handleMouseDown);
+			element.addEventListener(MapBrowserEventType.POINTERUP, handleMouseUp);
 			element.addEventListener('mouseenter', handleMouseEnter);
 			element.addEventListener('mouseleave', handleMouseLeave);
 		}

--- a/test/modules/map/components/olMap/handler/measure/MeasurementOverlayStyle.test.js
+++ b/test/modules/map/components/olMap/handler/measure/MeasurementOverlayStyle.test.js
@@ -6,6 +6,7 @@ import { $injector } from '../../../../../../../src/injection';
 import proj4 from 'proj4';
 import { register } from 'ol/proj/proj4';
 import { measurementReducer } from '../../../../../../../src/store/measurement/measurement.reducer';
+import { DragPan } from 'ol/interaction';
 
 
 
@@ -577,5 +578,87 @@ describe('MeasurementOverlayStyle', () => {
 
 		expect(actualPosition).toBeUndefined();
 		expect(actualProperty).toEqual({ key: '', value: null });
+	});
+
+	describe('_createDragOn', () => {
+
+		const getOverlay = () => {
+			const element = document.createElement('div');
+			return { getElement: () => element, set: () => { } };
+		};
+
+
+		const getMapMock = (interaction) => {
+			return {
+				getInteractions: () => {
+					return { getArray: () => [interaction] };
+				}
+			};
+		};
+
+		it('change overlay-property on pointerdown', () => {
+			setup();
+			const overlay = getOverlay();
+			const draggingSpy = spyOn(overlay, 'set');
+			const dragPan = new DragPan();
+			const interactionSpy = spyOn(dragPan, 'setActive');
+			const mapMock = getMapMock(dragPan);
+			const element = overlay.getElement();
+			const classUnderTest = new MeasurementOverlayStyle();
+
+			classUnderTest._createDragOn(overlay, mapMock);
+			element.dispatchEvent(new Event('pointerdown'));
+
+			expect(draggingSpy).toHaveBeenCalledWith('dragging', true);
+			expect(interactionSpy).toHaveBeenCalledWith(false);
+		});
+
+		it('change overlay-property on pointerup', () => {
+			setup();
+			const overlay = getOverlay();
+			const draggingSpy = spyOn(overlay, 'set');
+			const dragPan = new DragPan();
+			const interactionSpy = spyOn(dragPan, 'setActive');
+			const mapMock = getMapMock(dragPan);
+			const element = overlay.getElement();
+			const classUnderTest = new MeasurementOverlayStyle();
+
+			classUnderTest._createDragOn(overlay, mapMock);
+			element.dispatchEvent(new Event('pointerup'));
+
+			expect(draggingSpy).toHaveBeenCalledWith('dragging', false);
+			expect(interactionSpy).toHaveBeenCalledWith(true);
+		});
+
+		it('change overlay-property on mouseenter', () => {
+			setup();
+			const overlay = getOverlay();
+			const dragableSpy = spyOn(overlay, 'set');
+			const dragPan = new DragPan();
+			const mapMock = getMapMock(dragPan);
+			const element = overlay.getElement();
+			const classUnderTest = new MeasurementOverlayStyle();
+
+			classUnderTest._createDragOn(overlay, mapMock);
+			element.dispatchEvent(new MouseEvent('mouseenter'));
+
+			expect(dragableSpy).toHaveBeenCalledWith('dragable', true);
+		});
+
+		it('change overlay-property on mouseleave', () => {
+			setup();
+			const overlay = getOverlay();
+			const dragableSpy = spyOn(overlay, 'set');
+			const dragPan = new DragPan();
+			const mapMock = getMapMock(dragPan);
+			const element = overlay.getElement();
+			const classUnderTest = new MeasurementOverlayStyle();
+
+			classUnderTest._createDragOn(overlay, mapMock);
+			element.dispatchEvent(new MouseEvent('mouseleave'));
+
+			expect(dragableSpy).toHaveBeenCalledWith('dragable', false);
+		});
+
 	});
 });

--- a/test/modules/map/components/olMap/handler/measure/OlMeasurementHandler.test.js
+++ b/test/modules/map/components/olMap/handler/measure/OlMeasurementHandler.test.js
@@ -1557,6 +1557,31 @@ describe('OlMeasurementHandler', () => {
 				expect(overlay.get('dragging')).toBeFalse();
 			});
 
+			it('change overlay-property on pointerup', () => {
+				const state = { ...initialState, active: true };
+				setup(state);
+				const classUnderTest = new OlMeasurementHandler();
+				const map = setupMap();
+				classUnderTest.activate(map);
+
+				const geometry = new Polygon([[[0, 0], [500, 0], [550, 550], [0, 500], [0, 500]]]);
+				const feature = new Feature({ geometry: geometry });
+				simulateDrawEvent('drawstart', classUnderTest._draw, feature);
+				feature.getGeometry().dispatchEvent('change');
+				simulateDrawEvent('drawend', classUnderTest._draw, feature);
+				const overlay = feature.get('measurement');
+				const element = overlay.getElement();
+
+				element.dispatchEvent(new Event('pointerdown'));
+
+				expect(overlay.get('dragging')).toBeTrue();
+
+				element.dispatchEvent(new Event('pointerup'));
+
+				expect(overlay.get('dragging')).toBeFalse();
+			});
+
+
 			it('triggers overlay as dragable', () => {
 				const state = { ...initialState, active: true };
 				setup(state);


### PR DESCRIPTION
add event-handling on 'pointerup 'for a dragged overlay-element to reactivate DragPan-interaction


fixes #922