### PR TITLE
update MapService.getVisibleViewport with arg

### DIFF
--- a/src/services/MapService.js
+++ b/src/services/MapService.js
@@ -132,13 +132,14 @@ export class MapService {
 	}
 
 	/**
-	 * Returns a DOMRect instance describing the visible part of the map
+	 * Returns a DOMRect instance describing the visible part of the specified map
 	 * (which means the part of the map that is not overlapped by any other UI element)
+	 * @param {HTMLElement} mapElement the map containing element
 	 * @returns {DOMRect}
 	 */
-	getVisibleViewport() {
+	getVisibleViewport(mapElement) {
 		const overlappingElements = findAllByAttribute(document, 'data-register-for-viewport-calc');
 
-		return calculateVisibleViewport(document.body, overlappingElements);
+		return calculateVisibleViewport(mapElement, overlappingElements);
 	}
 }

--- a/test/service/MapService.test.js
+++ b/test/service/MapService.test.js
@@ -190,21 +190,23 @@ describe('MapService', () => {
 
 	describe('getVisibleViewport', () => {
 		it('returns a visible rectangle', () => {
+			const mapElementMock = { getBoundingClientRect: () => DOMRect.fromRect() };
+
 			document.body.innerHTML = '<div id="overlapping1" data-register-for-viewport-calc></div>'
 				+ '<div id="non-overlapping"></div>'
 				+ '<div id="overlapping2" data-register-for-viewport-calc></div>';
-			const bodySpy = spyOnProperty(document, 'body', 'get').and.returnValue({ getBoundingClientRect: () => DOMRect.fromRect() });
+
 			const overlappingElement1 = document.getElementById('overlapping1');
 			const overlappingElement2 = document.getElementById('overlapping2');
 			const nonOverlappingElement = document.getElementById('non-overlapping');
 			const spy1 = spyOn(overlappingElement1, 'getBoundingClientRect').and.returnValue(() => DOMRect.fromRect());
 			const spy2 = spyOn(overlappingElement2, 'getBoundingClientRect').and.returnValue(() => DOMRect.fromRect());
 			const spy3 = spyOn(nonOverlappingElement, 'getBoundingClientRect').and.returnValue(() => DOMRect.fromRect());
+
 			const instanceUnderTest = setup();
-			const visibleViewPort = instanceUnderTest.getVisibleViewport();
+			const visibleViewPort = instanceUnderTest.getVisibleViewport(mapElementMock);
 
 			expect(visibleViewPort).toEqual(jasmine.any(DOMRect));
-			expect(bodySpy).toHaveBeenCalled();
 			expect(spy1).toHaveBeenCalled();
 			expect(spy2).toHaveBeenCalled();
 			expect(spy3).not.toHaveBeenCalled();


### PR DESCRIPTION
Update MapService.getVisibleViewport with a mapElement-argument to get valid DOMRect-instances from a specified mapElement, instead of the general use of document.body, which resolves in unusable DOMRect instances (height=0)

the specified mapElement could be:
`const mapElement = this.shadowRoot.getElementById('ol-map');`
