### PR TITLE
fix StyleOptions of selected feature

### DIFF
--- a/src/modules/olMap/handler/draw/OlDrawHandler.js
+++ b/src/modules/olMap/handler/draw/OlDrawHandler.js
@@ -4,7 +4,7 @@ import { Vector as VectorSource } from 'ol/source';
 import { Vector as VectorLayer } from 'ol/layer';
 import { $injector } from '../../../../injection';
 import { DragPan, Draw, Modify, Select, Snap } from 'ol/interaction';
-import { createSketchStyleFunction, getColorFrom, getDrawingTypeFrom, getSymbolFrom, getTextFrom, selectStyleFunction } from '../../utils/olStyleUtils';
+import { createSketchStyleFunction, getColorFrom, getDrawingTypeFrom, getSizeFrom, getSymbolFrom, getTextFrom, selectStyleFunction } from '../../utils/olStyleUtils';
 import { StyleTypes } from '../../services/StyleService';
 import { StyleSizeTypes } from '../../../../domain/styles';
 import MapBrowserEventType from 'ol/MapBrowserEventType';
@@ -700,10 +700,12 @@ export class OlDrawHandler extends OlLayerHandler {
 		const featureColor = getColorFrom(feature);
 		const featureSymbol = getSymbolFrom(feature);
 		const featureText = getTextFrom(feature);
+		const featureScale = getSizeFrom(feature);
 		const color = featureColor ? featureColor : currentStyleOption.color;
 		const symbolSrc = featureSymbol ? featureSymbol : currentStyleOption.symbolSrc;
 		const text = featureText ? featureText : currentStyleOption.text;
-		const style = { ...currentStyleOption, color: color, symbolSrc: symbolSrc, text: text };
+		const scale = featureScale ? featureScale : currentStyleOption.scale;
+		const style = { ...currentStyleOption, color: color, symbolSrc: symbolSrc, text: text, scale: scale };
 		const selectedStyle = { type: getDrawingTypeFrom(feature), style: style };
 		setSelectedStyle(selectedStyle);
 	}

--- a/src/modules/olMap/utils/olStyleUtils.js
+++ b/src/modules/olMap/utils/olStyleUtils.js
@@ -55,6 +55,21 @@ const getTextScale = (sizeKeyword) => {
 	}
 };
 
+
+export const textScaleToKeyword = (scaleCandidate) => {
+	const scale = typeof (scaleCandidate) === 'number' ? scaleCandidate : getMarkerScale(scaleCandidate);
+
+	switch (scale) {
+		case 2:
+			return 'large';
+		case 1.5:
+			return 'medium';
+		case 1:
+		default:
+			return 'small';
+	}
+};
+
 const getMarkerScale = (sizeKeyword) => {
 	if (typeof (sizeKeyword) === 'number') {
 		return sizeKeyword;
@@ -655,6 +670,34 @@ export const getTextFrom = (feature) => {
 			return textStyle.getText();
 		}
 	}
+	return null;
+};
+
+/**
+ * Extracts from the specified feature the size-value if the
+ * StyleType is Marker/Text or null for all other StyleTypes.
+ * @param {Feature} feature the feature with or without a style
+ * @returns {StyleSizeTypes|null} the Size-Value or null
+ */
+export const getSizeFrom = (feature) => {
+	if (feature == null) {
+		return null;
+	}
+	const styles = getStyleArray(feature); feature.getStyle();
+	if (styles) {
+		const style = styles[0];
+		const image = style?.getImage();
+		const text = style?.getText();
+
+		if (image) {
+			return markerScaleToKeyword(image.getScale());
+		}
+
+		if (text) {
+			return textScaleToKeyword(text.getScale());
+		}
+	}
+
 	return null;
 };
 

