### PR TITLE
add: auto width for th and td tags

### DIFF
--- a/src/modules/featureInfo/components/featureInfoPanel.css
+++ b/src/modules/featureInfo/components/featureInfoPanel.css
@@ -71,6 +71,7 @@ tr {
 
 th, td {
 	padding: .8em 1em;
+	width: auto;
 }
 
 .is-portrait table , .is-portrait tr, .is-portrait th {


### PR DESCRIPTION
Left is the fixed one:
![fix](https://user-images.githubusercontent.com/76113751/166669667-06270466-6515-4b05-bf78-f580fe056829.png)
: