### PR TITLE
Add menu to LayerItem

### DIFF
--- a/src/modules/commons/components/overflowMenu/OverflowMenu.js
+++ b/src/modules/commons/components/overflowMenu/OverflowMenu.js
@@ -16,6 +16,7 @@ const Update_Anchor_Position = 'update_last_anchor_position';
 /**
  * @typedef {Object} MenuOption
  * @property {string} label the label of the menu item
+ * @property {string} [id] the id of the menu item
  * @property {string} [icon] the icon of the menu item; Data-URI of Base64 encoded SVG
  * @property {function} [action] the action to perform, when user press the menu item
  * @property {boolean} [disabled] whether or not the menu item is enabled
@@ -211,8 +212,8 @@ export class OverflowMenu extends MvuElement {
 
 	_getItems(menuItems) {
 		const toHtml = (menuItem, id) => {
-			const { label, icon, action, disabled } = menuItem;
-			const menuitemId = `menuitem_${id}`;
+			const { id: customId, label, icon, action, disabled } = menuItem;
+			const menuitemId = customId ? `menuitem_${customId}` : `menuitem_${id}`;
 
 			const getIcon = (id) => {
 				const createIcon = () => {
@@ -252,8 +253,8 @@ export class OverflowMenu extends MvuElement {
 				touch: environmentService.isTouch()
 			};
 			return html`            			
-			<button id=${menuitemId} class='menuitem ${classMap(classes)}' ?disabled=${disabled} .title=${label} @pointerdown=${onPointerDown} @click=${onClick} @pointerup=${onPointerUp}>
-				${getIcon(id)}
+			<button id=${menuitemId} data-test-id class='menuitem ${classMap(classes)}' ?disabled=${disabled} .title=${label} @pointerdown=${onPointerDown} @click=${onClick} @pointerup=${onPointerUp}>
+				${getIcon(customId ? customId : id)}
 				<div class="menuitem__text">${label}</div>
 			</button>`;
 		};

--- a/src/modules/commons/components/overflowMenu/menuitem.css
+++ b/src/modules/commons/components/overflowMenu/menuitem.css
@@ -34,4 +34,5 @@
 
 .menuitem__text {
 	padding-left: 0.5em;
+	white-space: nowrap
 }

--- a/src/modules/layerManager/components/LayerItem.js
+++ b/src/modules/layerManager/components/LayerItem.js
@@ -5,8 +5,8 @@ import { classMap } from 'lit-html/directives/class-map.js';
 import { addLayer, modifyLayer, removeLayer } from './../../../store/layers/layers.action';
 import arrowUpSvg from './assets/arrow-up-short.svg';
 import arrowDownSvg from './assets/arrow-down-short.svg';
-import clone from './assets/clone.svg';
-import zoomToExtend from './assets/zoomToExtent.svg';
+import cloneSvg from './assets/clone.svg';
+import zoomToExtentSvg from './assets/zoomToExtent.svg';
 import removeSvg from './assets/trash.svg';
 import infoSvg from './assets/info.svg';
 import { AbstractMvuContentPanel } from '../../menu/components/mainMenu/content/AbstractMvuContentPanel';
@@ -14,6 +14,7 @@ import { openModal } from '../../../../src/store/modal/modal.action';
 import { createUniqueId } from '../../../utils/numberUtils';
 import { fitLayer } from '../../../store/position/position.action';
 import { VectorGeoResource } from '../../../services/domain/geoResources';
+import { MenuTypes } from '../../commons/components/overflowMenu/OverflowMenu';
 
 
 const Update_Layer = 'update_layer';
@@ -193,16 +194,12 @@ export class LayerItem extends AbstractMvuContentPanel {
 			openModal(layer.label, this._getInfoPanelFor(layer.geoResourceId));
 		};
 
-		const cloneableClass = {
-			ishidden: !layer.constraints?.cloneable
-		};
-
-		const hasLayerInfoClass = {
-			ishidden: !layer.constraints?.metaData
-		};
-
-		const hasZoomToExtentClass = {
-			ishidden: !(this._geoResourceService.byId(layer.geoResourceId) instanceof VectorGeoResource)
+		const getMenuItems = () => {
+			return [
+				{ label: translate('layerManager_to_copy'), icon: cloneSvg, action: cloneLayer, disabled: !layer.constraints?.cloneable },
+				{ label: translate('layerManager_zoom_to_extent'), icon: zoomToExtentSvg, action: zoomToExtent, disabled: !(this._geoResourceService.byId(layer.geoResourceId) instanceof VectorGeoResource) },
+				{ label: 'Info', icon: infoSvg, action: openGeoResourceInfoPanel, disabled: !layer.constraints?.metaData }
+			];
 		};
 
 		return html`
@@ -223,19 +220,11 @@ export class LayerItem extends AbstractMvuContentPanel {
 				</div>                                                                                              
 				<div>                                                                                              
 					<ba-icon id='decrease' .icon='${arrowDownSvg}' .color=${'var(--primary-color)'} .color_hover=${'var(--text3)'} .size=${2.6} .title=${translate('layerManager_move_down')} @click=${decreaseIndex}></ba-icon>                                
-				</div>                                                                                              
-				<div>                                                                                              
-					<ba-icon id='copy' class='${classMap(cloneableClass)}' .icon='${clone}' .color=${'var(--primary-color)'} .color_hover=${'var(--text3)'} .size=${2.6} .title=${translate('layerManager_to_copy')} @click=${cloneLayer}></ba-icon>                                
-				</div>                                                                                              
-				<div>                                                                                              
-					<ba-icon id='zoomToExtent' class='${classMap(hasZoomToExtentClass)}' .icon='${zoomToExtend}' .color=${'var(--primary-color)'} .color_hover=${'var(--text3)'} .size=${2.6} .title=${translate('layerManager_zoom_to_extent')} @click=${zoomToExtent}></ba-icon>                                
-				</div>                                                                                              
-				<div>                                                                                              
-					<ba-icon id='info' class='${classMap(hasLayerInfoClass)}' data-test-id .icon='${infoSvg}' .color=${'var(--primary-color)'} .color_hover=${'var(--text3)'} .size=${2.6} @click=${openGeoResourceInfoPanel}></ba-icon>                 
-				</div>                                                                                              
+				</div>                                                                          
 				<div>                                                                                              
 					<ba-icon id='remove' .icon='${removeSvg}' .color=${'var(--primary-color)'} .color_hover=${'var(--text3)'} .size=${2.6} .title=${translate('layerManager_remove')} @click=${remove}></ba-icon>               
-				</div>           				
+				</div>
+				<ba-overflow-menu .type=${MenuTypes.MEATBALL} .items=${getMenuItems()} ></ba-overflow-menu>
             </div>
         </div>`;
 	}

--- a/src/modules/layerManager/components/LayerItem.js
+++ b/src/modules/layerManager/components/LayerItem.js
@@ -196,9 +196,9 @@ export class LayerItem extends AbstractMvuContentPanel {
 
 		const getMenuItems = () => {
 			return [
-				{ label: translate('layerManager_to_copy'), icon: cloneSvg, action: cloneLayer, disabled: !layer.constraints?.cloneable },
-				{ label: translate('layerManager_zoom_to_extent'), icon: zoomToExtentSvg, action: zoomToExtent, disabled: !(this._geoResourceService.byId(layer.geoResourceId) instanceof VectorGeoResource) },
-				{ label: 'Info', icon: infoSvg, action: openGeoResourceInfoPanel, disabled: !layer.constraints?.metaData }
+				{ id: 'copy', label: translate('layerManager_to_copy'), icon: cloneSvg, action: cloneLayer, disabled: !layer.constraints?.cloneable },
+				{ id: 'zoomToExtent', label: translate('layerManager_zoom_to_extent'), icon: zoomToExtentSvg, action: zoomToExtent, disabled: !(this._geoResourceService.byId(layer.geoResourceId) instanceof VectorGeoResource) },
+				{ id: 'info', label: 'Info', icon: infoSvg, action: openGeoResourceInfoPanel, disabled: !layer.constraints?.metaData }
 			];
 		};
 
@@ -224,7 +224,7 @@ export class LayerItem extends AbstractMvuContentPanel {
 				<div>                                                                                              
 					<ba-icon id='remove' .icon='${removeSvg}' .color=${'var(--primary-color)'} .color_hover=${'var(--text3)'} .size=${2.6} .title=${translate('layerManager_remove')} @click=${remove}></ba-icon>               
 				</div>
-				<ba-overflow-menu .type=${MenuTypes.MEATBALL} .items=${getMenuItems()} ></ba-overflow-menu>
+				<ba-overflow-menu .type=${MenuTypes.MEATBALL} data-test-id .items=${getMenuItems()} ></ba-overflow-menu>
             </div>
         </div>`;
 	}

--- a/test/modules/commons/components/OverflowMenu.test.js
+++ b/test/modules/commons/components/OverflowMenu.test.js
@@ -2,6 +2,7 @@ import { $injector } from '../../../../src/injection';
 import { OverflowMenu, MenuTypes } from '../../../../src/modules/commons/components/overflowMenu/OverflowMenu';
 import { notificationReducer } from '../../../../src/store/notifications/notifications.reducer';
 import { isTemplateResult } from '../../../../src/utils/checks';
+import { TEST_ID_ATTRIBUTE_NAME } from '../../../../src/utils/markup';
 import { TestUtils } from '../../../test-utils';
 window.customElements.define(OverflowMenu.tag, OverflowMenu);
 
@@ -68,9 +69,9 @@ describe('OverflowMenu', () => {
 	describe('when button is clicked', () => {
 
 		const menuItems = [
-			{ label: 'item 1', action: () => { } },
+			{ label: 'Item 1', action: () => { } },
 			{ label: 'Item 2', action: () => { } },
-			{ label: 'item 3', action: () => { } }];
+			{ label: 'Item 3', action: () => { } }];
 
 		it('opens menu with the menu-items', async () => {
 			const element = await TestUtils.render(OverflowMenu.tag);
@@ -80,6 +81,46 @@ describe('OverflowMenu', () => {
 			button.click();
 
 			expect(element.shadowRoot.querySelectorAll('.menuitem')).toHaveSize(3);
+			expect(element.shadowRoot.querySelectorAll(`button[${TEST_ID_ATTRIBUTE_NAME}]`)).toHaveSize(3);
+		});
+
+		it('has menu-items with indexed-based ids', async () => {
+			const element = await TestUtils.render(OverflowMenu.tag);
+			element.items = menuItems;
+			const button = element.shadowRoot.querySelector('.menu__button');
+
+			button.click();
+			const menuItemElements = element.shadowRoot.querySelectorAll('.menuitem');
+
+			expect(menuItemElements[0].id).toBe('menuitem_0');
+			expect(menuItemElements[0].title).toBe('Item 1');
+
+			expect(menuItemElements[1].id).toBe('menuitem_1');
+			expect(menuItemElements[1].title).toBe('Item 2');
+
+			expect(menuItemElements[2].id).toBe('menuitem_2');
+			expect(menuItemElements[2].title).toBe('Item 3');
+		});
+
+		it('has menu-items with custom ids', async () => {
+			const element = await TestUtils.render(OverflowMenu.tag);
+			element.items = [
+				{ id: 'foo', label: 'Item 1', action: () => { } },
+				{ id: 'bar', label: 'Item 2', action: () => { } },
+				{ id: 'baz', label: 'Item 3', action: () => { } }];
+			const button = element.shadowRoot.querySelector('.menu__button');
+
+			button.click();
+			const menuItemElements = element.shadowRoot.querySelectorAll('.menuitem');
+
+			expect(menuItemElements[0].id).toBe('menuitem_foo');
+			expect(menuItemElements[0].title).toBe('Item 1');
+
+			expect(menuItemElements[1].id).toBe('menuitem_bar');
+			expect(menuItemElements[1].title).toBe('Item 2');
+
+			expect(menuItemElements[2].id).toBe('menuitem_baz');
+			expect(menuItemElements[2].title).toBe('Item 3');
 		});
 
 		it('registers document listeners', async () => {

--- a/test/modules/layerManager/components/LayerItem.test.js
+++ b/test/modules/layerManager/components/LayerItem.test.js
@@ -139,51 +139,105 @@ describe('LayerItem', () => {
 			expect(dragstartContainerSpy).not.toHaveBeenCalled();
 		});
 
-		it('displays info button', async () => {
-			const layer = { ...createDefaultLayerProperties(), id: 'id0', label: 'label0', visible: true, zIndex: 0, opacity: 1, collapsed: true };
-			const element = await setup(layer);
-			expect(element.shadowRoot.querySelector('#info')).toBeTruthy();
-		});
-
-		it('hides inactive copy button', async () => {
-			const layer = { ...createDefaultLayerProperties(), id: 'id0', label: 'label0', visible: true, zIndex: 0, opacity: 1, collapsed: true, constraints: { cloneable: false } };
-			const element = await setup(layer);
-
-			expect(element.shadowRoot.querySelector('#copy')).toBeTruthy();
-			expect(element.shadowRoot.querySelector('#copy').matches('.ishidden')).toBeTrue();
-		});
-
-		it('hides inactive info button', async () => {
-			const layer = { ...createDefaultLayerProperties(), id: 'id0', label: 'label0', visible: true, zIndex: 0, opacity: 1, collapsed: true, constraints: { metaData: false } };
-			const element = await setup(layer);
-
-			expect(element.shadowRoot.querySelector('#info')).toBeTruthy();
-			expect(element.shadowRoot.querySelector('#info').matches('.ishidden')).toBeTrue();
-		});
-
-		it('displays zoomToExtent button', async () => {
+		it('displays a overflow-menu', async () => {
 			const layer = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0', label: 'label0', visible: true, zIndex: 0, opacity: 1, collapsed: true };
 			spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(new VectorGeoResource('geoResourceId0', 'id0', VectorSourceType.KML));
 			const element = await setup(layer);
-			expect(element.shadowRoot.querySelector('#zoomToExtent')).toBeTruthy();
+			expect(element.shadowRoot.querySelector('ba-overflow-menu')).toBeTruthy();
 		});
 
-		it('hides inactive zoomToExtent button', async () => {
-			const layer = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0', label: 'label0', visible: true, zIndex: 0, opacity: 1, collapsed: true, constraints: { metaData: false } };
+		it('have a menu-item for info', async () => {
+			const layer = { ...createDefaultLayerProperties(), id: 'id0', label: 'label0', visible: true, zIndex: 0, opacity: 1, collapsed: true };
+			const element = await setup(layer);
+
+			const menu = element.shadowRoot.querySelector('ba-overflow-menu');
+			const infoMenuItem = menu.items.find(item => item.label === 'Info');
+
+			expect(infoMenuItem).not.toBeNull();
+			expect(infoMenuItem.label).toEqual('Info');
+			expect(infoMenuItem.action).toEqual(jasmine.any(Function));
+			expect(infoMenuItem.disabled).toBeFalse();
+			expect(infoMenuItem.icon).toContain('data:image/svg+xml;base64,PHN2ZyB4bWxuc');
+		});
+
+		it('have a disabled menu-item for info', async () => {
+			const layer = { ...createDefaultLayerProperties(), id: 'id0', label: 'label0', visible: true, zIndex: 0, opacity: 1, collapsed: true, constraints: { metaData: false } };
+			const element = await setup(layer);
+
+			const menu = element.shadowRoot.querySelector('ba-overflow-menu');
+			const infoMenuItem = menu.items.find(item => item.label === 'Info');
+
+			expect(infoMenuItem).not.toBeNull();
+			expect(infoMenuItem.label).toEqual('Info');
+			expect(infoMenuItem.action).toEqual(jasmine.any(Function));
+			expect(infoMenuItem.disabled).toBeTrue();
+			expect(infoMenuItem.icon).toContain('data:image/svg+xml;base64,PHN2ZyB4bWxuc');
+		});
+
+		it('have a menu-item for copy', async () => {
+			const layer = { ...createDefaultLayerProperties(), id: 'id0', label: 'label0', visible: true, zIndex: 0, opacity: 1, collapsed: true };
+			const element = await setup(layer);
+
+			const menu = element.shadowRoot.querySelector('ba-overflow-menu');
+			const copyMenuItem = menu.items.find(item => item.label === 'layerManager_to_copy');
+
+			expect(copyMenuItem).not.toBeNull();
+			expect(copyMenuItem.label).toEqual('layerManager_to_copy');
+			expect(copyMenuItem.action).toEqual(jasmine.any(Function));
+			expect(copyMenuItem.disabled).toBeFalse();
+			expect(copyMenuItem.icon).toContain('data:image/svg+xml;base64,PD94bWwgdmVyc2l');
+		});
+
+		it('have a disabled menu-item for copy', async () => {
+			const layer = { ...createDefaultLayerProperties(), id: 'id0', label: 'label0', visible: true, zIndex: 0, opacity: 1, collapsed: true, constraints: { cloneable: false } };
+			const element = await setup(layer);
+
+			const menu = element.shadowRoot.querySelector('ba-overflow-menu');
+			const copyMenuItem = menu.items.find(item => item.label === 'layerManager_to_copy');
+
+			expect(copyMenuItem).not.toBeNull();
+			expect(copyMenuItem.label).toEqual('layerManager_to_copy');
+			expect(copyMenuItem.action).toEqual(jasmine.any(Function));
+			expect(copyMenuItem.disabled).toBeTrue();
+			expect(copyMenuItem.icon).toContain('data:image/svg+xml;base64,PD94bWwgdmVyc2l');
+		});
+
+		it('have a menu-item for zoomToExtent', async () => {
+			const layer = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0', label: 'label0', visible: true, zIndex: 0, opacity: 1, collapsed: true };
+			spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(new VectorGeoResource('geoResourceId0', 'id0', VectorSourceType.KML));
+			const element = await setup(layer);
+
+			const menu = element.shadowRoot.querySelector('ba-overflow-menu');
+			const zoomToExtentMenuItem = menu.items.find(item => item.label === 'layerManager_zoom_to_extent');
+
+			expect(zoomToExtentMenuItem).not.toBeNull();
+			expect(zoomToExtentMenuItem.label).toEqual('layerManager_zoom_to_extent');
+			expect(zoomToExtentMenuItem.action).toEqual(jasmine.any(Function));
+			expect(zoomToExtentMenuItem.disabled).toBeFalse();
+			expect(zoomToExtentMenuItem.icon).toContain('data:image/svg+xml;base64,PD94bWwgdmVyc2l');
+		});
+
+		it('have a disabled menu-item for zoomToExtent', async () => {
+			const layer = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0', label: 'label0', visible: true, zIndex: 0, opacity: 1, collapsed: true, constraints: { cloneable: false } };
 			spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(new WmsGeoResource('geoResourceId0', 'id0', '', [], ''));
 			const element = await setup(layer);
 
-			expect(element.shadowRoot.querySelector('#zoomToExtent')).toBeTruthy();
-			expect(element.shadowRoot.querySelector('#zoomToExtent').matches('.ishidden')).toBeTrue();
+			const menu = element.shadowRoot.querySelector('ba-overflow-menu');
+			const zoomToExtentMenuItem = menu.items.find(item => item.label === 'layerManager_zoom_to_extent');
+
+			expect(zoomToExtentMenuItem).not.toBeNull();
+			expect(zoomToExtentMenuItem.label).toEqual('layerManager_zoom_to_extent');
+			expect(zoomToExtentMenuItem.action).toEqual(jasmine.any(Function));
+			expect(zoomToExtentMenuItem.disabled).toBeTrue();
+			expect(zoomToExtentMenuItem.icon).toContain('data:image/svg+xml;base64,PD94bWwgdmVyc2l');
 		});
 
 		it('contains test-id attributes', async () => {
 			const layer = { ...createDefaultLayerProperties(), id: 'id0', label: 'label0', visible: true, zIndex: 0, opacity: 1, collapsed: true };
 			const element = await setup(layer);
 
-			expect(element.shadowRoot.querySelectorAll(`[${TEST_ID_ATTRIBUTE_NAME}]`)).toHaveSize(2);
+			expect(element.shadowRoot.querySelectorAll(`[${TEST_ID_ATTRIBUTE_NAME}]`)).toHaveSize(1);
 			expect(element.shadowRoot.querySelector('#button-detail').hasAttribute(TEST_ID_ATTRIBUTE_NAME)).toBeTrue();
-			expect(element.shadowRoot.querySelector('#info').hasAttribute(TEST_ID_ATTRIBUTE_NAME)).toBeTrue();
 		});
 
 		it('uses geoResourceId for a InfoPanel ', async () => {
@@ -191,8 +245,9 @@ describe('LayerItem', () => {
 			const element = await setup(layer);
 			const spy = spyOn(element, '_getInfoPanelFor').and.callThrough();
 
-			const infoButton = element.shadowRoot.querySelector('#info');
-			infoButton.click();
+			const menu = element.shadowRoot.querySelector('ba-overflow-menu');
+			const infoMenuItem = menu.items.find(item => item.label === 'Info');
+			infoMenuItem.action();
 
 			expect(spy).toHaveBeenCalledWith(layer.geoResourceId);
 		});
@@ -263,9 +318,9 @@ describe('LayerItem', () => {
 			const element = await TestUtils.render(LayerItem.tag);
 			element.layer = { ...layer };
 
-			const infoButton = element.shadowRoot.querySelector('#info');
-
-			infoButton.click();
+			const menu = element.shadowRoot.querySelector('ba-overflow-menu');
+			const infoMenuItem = menu.items.find(item => item.label === 'Info');
+			infoMenuItem.action();
 
 			expect(store.getState().modal.data.title).toBe('label0');
 			expect(isTemplateResult(store.getState().modal.data.content)).toBeTrue();
@@ -276,9 +331,9 @@ describe('LayerItem', () => {
 			const element = await TestUtils.render(LayerItem.tag);
 			element.layer = { ...layer };
 
-			const zoomToExtentButton = element.shadowRoot.querySelector('#zoomToExtent');
-
-			zoomToExtentButton.click();
+			const menu = element.shadowRoot.querySelector('ba-overflow-menu');
+			const zoomToExtentMenuItem = menu.items.find(item => item.label === 'layerManager_zoom_to_extent');
+			zoomToExtentMenuItem.action();
 
 			expect(store.getState().position.fitLayerRequest.payload.id).toEqual('id0');
 		});
@@ -415,8 +470,9 @@ describe('LayerItem', () => {
 
 			expect(store.getState().layers.active[0].id).toBe('id0');
 
-			const copyButton = element.shadowRoot.querySelector('#copy');
-			copyButton.click();
+			const menu = element.shadowRoot.querySelector('ba-overflow-menu');
+			const copyMenuItem = menu.items.find(item => item.label === 'layerManager_to_copy');
+			copyMenuItem.action();
 
 			expect(store.getState().layers.active[0].id).toBe(layer0.id);
 			expect(store.getState().layers.active[1].id.startsWith('geoResourceId0_')).toBeTrue();

--- a/test/modules/layerManager/components/LayerItem.test.js
+++ b/test/modules/layerManager/components/LayerItem.test.js
@@ -276,7 +276,6 @@ describe('LayerItem', () => {
 			return store;
 		};
 
-
 		it('click on layer toggle change state in store', async () => {
 			const store = setup();
 			const element = await TestUtils.render(LayerItem.tag);
@@ -300,6 +299,22 @@ describe('LayerItem', () => {
 
 			const actualLayer = store.getState().layers.active[0];
 			expect(actualLayer.opacity).toBe(0.66);
+		});
+
+		it('click on opacity slider change style-property', async () => {
+			setup();
+			const element = await TestUtils.render(LayerItem.tag);
+			element.layer = { ...layer };
+
+			// explicit call to fake/step over render-phase
+			element.onAfterRender(true);
+			const slider = element.shadowRoot.querySelector('.opacity-slider');
+			slider.value = 66;
+			const propertySpy = spyOn(slider.style, 'setProperty').withArgs('--track-fill', `${slider.value}%`).and.callThrough();
+
+			slider.dispatchEvent(new Event('input'));
+
+			expect(propertySpy).toHaveBeenCalled();
 		});
 
 		it('click on layer collapse button change collapsed property', async () => {

--- a/test/modules/layerManager/components/LayerItem.test.js
+++ b/test/modules/layerManager/components/LayerItem.test.js
@@ -236,8 +236,9 @@ describe('LayerItem', () => {
 			const layer = { ...createDefaultLayerProperties(), id: 'id0', label: 'label0', visible: true, zIndex: 0, opacity: 1, collapsed: true };
 			const element = await setup(layer);
 
-			expect(element.shadowRoot.querySelectorAll(`[${TEST_ID_ATTRIBUTE_NAME}]`)).toHaveSize(1);
+			expect(element.shadowRoot.querySelectorAll(`[${TEST_ID_ATTRIBUTE_NAME}]`)).toHaveSize(2);
 			expect(element.shadowRoot.querySelector('#button-detail').hasAttribute(TEST_ID_ATTRIBUTE_NAME)).toBeTrue();
+			expect(element.shadowRoot.querySelector('ba-overflow-menu').hasAttribute(TEST_ID_ATTRIBUTE_NAME)).toBeTrue();
 		});
 
 		it('uses geoResourceId for a InfoPanel ', async () => {

--- a/test/modules/layerManager/components/LayerItem.test.js
+++ b/test/modules/layerManager/components/LayerItem.test.js
@@ -317,6 +317,23 @@ describe('LayerItem', () => {
 			expect(propertySpy).toHaveBeenCalled();
 		});
 
+		it('click on opacity slider without \'max\'-attribute change style-property', async () => {
+			setup();
+			const element = await TestUtils.render(LayerItem.tag);
+			element.layer = { ...layer };
+
+			// explicit call to fake/step over render-phase
+			element.onAfterRender(true);
+			const slider = element.shadowRoot.querySelector('.opacity-slider');
+			slider.value = 66;
+			spyOn(slider, 'getAttribute').withArgs('max').and.returnValue(null);
+			const propertySpy = spyOn(slider.style, 'setProperty').withArgs('--track-fill', `${slider.value}%`).and.callThrough();
+
+			slider.dispatchEvent(new Event('input'));
+
+			expect(propertySpy).toHaveBeenCalled();
+		});
+
 		it('click on layer collapse button change collapsed property', async () => {
 			setup();
 			const element = await TestUtils.render(LayerItem.tag);

--- a/test/modules/layerManager/components/LayerItem.test.js
+++ b/test/modules/layerManager/components/LayerItem.test.js
@@ -146,7 +146,7 @@ describe('LayerItem', () => {
 			expect(element.shadowRoot.querySelector('ba-overflow-menu')).toBeTruthy();
 		});
 
-		it('have a menu-item for info', async () => {
+		it('contains a menu-item for info', async () => {
 			const layer = { ...createDefaultLayerProperties(), id: 'id0', label: 'label0', visible: true, zIndex: 0, opacity: 1, collapsed: true };
 			const element = await setup(layer);
 
@@ -160,7 +160,7 @@ describe('LayerItem', () => {
 			expect(infoMenuItem.icon).toContain('data:image/svg+xml;base64,PHN2ZyB4bWxuc');
 		});
 
-		it('have a disabled menu-item for info', async () => {
+		it('contains a disabled menu-item for info', async () => {
 			const layer = { ...createDefaultLayerProperties(), id: 'id0', label: 'label0', visible: true, zIndex: 0, opacity: 1, collapsed: true, constraints: { metaData: false } };
 			const element = await setup(layer);
 
@@ -174,7 +174,7 @@ describe('LayerItem', () => {
 			expect(infoMenuItem.icon).toContain('data:image/svg+xml;base64,PHN2ZyB4bWxuc');
 		});
 
-		it('have a menu-item for copy', async () => {
+		it('contains a menu-item for copy', async () => {
 			const layer = { ...createDefaultLayerProperties(), id: 'id0', label: 'label0', visible: true, zIndex: 0, opacity: 1, collapsed: true };
 			const element = await setup(layer);
 
@@ -188,7 +188,7 @@ describe('LayerItem', () => {
 			expect(copyMenuItem.icon).toContain('data:image/svg+xml;base64,PD94bWwgdmVyc2l');
 		});
 
-		it('have a disabled menu-item for copy', async () => {
+		it('contains a disabled menu-item for copy', async () => {
 			const layer = { ...createDefaultLayerProperties(), id: 'id0', label: 'label0', visible: true, zIndex: 0, opacity: 1, collapsed: true, constraints: { cloneable: false } };
 			const element = await setup(layer);
 
@@ -202,7 +202,7 @@ describe('LayerItem', () => {
 			expect(copyMenuItem.icon).toContain('data:image/svg+xml;base64,PD94bWwgdmVyc2l');
 		});
 
-		it('have a menu-item for zoomToExtent', async () => {
+		it('contains a menu-item for zoomToExtent', async () => {
 			const layer = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0', label: 'label0', visible: true, zIndex: 0, opacity: 1, collapsed: true };
 			spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(new VectorGeoResource('geoResourceId0', 'id0', VectorSourceType.KML));
 			const element = await setup(layer);
@@ -217,7 +217,7 @@ describe('LayerItem', () => {
 			expect(zoomToExtentMenuItem.icon).toContain('data:image/svg+xml;base64,PD94bWwgdmVyc2l');
 		});
 
-		it('have a disabled menu-item for zoomToExtent', async () => {
+		it('contains a disabled menu-item for zoomToExtent', async () => {
 			const layer = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0', label: 'label0', visible: true, zIndex: 0, opacity: 1, collapsed: true, constraints: { cloneable: false } };
 			spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(new WmsGeoResource('geoResourceId0', 'id0', '', [], ''));
 			const element = await setup(layer);


### PR DESCRIPTION
Add a overflow-menu to remove buttons connected to less important (and volatile) actions from the LayerItem and to regain space for the more important and often used controls.