--- a/test/modules/olMap/util/olStyleUtils.test.js
+++ b/test/modules/olMap/util/olStyleUtils.test.js
@@ -1,4 +1,4 @@
-import { measureStyleFunction, createSketchStyleFunction, modifyStyleFunction, nullStyleFunction, highlightStyleFunction, highlightTemporaryStyleFunction, markerStyleFunction, selectStyleFunction, getColorFrom, lineStyleFunction, polygonStyleFunction, textStyleFunction, getIconUrl, getMarkerSrc, getDrawingTypeFrom, getSymbolFrom, markerScaleToKeyword, getTextFrom, getStyleArray, renderRulerSegments, defaultStyleFunction, geojsonStyleFunction, DEFAULT_TEXT } from '../../../../src/modules/olMap/utils/olStyleUtils';
+import { measureStyleFunction, createSketchStyleFunction, modifyStyleFunction, nullStyleFunction, highlightStyleFunction, highlightTemporaryStyleFunction, markerStyleFunction, selectStyleFunction, getColorFrom, lineStyleFunction, polygonStyleFunction, textStyleFunction, getIconUrl, getMarkerSrc, getDrawingTypeFrom, getSymbolFrom, markerScaleToKeyword, getTextFrom, getStyleArray, renderRulerSegments, defaultStyleFunction, geojsonStyleFunction, DEFAULT_TEXT, getSizeFrom, textScaleToKeyword } from '../../../../src/modules/olMap/utils/olStyleUtils';
 import { Point, LineString, Polygon, Geometry } from 'ol/geom';
 import { Feature } from 'ol';
 import proj4 from 'proj4';
@@ -50,6 +50,19 @@ describe('getMarkerSrc', () => {
 		expect(getMarkerSrc(markerSrc)).toBe('http://foo.bar/42/baz');
 	});
 
+});
+
+describe('textScaleToKeyword', () => {
+	it('should map to keyword', () => {
+
+		expect(textScaleToKeyword(2)).toBe('large');
+		expect(textScaleToKeyword(1.5)).toBe('medium');
+		expect(textScaleToKeyword(1)).toBe('small');
+		expect(textScaleToKeyword(null)).toBe('small');
+		expect(textScaleToKeyword('something')).toBe('small');
+		expect(textScaleToKeyword(true)).toBe('small');
+		expect(textScaleToKeyword(false)).toBe('small');
+	});
 });
 
 describe('markerScaleToKeyword', () => {
@@ -908,6 +921,74 @@ describe('getTextFrom', () => {
 		expect(getTextFrom(featureWithoutStyle)).toBeNull();
 		expect(getTextFrom(null)).toBeNull();
 		expect(getTextFrom(undefined)).toBeNull();
+	});
+
+});
+
+describe('getSizeFrom', () => {
+	const imageStyle = new Style({
+		image: new Icon({
+			src: markerIcon,
+			color: [255, 0, 0],
+			scale: .75
+		})
+	});
+
+
+	const getTextStyle = (size) => {
+		const strokeWidth = 1;
+		return new Style({
+			text: new Text({
+				text: 'Foo',
+				font: 'normal 16px sans-serif',
+				stroke: new Stroke({
+					color: [0, 0, 0],
+					width: strokeWidth
+				}),
+				fill: new Fill({
+					color: [255, 255, 255]
+				}),
+				scale: size
+			})
+		});
+	};
+
+	const strokeStyle = new Style({
+		fill: new Fill({
+			color: [255, 255, 255, 0.4]
+		}),
+		stroke: new Stroke({
+			color: [255, 255, 0],
+			width: 0
+		})
+	});
+
+
+	it('should extract a size from feature with text style', () => {
+		expect(getSizeFrom({ getStyle: () => [getTextStyle(2)] })).toBe('large');
+		expect(getSizeFrom({ getStyle: () => [getTextStyle(1.5)] })).toBe('medium');
+		expect(getSizeFrom({ getStyle: () => [getTextStyle(1)] })).toBe('small');
+	});
+
+	it('should extract a size from feature with marker style', () => {
+		const featureMock = { getStyle: () => [imageStyle] };
+		const expectedSize = 'medium';
+
+		expect(getSizeFrom(featureMock)).toBe(expectedSize);
+	});
+
+	it('should NOT extract a size from feature style', () => {
+		const featureMock = { getStyle: () => [strokeStyle] };
+
+		expect(getSizeFrom(featureMock)).toBeNull();
+	});
+
+	it('should return null for empty feature', () => {
+		const featureWithoutStyle = { getStyle: () => null };
+
+		expect(getSizeFrom(featureWithoutStyle)).toBeNull();
+		expect(getSizeFrom(null)).toBeNull();
+		expect(getSizeFrom(undefined)).toBeNull();
 	});
 
 });


### PR DESCRIPTION
Add scale information of selected features to the changed styleOption in store, to display the correct scale-value in the DrawToolContent

fixes #1104