### PR TITLE
update visibility of zoomToExtent-button

### DIFF
--- a/src/modules/layerManager/components/LayerItem.js
+++ b/src/modules/layerManager/components/LayerItem.js
@@ -13,6 +13,7 @@ import { AbstractMvuContentPanel } from '../../menu/components/mainMenu/content/
 import { openModal } from '../../../../src/store/modal/modal.action';
 import { createUniqueId } from '../../../utils/numberUtils';
 import { fitLayer } from '../../../store/position/position.action';
+import { VectorGeoResource } from '../../../services/domain/geoResources';
 
 
 const Update_Layer = 'update_layer';
@@ -39,8 +40,9 @@ export class LayerItem extends AbstractMvuContentPanel {
 		super({
 			layer: null
 		});
-		const { TranslationService } = $injector.inject('TranslationService');
+		const { TranslationService, GeoResourceService } = $injector.inject('TranslationService', 'GeoResourceService');
 		this._translationService = TranslationService;
+		this._geoResourceService = GeoResourceService;
 
 
 		this._onCollapse = () => { };
@@ -106,7 +108,6 @@ export class LayerItem extends AbstractMvuContentPanel {
 			return nothing;
 		}
 		const currentLabel = layer.label === '' ? layer.id : layer.label;
-
 		const getCollapseTitle = () => {
 			return layer.collapsed ? translate('layerManager_expand') : translate('layerManager_collapse');
 		};
@@ -200,6 +201,10 @@ export class LayerItem extends AbstractMvuContentPanel {
 			ishidden: !layer.constraints?.metaData
 		};
 
+		const hasZoomToExtentClass = {
+			ishidden: !(this._geoResourceService.byId(layer.geoResourceId) instanceof VectorGeoResource)
+		};
+
 		return html`
         <style>${css}</style>
         <div class='ba-section divider'>
@@ -223,7 +228,7 @@ export class LayerItem extends AbstractMvuContentPanel {
 					<ba-icon id='copy' class='${classMap(cloneableClass)}' .icon='${clone}' .color=${'var(--primary-color)'} .color_hover=${'var(--text3)'} .size=${2.6} .title=${translate('layerManager_to_copy')} @click=${cloneLayer}></ba-icon>                                
 				</div>                                                                                              
 				<div>                                                                                              
-					<ba-icon id='zoomToExtent' .icon='${zoomToExtend}' .color=${'var(--primary-color)'} .color_hover=${'var(--text3)'} .size=${2.6} .title=${translate('layerManager_zoom_to_extent')} @click=${zoomToExtent}></ba-icon>                                
+					<ba-icon id='zoomToExtent' class='${classMap(hasZoomToExtentClass)}' .icon='${zoomToExtend}' .color=${'var(--primary-color)'} .color_hover=${'var(--text3)'} .size=${2.6} .title=${translate('layerManager_zoom_to_extent')} @click=${zoomToExtent}></ba-icon>                                
 				</div>                                                                                              
 				<div>                                                                                              
 					<ba-icon id='info' class='${classMap(hasLayerInfoClass)}' data-test-id .icon='${infoSvg}' .color=${'var(--primary-color)'} .color_hover=${'var(--text3)'} .size=${2.6} @click=${openGeoResourceInfoPanel}></ba-icon>                 

--- a/test/modules/layerManager/components/LayerItem.test.js
+++ b/test/modules/layerManager/components/LayerItem.test.js
@@ -9,6 +9,7 @@ import { isTemplateResult } from '../../../../src/utils/checks';
 import { TEST_ID_ATTRIBUTE_NAME } from '../../../../src/utils/markup';
 import { EventLike } from '../../../../src/utils/storeUtils';
 import { positionReducer } from '../../../../src/store/position/position.reducer';
+import { VectorGeoResource, VectorSourceType, WmsGeoResource } from '../../../../src/services/domain/geoResources';
 
 
 window.customElements.define(LayerItem.tag, LayerItem);
@@ -45,10 +46,12 @@ describe('LayerItem', () => {
 	};
 
 	describe('when layer item is rendered', () => {
+		const geoResourceService = { byId: () => { } };
 
 		const setup = async (layer) => {
 			TestUtils.setupStoreAndDi({}, { layers: layersReducer });
 			$injector.registerSingleton('TranslationService', { translate: (key) => key });
+			$injector.registerSingleton('GeoResourceService', geoResourceService);
 			const element = await TestUtils.render(LayerItem.tag);
 			element.layer = layer;
 			return element;
@@ -150,12 +153,28 @@ describe('LayerItem', () => {
 			expect(element.shadowRoot.querySelector('#copy').matches('.ishidden')).toBeTrue();
 		});
 
-		it('hides inactive copy button', async () => {
+		it('hides inactive info button', async () => {
 			const layer = { ...createDefaultLayerProperties(), id: 'id0', label: 'label0', visible: true, zIndex: 0, opacity: 1, collapsed: true, constraints: { metaData: false } };
 			const element = await setup(layer);
 
 			expect(element.shadowRoot.querySelector('#info')).toBeTruthy();
 			expect(element.shadowRoot.querySelector('#info').matches('.ishidden')).toBeTrue();
+		});
+
+		it('displays zoomToExtent button', async () => {
+			const layer = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0', label: 'label0', visible: true, zIndex: 0, opacity: 1, collapsed: true };
+			spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(new VectorGeoResource('geoResourceId0', 'id0', VectorSourceType.KML));
+			const element = await setup(layer);
+			expect(element.shadowRoot.querySelector('#zoomToExtent')).toBeTruthy();
+		});
+
+		it('hides inactive zoomToExtent button', async () => {
+			const layer = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0', label: 'label0', visible: true, zIndex: 0, opacity: 1, collapsed: true, constraints: { metaData: false } };
+			spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(new WmsGeoResource('geoResourceId0', 'id0', '', [], ''));
+			const element = await setup(layer);
+
+			expect(element.shadowRoot.querySelector('#zoomToExtent')).toBeTruthy();
+			expect(element.shadowRoot.querySelector('#zoomToExtent').matches('.ishidden')).toBeTrue();
 		});
 
 		it('contains test-id attributes', async () => {
@@ -198,6 +217,7 @@ describe('LayerItem', () => {
 			};
 			const store = TestUtils.setupStoreAndDi(state, { layers: layersReducer, modal: modalReducer, position: positionReducer });
 			$injector.registerSingleton('TranslationService', { translate: (key) => key });
+			$injector.registerSingleton('GeoResourceService', { byId: () => { } });
 			return store;
 		};
 
@@ -271,6 +291,7 @@ describe('LayerItem', () => {
 		const setup = (state) => {
 			store = TestUtils.setupStoreAndDi(state, { layers: layersReducer });
 			$injector.registerSingleton('TranslationService', { translate: (key) => key });
+			$injector.registerSingleton('GeoResourceService', { byId: () => { } });
 			return store;
 		};
 
@@ -447,6 +468,7 @@ describe('LayerItem', () => {
 
 			const store = TestUtils.setupStoreAndDi({}, { layers: layersReducer, modal: modalReducer });
 			$injector.registerSingleton('TranslationService', { translate: (key) => key });
+			$injector.registerSingleton('GeoResourceService', { byId: () => { } });
 			return store;
 		};
 		describe('on collapse', () => {

--- a/test/modules/layerManager/components/LayerManager.test.js
+++ b/test/modules/layerManager/components/LayerManager.test.js
@@ -23,6 +23,7 @@ describe('LayerManager', () => {
 		store = TestUtils.setupStoreAndDi(state, { layers: layersReducer });
 		$injector.registerSingleton('TranslationService', { translate: (key) => key });
 		$injector.registerSingleton('EnvironmentService', environmentServiceMock);
+		$injector.registerSingleton('GeoResourceService', { byId: () => { } });
 		return TestUtils.render(LayerManager.tag);
 	};
 


### PR DESCRIPTION
The zoomToExtent-Button in the LayerItem will be not visible, when the
georecource of a layer is not a VectorGeoResource.