### PR TITLE
search query state changes should trigger SearchUI

### DIFF
--- a/src/modules/header/components/Header.js
+++ b/src/modules/header/components/Header.js
@@ -12,7 +12,7 @@ const Update_IsOpen_TabIndex = 'update_isOpen_tabIndex';
 const Update_Fetching = 'update_fetching';
 const Update_Layers = 'update_layers';
 const Update_IsPortrait_HasMinWidth = 'update_isPortrait_hasMinWidth';
-const Update_HasSearchTerm = 'update_hasSearchTerm';
+const Update_SearchTerm = 'update_searchTerm';
 
 /**
  * Container element for header stuff.
@@ -30,7 +30,7 @@ export class Header extends MvuElement {
 			layers: [],
 			isPortrait: false,
 			hasMinWidth: false,
-			hasSearchTerm: false
+			searchTerm: null
 		});
 
 		const {
@@ -55,8 +55,8 @@ export class Header extends MvuElement {
 				return { ...model, layers: data };
 			case Update_IsPortrait_HasMinWidth:
 				return { ...model, ...data };
-			case Update_HasSearchTerm:
-				return { ...model, hasSearchTerm: data };
+			case Update_SearchTerm:
+				return { ...model, searchTerm: data };
 		}
 	}
 
@@ -65,6 +65,7 @@ export class Header extends MvuElement {
 		this.observe(state => state.network.fetching, fetching => this.signal(Update_Fetching, fetching));
 		this.observe(state => state.layers.active, active => this.signal(Update_Layers, active.filter(l => l.constraints.hidden === false)));
 		this.observe(state => state.media, media => this.signal(Update_IsPortrait_HasMinWidth, { isPortrait: media.portrait, hasMinWidth: media.minWidth }));
+		this.observe(state => state.search.query, query => this.signal(Update_SearchTerm, query.payload));
 	}
 
 	onAfterRender(firsttime) {
@@ -101,7 +102,7 @@ export class Header extends MvuElement {
 
 	createView(model) {
 
-		const { isOpen, tabIndex, isFetching, layers, isPortrait, hasMinWidth, hasSearchTerm } = model;
+		const { isOpen, tabIndex, isFetching, layers, isPortrait, hasMinWidth, searchTerm } = model;
 
 		const showModalInfo = () => {
 			openModal('Showcase', html`<ba-showcase>`);
@@ -128,7 +129,7 @@ export class Header extends MvuElement {
 		};
 
 		const getIsClearClass = () => {
-			return hasSearchTerm ? 'is-clear-visible' : '';
+			return searchTerm ? 'is-clear-visible' : '';
 		};
 
 		const layerCount = layers.length;
@@ -154,7 +155,6 @@ export class Header extends MvuElement {
 			const term = evt.target.value;
 			openMainMenu();
 			setQuery(term);
-			this.signal(Update_HasSearchTerm, !!term);
 		};
 
 		const onInputBlur = () => {
@@ -219,7 +219,7 @@ export class Header extends MvuElement {
 						<div class="header__background">
 						</div>
 						<div class='header__search-container'>
-							<input id='input' data-test-id placeholder='${translate('header_search_placeholder')}' @focus="${onInputFocus}" @blur="${onInputBlur}" @input="${onInput}" class='header__search' type="search" placeholder="" />          
+							<input id='input' data-test-id placeholder='${translate('header_search_placeholder')}' value="${searchTerm}" @focus="${onInputFocus}" @blur="${onInputBlur}" @input="${onInput}" class='header__search' type="search" placeholder="" />          
 							<span class="header__search-clear ${getIsClearClass()}" @click="${clearSearchInput}">        							
 							</span>       
 							<button @click="${showModalInfo}" class="header__modal-button hide" title="modal">

--- a/src/plugins/MainMenuPlugin.js
+++ b/src/plugins/MainMenuPlugin.js
@@ -67,6 +67,14 @@ export class MainMenuPlugin extends BaPlugin {
 			setTab(this._previousTab);
 		};
 
+		const onQueryChanged = ({ payload }) => {
+
+			if (payload) {
+				setTab(TabId.SEARCH);
+				open();
+			}
+		};
+
 		const onTabChanged = (tab, state) => {
 			if (tab === TabId.FEATUREINFO) {
 				this._open = state.mainMenu.open;
@@ -78,6 +86,7 @@ export class MainMenuPlugin extends BaPlugin {
 
 		observe(store, state => state.featureInfo.querying, onFeatureInfoQueryingChanged);
 		observe(store, state => state.featureInfo.aborted, onFeatureInfoAbortedChanged);
+		observe(store, state => state.search.query, onQueryChanged, false);
 		observe(store, store => store.mainMenu.tab, onTabChanged, false);
 	}
 }

--- a/test/modules/header/components/Header.test.js
+++ b/test/modules/header/components/Header.test.js
@@ -691,7 +691,6 @@ describe('Header', () => {
 	describe('when search query state changes', () => {
 
 		it('takes the query term over to the input field', async () => {
-
 			const element = await setup();
 
 			expect(element.shadowRoot.querySelector('#input').getAttribute('value')).toBe('');

--- a/test/modules/header/components/Header.test.js
+++ b/test/modules/header/components/Header.test.js
@@ -219,7 +219,7 @@ describe('Header', () => {
 			expect(element.shadowRoot.querySelector('.header__button-container').children[1].children[1].innerText).toBe('2');
 		});
 
-		it('takes the query term over to the input field', async () => {
+		it('adopts the states query term', async () => {
 			const term = 'foo';
 			const state = {
 				search: {
@@ -690,7 +690,7 @@ describe('Header', () => {
 
 	describe('when search query state changes', () => {
 
-		it('takes the query term over to the input field', async () => {
+		it('adopts the states query term', async () => {
 			const element = await setup();
 
 			expect(element.shadowRoot.querySelector('#input').getAttribute('value')).toBe('');

--- a/test/modules/header/components/Header.test.js
+++ b/test/modules/header/components/Header.test.js
@@ -13,6 +13,7 @@ import { createNoInitialStateMediaReducer } from '../../../../src/store/media/me
 import { TabId } from '../../../../src/store/mainMenu/mainMenu.action';
 import { modalReducer } from '../../../../src/store/modal/modal.reducer';
 import { TEST_ID_ATTRIBUTE_NAME } from '../../../../src/utils/markup';
+import { setQuery } from '../../../../src/store/search/search.action';
 
 window.customElements.define(Header.tag, Header);
 
@@ -76,7 +77,7 @@ describe('Header', () => {
 				layers: [],
 				isPortrait: false,
 				hasMinWidth: false,
-				hasSearchTerm: false
+				searchTerm: null
 			});
 		});
 
@@ -216,6 +217,19 @@ describe('Header', () => {
 			const element = await setup(state);
 
 			expect(element.shadowRoot.querySelector('.header__button-container').children[1].children[1].innerText).toBe('2');
+		});
+
+		it('takes the query term over to the input field', async () => {
+			const term = 'foo';
+			const state = {
+				search: {
+					query: new EventLike(term)
+				}
+			};
+
+			const element = await setup(state);
+
+			expect(element.shadowRoot.querySelector('#input').getAttribute('value')).toBe(term);
 		});
 
 		it('contains test-id attributes', async () => {
@@ -671,6 +685,20 @@ describe('Header', () => {
 			expect(element.shadowRoot.querySelector('.action-button__border.animated-action-button__border').classList.contains('animated-action-button__border__running')).toBeTrue();
 			setFetching(false);
 			expect(element.shadowRoot.querySelector('.action-button__border.animated-action-button__border').classList.contains('animated-action-button__border__running')).toBeFalse();
+		});
+	});
+
+	describe('when search query state changes', () => {
+
+		it('takes the query term over to the input field', async () => {
+
+			const element = await setup();
+
+			expect(element.shadowRoot.querySelector('#input').getAttribute('value')).toBe('');
+
+			setQuery('foo');
+
+			expect(element.shadowRoot.querySelector('#input').getAttribute('value')).toBe('foo');
 		});
 	});
 });

--- a/test/plugins/MainMenuPlugin.test.js
+++ b/test/plugins/MainMenuPlugin.test.js
@@ -6,6 +6,9 @@ import { createNoInitialStateMainMenuReducer } from '../../src/store/mainMenu/ma
 import { MainMenuPlugin } from '../../src/plugins/MainMenuPlugin.js';
 import { $injector } from '../../src/injection/index.js';
 import { QueryParameters } from '../../src/services/domain/queryParameters.js';
+import { EventLike } from '../../src/utils/storeUtils.js';
+import { searchReducer } from '../../src/store/search/search.reducer.js';
+import { setQuery } from '../../src/store/search/search.action.js';
 
 
 describe('MainMenuPlugin', () => {
@@ -27,12 +30,16 @@ describe('MainMenuPlugin', () => {
 				open: false,
 				tab: null
 			},
+			search: {
+				query: new EventLike(null)
+			},
 			...state
 		};
 
 		const store = TestUtils.setupStoreAndDi(initialState, {
 			mainMenu: createNoInitialStateMainMenuReducer(),
-			featureInfo: featureInfoReducer
+			featureInfo: featureInfoReducer,
+			search: searchReducer
 		});
 		$injector
 			.registerSingleton('EnvironmentService', { getWindow: () => windowMock });
@@ -109,6 +116,20 @@ describe('MainMenuPlugin', () => {
 			expect(instanceUnderTest._open).toBeTrue();
 			expect(instanceUnderTest._previousTab).toBe(defaultTabId);
 			expect(initSpy).toHaveBeenCalled();
+		});
+
+
+		it('opens the search panel when query is available', async () => {
+			const store = setup({
+				search: {
+					query: new EventLike('foo')
+				}
+			});
+			const instanceUnderTest = new MainMenuPlugin();
+			await instanceUnderTest.register(store);
+
+			expect(store.getState().mainMenu.tab).toBe(TabId.SEARCH);
+			expect(store.getState().mainMenu.open).toBeTrue();
 		});
 	});
 
@@ -281,6 +302,39 @@ describe('MainMenuPlugin', () => {
 			setTab(TabId.FEATUREINFO);
 
 			expect(instanceUnderTest._open).toBeTrue();
+		});
+	});
+
+	describe('when search.query property changes', () => {
+
+		it('opens the search panel', async () => {
+			const store = setup({
+				mainMenu: {
+					open: false
+				}
+			});
+			const instanceUnderTest = new MainMenuPlugin();
+			await instanceUnderTest.register(store);
+
+			setQuery('foo');
+
+			expect(store.getState().mainMenu.tab).toBe(TabId.SEARCH);
+			expect(store.getState().mainMenu.open).toBeTrue();
+		});
+
+		it('does NOT open the search panel when query is not available', async () => {
+			const store = setup({
+				mainMenu: {
+					open: false
+				}
+			});
+			const instanceUnderTest = new MainMenuPlugin();
+			await instanceUnderTest.register(store);
+
+			setQuery(null);
+
+			expect(store.getState().mainMenu.open).toBeFalse();
+			expect(store.getState().mainMenu.tab).not.toBe(TabId.SEARCH);
 		});
 	});
 });

--- a/test/plugins/MainMenuPlugin.test.js
+++ b/test/plugins/MainMenuPlugin.test.js
@@ -95,8 +95,6 @@ describe('MainMenuPlugin', () => {
 				expect(store.getState().mainMenu.tab).toEqual(defaultTabId);
 			});
 		});
-
-
 	});
 
 	describe('register', () => {
@@ -117,7 +115,6 @@ describe('MainMenuPlugin', () => {
 			expect(instanceUnderTest._previousTab).toBe(defaultTabId);
 			expect(initSpy).toHaveBeenCalled();
 		});
-
 
 		it('opens the search panel when query is available', async () => {
 			const store = setup({


### PR DESCRIPTION
When search.query state changes, our Search UI should reflect it

- [x] bind input field bidirectionally -> input field shows current query term
- [x] open Search UI