### PR TITLE
AutocompleteSearch refactor to increase testcoverage

### DIFF
--- a/src/modules/commons/components/autocomplete/AutocompleteSearch.js
+++ b/src/modules/commons/components/autocomplete/AutocompleteSearch.js
@@ -94,26 +94,28 @@ export class AutocompleteSearch extends MvuElement {
 
 		};
 
+		const isEmpty = (x) => {
+			/*a function to check, whether a list is null/empty or not:*/
+			return !x || x.length < 1;
+		};
+
 		const addActive = (x) => {
-			// /*a function to classify an item as "active":*/
-			// if (!x || x.length < 1) {
-			// 	return false;
-			// }
-			/*start by removing the "active" class on all items:*/
-			//removeActive(x);
-			// if (this._currentFocus >= x.length) {
-			// 	this._currentFocus = 0;
-			// }
-			// if (this._currentFocus < 0) {
-			// 	this._currentFocus = (x.length - 1);
-			// }
 			/*add class "autocomplete-active":*/
 			x[this._currentFocus].classList.add('autocomplete-active');
 		};
 		const removeActive = (x) => {
 			/*a function to remove the "active" class from all autocomplete items:*/
-			for (let i = 0; i < x.length; i++) {
-				x[i].classList.remove('autocomplete-active');
+			x.forEach(element => element.classList.remove('autocomplete-active'));
+		};
+
+		const updateActive = (x) => {
+			/*a function to classify an item as "active":*/
+			if (!isEmpty(x)) {
+				/*start by removing the "active" class on all items:*/
+				removeActive(x);
+				this._currentFocus = this._syncFocusWith(x, this._currentFocus);
+				/*add class "autocomplete-active":*/
+				addActive(x);
 			}
 		};
 
@@ -134,23 +136,14 @@ export class AutocompleteSearch extends MvuElement {
 				increase the currentFocus variable:*/
 				this._currentFocus++;
 				/*and and make the current item more visible:*/
-				if (x && x.length >= 1) {
-					removeActive(x);
-					this._syncFocusWith(x);// todo: refactor to pure function -> this._currentFocus=this._syncFocusWith(this._currentFocus,x)
-					addActive(x);
-				}
-
+				updateActive(x);
 			}
 			else if (e.keyCode === 38) { //up
 				/*If the arrow UP key is pressed,
 				decrease the currentFocus variable:*/
 				this._currentFocus--;
 				/*and and make the current item more visible:*/
-				if (x && x.length >= 1) {
-					removeActive(x);
-					this._syncFocusWith(x); // todo: refactor to pure function -> this._currentFocus=this._syncFocusWith(this._currentFocus,x)
-					addActive(x);
-				}
+				updateActive(x);
 			}
 			else if (e.keyCode === 13) {
 				/*If the ENTER key is pressed, prevent the form from being submitted,*/
@@ -175,14 +168,15 @@ export class AutocompleteSearch extends MvuElement {
 		`;
 	}
 
-	_syncFocusWith(autocompleteList) {
-		// todo: find a better name for this method and refactor to a pure function -> return newFocus
-		if (this._currentFocus >= autocompleteList.length) {
-			this._currentFocus = 0;
+	_syncFocusWith(autocompleteList, focus) {
+		// todo: find a better name for this method
+		if (focus >= autocompleteList.length) {
+			return 0;
 		}
-		if (this._currentFocus < 0) {
-			this._currentFocus = (autocompleteList.length - 1);
+		if (focus < 0) {
+			return (autocompleteList.length - 1);
 		}
+		return focus;
 	}
 
 	static get tag() {

--- a/src/modules/commons/components/autocomplete/AutocompleteSearch.js
+++ b/src/modules/commons/components/autocomplete/AutocompleteSearch.js
@@ -95,18 +95,18 @@ export class AutocompleteSearch extends MvuElement {
 		};
 
 		const addActive = (x) => {
-			/*a function to classify an item as "active":*/
-			if (!x || x.length < 1) {
-				return false;
-			}
+			// /*a function to classify an item as "active":*/
+			// if (!x || x.length < 1) {
+			// 	return false;
+			// }
 			/*start by removing the "active" class on all items:*/
-			removeActive(x);
-			if (this._currentFocus >= x.length) {
-				this._currentFocus = 0;
-			}
-			if (this._currentFocus < 0) {
-				this._currentFocus = (x.length - 1);
-			}
+			//removeActive(x);
+			// if (this._currentFocus >= x.length) {
+			// 	this._currentFocus = 0;
+			// }
+			// if (this._currentFocus < 0) {
+			// 	this._currentFocus = (x.length - 1);
+			// }
 			/*add class "autocomplete-active":*/
 			x[this._currentFocus].classList.add('autocomplete-active');
 		};
@@ -134,14 +134,23 @@ export class AutocompleteSearch extends MvuElement {
 				increase the currentFocus variable:*/
 				this._currentFocus++;
 				/*and and make the current item more visible:*/
-				addActive(x);
+				if (x && x.length >= 1) {
+					removeActive(x);
+					this._syncFocusWith(x);
+					addActive(x);
+				}
+
 			}
 			else if (e.keyCode === 38) { //up
 				/*If the arrow UP key is pressed,
 				decrease the currentFocus variable:*/
 				this._currentFocus--;
 				/*and and make the current item more visible:*/
-				addActive(x);
+				if (x && x.length >= 1) {
+					removeActive(x);
+					this._syncFocusWith(x);
+					addActive(x);
+				}
 			}
 			else if (e.keyCode === 13) {
 				/*If the ENTER key is pressed, prevent the form from being submitted,*/
@@ -164,6 +173,15 @@ export class AutocompleteSearch extends MvuElement {
 		  `)}</div>`} 
 		 </div>
 		`;
+	}
+
+	_syncFocusWith(autocompleteList) {
+		if (this._currentFocus >= autocompleteList.length) {
+			this._currentFocus = 0;
+		}
+		if (this._currentFocus < 0) {
+			this._currentFocus = (autocompleteList.length - 1);
+		}
 	}
 
 	static get tag() {

--- a/src/modules/commons/components/autocomplete/AutocompleteSearch.js
+++ b/src/modules/commons/components/autocomplete/AutocompleteSearch.js
@@ -136,7 +136,7 @@ export class AutocompleteSearch extends MvuElement {
 				/*and and make the current item more visible:*/
 				if (x && x.length >= 1) {
 					removeActive(x);
-					this._syncFocusWith(x);
+					this._syncFocusWith(x);// todo: refactor to pure function -> this._currentFocus=this._syncFocusWith(this._currentFocus,x)
 					addActive(x);
 				}
 
@@ -148,7 +148,7 @@ export class AutocompleteSearch extends MvuElement {
 				/*and and make the current item more visible:*/
 				if (x && x.length >= 1) {
 					removeActive(x);
-					this._syncFocusWith(x);
+					this._syncFocusWith(x); // todo: refactor to pure function -> this._currentFocus=this._syncFocusWith(this._currentFocus,x)
 					addActive(x);
 				}
 			}
@@ -176,6 +176,7 @@ export class AutocompleteSearch extends MvuElement {
 	}
 
 	_syncFocusWith(autocompleteList) {
+		// todo: find a better name for this method and refactor to a pure function -> return newFocus
 		if (this._currentFocus >= autocompleteList.length) {
 			this._currentFocus = 0;
 		}

--- a/test/modules/commons/components/AutocompleteSearch.test.js
+++ b/test/modules/commons/components/AutocompleteSearch.test.js
@@ -228,4 +228,24 @@ describe('Button', () => {
 			});
 		});
 	});
