### PR TITLE
fix createStringLatLong

### DIFF
--- a/src/services/provider/stringifyCoords.provider.js
+++ b/src/services/provider/stringifyCoords.provider.js
@@ -36,11 +36,12 @@ export const bvvStringifyFunction = (srid, options = {}) => {
 
 /**
  * A function that returns a function specific for the representation of geographic
- * point location according to {@link https://en.wikipedia.org/wiki/ISO_6709|ISO 6709}
+ * point location according to {@link https://en.wikipedia.org/wiki/ISO_6709|ISO 6709}.
+ * Switching [X,Y,(Z)] to [Y,X,(Z)]
  * @param {number} digits
  */
 const createStringLatLong = (digits) => {
-	return (coordinate) => createStringXY(digits)(coordinate.reverse());
+	return (coordinate) => createStringXY(digits)([...coordinate.slice(0, 2).reverse(), ...coordinate.slice(2)]);
 };
 
 const createStringUTM = (srid, digits) => {

--- a/src/services/provider/stringifyCoords.provider.js
+++ b/src/services/provider/stringifyCoords.provider.js
@@ -37,11 +37,12 @@ export const bvvStringifyFunction = (srid, options = {}) => {
 /**
  * A function that returns a function specific for the representation of geographic
  * point location according to {@link https://en.wikipedia.org/wiki/ISO_6709|ISO 6709}.
- * Switching [X,Y,(Z)] to [Y,X,(Z)]
+ * Switching [X,Y,(Z,M)] to [Y,X].
+ * Possible Z-, M-values are currently ignored. This may change in future implementations.
  * @param {number} digits
  */
 const createStringLatLong = (digits) => {
-	return (coordinate) => createStringXY(digits)([...coordinate.slice(0, 2).reverse(), ...coordinate.slice(2)]);
+	return (coordinate) => createStringXY(digits)(coordinate.slice(0, 2).reverse());
 };
 
 const createStringUTM = (srid, digits) => {

--- a/src/services/provider/stringifyCoords.provider.js
+++ b/src/services/provider/stringifyCoords.provider.js
@@ -38,10 +38,10 @@ export const bvvStringifyFunction = (srid, options = {}) => {
  * A function that returns a function specific for the representation of geographic
  * point location according to {@link https://en.wikipedia.org/wiki/ISO_6709|ISO 6709}.
  * Switching [X,Y,(Z,M)] to [Y,X].
- * Possible Z-, M-values are currently ignored. This may change in future implementations.
  * @param {number} digits
  */
 const createStringLatLong = (digits) => {
+	// Possible Z-, M-values are currently ignored. This may change in future implementations.
 	return (coordinate) => createStringXY(digits)(coordinate.slice(0, 2).reverse());
 };
 

--- a/test/service/provider/stringifyCoords.provider.test.js
+++ b/test/service/provider/stringifyCoords.provider.test.js
@@ -37,10 +37,11 @@ describe('StringifyCoord provider', () => {
 		it('stringifies a 4326 coordinate', () => {
 
 			const coord4326 = [11.57245, 48.14021];
+			const coord4326_3d = [11.57245, 48.14021, 42];
 
-			const formatedString = bvvStringifyFunction(4326)(coord4326, { digits: 3 });
+			expect(bvvStringifyFunction(4326)(coord4326, { digits: 3 })).toBe('48.140, 11.572');
+			expect(bvvStringifyFunction(4326)(coord4326_3d, { digits: 3 })).toBe('48.140, 11.572');
 
-			expect(formatedString).toBe('48.140, 11.572');
 		});
 
 


### PR DESCRIPTION
Instead of simple reverse the order of assumed 2D coordinate-array only
switching the XY-part of the coordinate-array to left the righter
parts (Z,...) untouched.

fixes #994 