+
+	describe('_syncFocusWith', () => {
+		it('resets the currentFocus on a smaller autocomplete list', () => {
+			const classUnderTest = new AutocompleteSearch();
+			const smallAutocompleteList = [{}, {}];
+
+			classUnderTest._currentFocus = 2;
+			classUnderTest._syncFocusWith(smallAutocompleteList);
+			expect(classUnderTest._currentFocus).toBe(0);
+		});
+
+		it('resets the currentFocus on a larger autocomplete list', () => {
+			const classUnderTest = new AutocompleteSearch();
+			const largerAutocompleteList = [{}, {}, {}];
+
+			classUnderTest._currentFocus = -1;
+			classUnderTest._syncFocusWith(largerAutocompleteList);
+			expect(classUnderTest._currentFocus).toBe(2);
+		});
+	});
 });

--- a/test/modules/commons/components/AutocompleteSearch.test.js
+++ b/test/modules/commons/components/AutocompleteSearch.test.js
@@ -233,21 +233,15 @@ describe('Button', () => {
 		it('resets the currentFocus on a smaller autocomplete list', () => {
 			// todo: find a better description for this test case
 			const classUnderTest = new AutocompleteSearch();
-			const smallAutocompleteList = [{}, {}];
 
-			classUnderTest._currentFocus = 2;
-			classUnderTest._syncFocusWith(smallAutocompleteList);
-			expect(classUnderTest._currentFocus).toBe(0);
+			expect(classUnderTest._syncFocusWith([{}, {}], 2)).toBe(0);
 		});
 
 		it('resets the currentFocus on a larger autocomplete list', () => {
 			// todo: find a better description for this test case
 			const classUnderTest = new AutocompleteSearch();
-			const largerAutocompleteList = [{}, {}, {}];
 
-			classUnderTest._currentFocus = -1;
-			classUnderTest._syncFocusWith(largerAutocompleteList);
-			expect(classUnderTest._currentFocus).toBe(2);
+			expect(classUnderTest._syncFocusWith([{}, {}, {}], -1)).toBe(2);
 		});
 	});
 });

--- a/test/modules/commons/components/AutocompleteSearch.test.js
+++ b/test/modules/commons/components/AutocompleteSearch.test.js
@@ -231,6 +231,7 @@ describe('Button', () => {
 
 	describe('_syncFocusWith', () => {
 		it('resets the currentFocus on a smaller autocomplete list', () => {
+			// todo: find a better description for this test case
 			const classUnderTest = new AutocompleteSearch();
 			const smallAutocompleteList = [{}, {}];
 
@@ -240,6 +241,7 @@ describe('Button', () => {
 		});
 
 		it('resets the currentFocus on a larger autocomplete list', () => {
+			// todo: find a better description for this test case
 			const classUnderTest = new AutocompleteSearch();
 			const largerAutocompleteList = [{}, {}, {}];
 


### PR DESCRIPTION
The AutocompleteSearch component has untested (untestable?) code. This PR have the goal to refactor the code to make the behavior of 'update the current focus'(?) testable.

- [x] isolate the behavior
- [x] test the behavior
- [ ] find better names for the testcase description
- [ ] find a better name for the refactored method (_syncFocusWith)