### PR TITLE
PdfExport: connect client with backend (I)

### DIFF
--- a/src/injection/config.js
+++ b/src/injection/config.js
@@ -68,7 +68,7 @@ $injector
 	.register('SourceTypeService', SourceTypeService)
 	.registerSingleton('SecurityService', new SecurityService())
 	.registerSingleton('BaaCredentialService', new BaaCredentialService())
-	.register('MfpService', MfpService)
+	.registerSingleton('MfpService', new MfpService())
 
 	.registerSingleton('DrawPlugin', new DrawPlugin())
 	.registerSingleton('TopicsPlugin', new TopicsPlugin())

--- a/src/plugins/ExportMfpPlugin.js
+++ b/src/plugins/ExportMfpPlugin.js
@@ -36,7 +36,7 @@ export class ExportMfpPlugin extends BaPlugin {
 
 			if (!this._initialized) {
 				// let's set the initial mfp properties
-				const capabilities = await mfpService.getCapabilities();
+				const capabilities = await mfpService.init();
 				const { id, scales, dpis } = capabilities[0];
 				setCurrent({ id: id, dpi: dpis[0], scale: scales[0] });
 				this._initialized = true;

--- a/src/services/MfpService.js
+++ b/src/services/MfpService.js
@@ -1,8 +1,10 @@
 import { sleep } from '../utils/sleep';
+import { loadBvvMfpCapabilities } from './provider/mfp.provider';
 /**
  *
  * @typedef {Object} MfpCapabilities
- * @property {string} name
+ * @property {string} id
+ * @property {string} urlId
  * @property {Array<number>} scales
  * @property {Array<number>} dpis
  * @property {MfpMapSize} mapSize
@@ -21,37 +23,29 @@ import { sleep } from '../utils/sleep';
  */
 export class MfpService {
 
-	constructor() {
+	constructor(mfpCapabilitiesProvider = loadBvvMfpCapabilities) {
 		this._abortController = null;
-	}
-
-	_getMockCapabilities() {
-		const scales = [2000000, 1000000, 500000, 200000, 100000, 50000, 25000, 10000, 5000, 2500, 1250, 1000, 500];
-		const dpis = [125, 200];
-
-		return [
-			{ id: 'a4_portrait', scales: scales, dpis: dpis, mapSize: { width: 539, height: 722 } },
-			{ id: 'a4_landscape', scales: scales, dpis: dpis, mapSize: { width: 785, height: 475 } },
-			{ id: 'a3_portrait', scales: scales, dpis: dpis, mapSize: { width: 786, height: 1041 } },
-			{ id: 'a3_landscape', scales: scales, dpis: dpis, mapSize: { width: 1132, height: 692 } }
-		];
+		this._mfpCapabilities = null;
+		this._mfpCapabilitiesProvider = mfpCapabilitiesProvider;
 	}
 
 	/**
 	 * @returns {Array<MfpCapabilities>} all available capbilities
 	 */
 	async getCapabilities() {
-		return this._getMockCapabilities();
+		if (!this._mfpCapabilities) {
+			this._mfpCapabilities = await this._mfpCapabilitiesProvider();
+		}
+		return this._mfpCapabilities;
 	}
 
 	/**
-	* Returns the corresponding  {@link MfpCapabilities} for an id.
-	* @public
+	* Returns the corresponding  {@link MfpCapabilities} for a specific id.
 	* @param {string} id Id of the desired {@link MfpCapabilities}
 	* @returns {MfpCapabilities|null}
 	*/
 	getCapabilitiesById(id) {
-		return this._getMockCapabilities().find(cp => cp.id === id) ?? null;
+		return this._mfpCapabilities?.find(cp => cp.id === id) ?? null;
 	}
 
 	/**

--- a/src/services/provider/mfp.provider.js
+++ b/src/services/provider/mfp.provider.js
@@ -1,0 +1,22 @@
+import { $injector } from '../../injection';
+
+/**
+ * Uses the BVV backend to load an array of MfpCapabilities.
+ * @function
+ * @returns {Array<MfpCapabilities>}
+ */
+export const loadBvvMfpCapabilities = async () => {
+
+	const { HttpService: httpService, ConfigService: configService } = $injector.inject('HttpService', 'ConfigService');
+	const url = configService.getValueAsPath('BACKEND_URL') + 'print/info';
+	const result = await httpService.get(`${url}`);
+
+	const readCapabilities = capabilities => capabilities.map(c => ({ id: c.name, urlId: c.urlId, scales: [...c.scales], dpis: [...c.dpis], mapSize: { ...c.map } }));
+
+	switch (result.status) {
+		case 200:
+			return readCapabilities(await result.json());
+		default:
+			throw new Error(`MfpCapabilties could not be loaded: Http-Status ${result.status}`);
+	}
+};

--- a/src/services/provider/mfp.provider.js
+++ b/src/services/provider/mfp.provider.js
@@ -11,7 +11,7 @@ export const loadBvvMfpCapabilities = async () => {
 	const url = configService.getValueAsPath('BACKEND_URL') + 'print/info';
 	const result = await httpService.get(`${url}`);
 
-	const readCapabilities = capabilities => capabilities.map(c => ({ id: c.name, urlId: c.urlId, scales: [...c.scales], dpis: [...c.dpis], mapSize: { ...c.map } }));
+	const readCapabilities = capabilities => capabilities.map(c => ({ id: c.id, urlId: c.urlId, scales: [...c.scales], dpis: [...c.dpis], mapSize: { ...c.mapSize } }));
 
 	switch (result.status) {
 		case 200:

--- a/test/plugins/ExportMfpPlugin.test.js
+++ b/test/plugins/ExportMfpPlugin.test.js
@@ -12,7 +12,7 @@ import { layersReducer } from '../../src/store/layers/layers.reducer.js';
 describe('ExportMfpPlugin', () => {
 
 	const mfpService = {
-		async getCapabilities() { },
+		async init() { },
 		async createJob() { },
 		cancelJob() { }
 	};
@@ -47,7 +47,7 @@ describe('ExportMfpPlugin', () => {
 			const store = setup();
 			const instanceUnderTest = new ExportMfpPlugin();
 			await instanceUnderTest.register(store);
-			spyOn(mfpService, 'getCapabilities').and.resolveTo(getMockCapabilities());
+			spyOn(mfpService, 'init').and.resolveTo(getMockCapabilities());
 
 			setCurrentTool(ToolId.EXPORT);
 

--- a/test/service/MfpService.test.js
+++ b/test/service/MfpService.test.js
@@ -1,39 +1,62 @@
 import { MfpService } from '../../src/services/MfpService';
+import { loadBvvMfpCapabilities } from '../../src/services/provider/mfp.provider';
 
 describe('MfpService', () => {
 
-	describe('init', () => {
+	const scales = [2000000, 1000000, 500000, 200000, 100000, 50000, 25000, 10000, 5000, 2500, 1250, 1000, 500];
+	const dpis = [125, 200];
+	const mockCapabilities = [
+		{ id: 'a4_portrait', urlId: 0, scales: scales, dpis: dpis, mapSize: { width: 539, height: 722 } },
+		{ id: 'a4_landscape', urlId: 0, scales: scales, dpis: dpis, mapSize: { width: 785, height: 475 } },
+		{ id: 'a3_portrait', urlId: 0, scales: scales, dpis: dpis, mapSize: { width: 786, height: 1041 } },
+		{ id: 'a3_landscape', urlId: 0, scales: scales, dpis: dpis, mapSize: { width: 1132, height: 692 } }
+	];
 
-		it('initializes the service', async () => {
+	const setup = (provider = loadBvvMfpCapabilities) => {
+		return new MfpService(provider);
+	};
+
+	describe('constructor', () => {
+
+		it('initializes the with default providers', async () => {
 			const instanceUnderTest = new MfpService();
 
 			expect(instanceUnderTest._abortController).toBeNull();
+			expect(instanceUnderTest._mfpCapabilitiesProvider).toEqual(loadBvvMfpCapabilities);
+		});
+
+		it('initializes the service with custom providers', async () => {
+			const customProvider = async () => { };
+			const instanceUnderTest = setup(customProvider);
+			expect(instanceUnderTest._mfpCapabilitiesProvider).toEqual(customProvider);
 		});
 	});
 
 	describe('getCapabilities', () => {
 
 		it('provides an array of MfpCapabilities', async () => {
+			const provider = jasmine.createSpy().and.resolveTo(mockCapabilities);
+			const instanceUnderTest = setup(provider);
 
-			const instanceUnderTest = new MfpService();
-
-			const result = await instanceUnderTest.getCapabilities();
-
-			expect(result).toHaveSize(4);
+			// first call served from provider
+			await expectAsync(instanceUnderTest.getCapabilities()).toBeResolvedTo(mockCapabilities);
+			// second from cache
+			await expectAsync(instanceUnderTest.getCapabilities()).toBeResolvedTo(mockCapabilities);
+			expect(provider).toHaveBeenCalledTimes(1);
 		});
 	});
 
 	describe('getCapabilitiesById', () => {
 
-		it('provides a MfpCapabilities object by its id', () => {
-
-			const instanceUnderTest = new MfpService();
+		it('provides a MfpCapabilities object by its id', async () => {
+			const instanceUnderTest = setup(async () => mockCapabilities);
+			// initially load capabilities
+			await instanceUnderTest.getCapabilities();
 
 			expect(instanceUnderTest.getCapabilitiesById('a4_landscape')).not.toBeNull();
 			expect(instanceUnderTest.getCapabilitiesById('foo')).toBeNull();
 		});
 	});
-
 
 	describe('createJob', () => {
 

--- a/test/service/MfpService.test.js
+++ b/test/service/MfpService.test.js
@@ -1,7 +1,17 @@
+import { $injector } from '../../src/injection';
 import { MfpService } from '../../src/services/MfpService';
 import { loadBvvMfpCapabilities } from '../../src/services/provider/mfp.provider';
 
 describe('MfpService', () => {
+
+	const environmentService = {
+		isStandalone: () => { }
+	};
+
+	beforeAll(() => {
+		$injector
+			.registerSingleton('EnvironmentService', environmentService);
+	});
 
 	const scales = [2000000, 1000000, 500000, 200000, 100000, 50000, 25000, 10000, 5000, 2500, 1250, 1000, 500];
 	const dpis = [125, 200];
@@ -18,40 +28,107 @@ describe('MfpService', () => {
 
 	describe('constructor', () => {
 
-		it('initializes the with default providers', async () => {
+		it('instantiates the service with default providers', async () => {
 			const instanceUnderTest = new MfpService();
 
 			expect(instanceUnderTest._abortController).toBeNull();
 			expect(instanceUnderTest._mfpCapabilitiesProvider).toEqual(loadBvvMfpCapabilities);
 		});
 
-		it('initializes the service with custom providers', async () => {
+		it('instantiates the service with custom providers', async () => {
 			const customProvider = async () => { };
 			const instanceUnderTest = setup(customProvider);
 			expect(instanceUnderTest._mfpCapabilitiesProvider).toEqual(customProvider);
 		});
 	});
 
+	describe('init', () => {
+
+		it('initializes the service', async () => {
+			const instanceUnderTest = setup(async () => mockCapabilities);
+			expect(instanceUnderTest._mfpCapabilities).toBeNull();
+
+			const mfpCapabilities = await instanceUnderTest.init();
+
+			expect(mfpCapabilities.length).toBe(4);
+		});
+
+		it('just provides the topics when already initialized', async () => {
+			const instanceUnderTest = setup();
+			instanceUnderTest._mfpCapabilities = mockCapabilities;
+
+			const mfpCapabilities = await instanceUnderTest.init();
+
+			expect(mfpCapabilities.length).toBe(4);
+		});
+
+		describe('provider cannot fulfill', () => {
+
+			it('loads two fallback topics when we are in standalone mode', async () => {
+
+				spyOn(environmentService, 'isStandalone').and.returnValue(true);
+				const instanceUnderTest = setup(async () => {
+					throw new Error('MfpCapabilities could not be loaded');
+				});
+				const warnSpy = spyOn(console, 'warn');
+
+
+				const mfpCapabilities = await instanceUnderTest.init();
+
+				expect(mfpCapabilities.length).toBe(2);
+				expect(warnSpy).toHaveBeenCalledWith('MfpCapabilities could not be fetched from backend. Using fallback capabilities ...');
+			});
+
+			it('logs an error when we are NOT in standalone mode', async () => {
+
+				spyOn(environmentService, 'isStandalone').and.returnValue(false);
+				const instanceUnderTest = setup(async () => {
+					throw new Error('something got wrong');
+				});
+				const errorSpy = spyOn(console, 'error');
+
+
+				const mfpCapabilities = await instanceUnderTest.init();
+
+				expect(mfpCapabilities).toEqual([]);
+				expect(errorSpy).toHaveBeenCalledWith('MfpCapabilities could not be fetched from backend.', jasmine.anything());
+			});
+		});
+	});
+
 	describe('getCapabilities', () => {
 
-		it('provides an array of MfpCapabilities', async () => {
+		it('returns an empty array of MfpCapabilities when not initialized', async () => {
 			const provider = jasmine.createSpy().and.resolveTo(mockCapabilities);
 			const instanceUnderTest = setup(provider);
 
+			expect(instanceUnderTest.getCapabilities()).toHaveSize(0);
+		});
+
+		it('returns an array of MfpCapabilities', async () => {
+			const provider = jasmine.createSpy().and.resolveTo(mockCapabilities);
+			const instanceUnderTest = setup(provider);
+			await instanceUnderTest.init();
+
 			// first call served from provider
-			await expectAsync(instanceUnderTest.getCapabilities()).toBeResolvedTo(mockCapabilities);
+			expect(instanceUnderTest.getCapabilities()).toEqual(mockCapabilities);
 			// second from cache
-			await expectAsync(instanceUnderTest.getCapabilities()).toBeResolvedTo(mockCapabilities);
+			expect(instanceUnderTest.getCapabilities()).toEqual(mockCapabilities);
 			expect(provider).toHaveBeenCalledTimes(1);
 		});
 	});
 
 	describe('getCapabilitiesById', () => {
 
-		it('provides a MfpCapabilities object by its id', async () => {
+		it('returns NULL when not initialized', async () => {
 			const instanceUnderTest = setup(async () => mockCapabilities);
-			// initially load capabilities
-			await instanceUnderTest.getCapabilities();
+
+			expect(instanceUnderTest.getCapabilitiesById('a4_landscape')).toBeNull();
+		});
+
+		it('returns a MfpCapabilities object by its id', async () => {
+			const instanceUnderTest = setup(async () => mockCapabilities);
+			await instanceUnderTest.init();
 
 			expect(instanceUnderTest.getCapabilitiesById('a4_landscape')).not.toBeNull();
 			expect(instanceUnderTest.getCapabilitiesById('foo')).toBeNull();
@@ -83,6 +160,19 @@ describe('MfpService', () => {
 			instanceUnderTest.cancelJob();
 
 			expect(spy).toHaveBeenCalled();
+		});
+	});
+
+	describe('_newFallbackCapabilities', () => {
+
+		it('cancels an running MFP job', async () => {
+			const expected = [
+				{ id: 'a4_landscape', urlId: 0, mapSize: { width: 785, height: 475 }, dpis: [72, 120, 200], scales: [2000000, 1000000, 500000, 200000, 100000, 50000, 25000, 10000, 5000, 2500, 1250, 1000, 500] },
+				{ id: 'a4_portrait', urlId: 0, mapSize: { width: 539, height: 722 }, dpis: [72, 120, 200], scales: [2000000, 1000000, 500000, 200000, 100000, 50000, 25000, 10000, 5000, 2500, 1250, 1000, 500] }
+			];
+			const instanceUnderTest = new MfpService();
+
+			expect(instanceUnderTest._newFallbackCapabilities()).toEqual(expected);
 		});
 	});
 });

--- a/test/service/mfp.provider.test.js
+++ b/test/service/mfp.provider.test.js
@@ -1,0 +1,48 @@
+import { $injector } from '../../src/injection';
+import { loadBvvMfpCapabilities } from '../../src/services/provider/mfp.provider';
+
+describe('bvvMfpCapabilitiesProvider', () => {
+	const configService = {
+		getValueAsPath() { }
+	};
+
+	const httpService = {
+		async get() { }
+	};
+
+	beforeAll(() => {
+		$injector
+			.registerSingleton('ConfigService', configService)
+			.registerSingleton('HttpService', httpService);
+	});
+
+
+	it('loads an array of MfpCapabilities', async () => {
+		const backendUrl = 'https://backend.url';
+		const mockResponse = [{ 'name': 'A4 landscape', 'urlId': 0, 'map': { 'width': 785, 'height': 475 }, 'dpis': [72, 120, 200], 'scales': [2000000, 1000000, 500000, 200000, 100000, 50000, 25000, 10000, 5000, 2500, 1250, 1000, 500] }, { 'name': 'A3 portrait', 'urlId': 0, 'map': { 'width': 786, 'height': 1041 }, 'dpis': [72, 120, 200], 'scales': [2000000, 1000000, 500000, 200000, 100000, 50000, 25000, 10000, 5000, 2500, 1250, 1000, 500] }];
+		const expectedResult = [{ id: 'A4 landscape', urlId: 0, mapSize: { width: 785, height: 475 }, dpis: [72, 120, 200], scales: [2000000, 1000000, 500000, 200000, 100000, 50000, 25000, 10000, 5000, 2500, 1250, 1000, 500] }, { id: 'A3 portrait', urlId: 0, mapSize: { width: 786, height: 1041 }, dpis: [72, 120, 200], scales: [2000000, 1000000, 500000, 200000, 100000, 50000, 25000, 10000, 5000, 2500, 1250, 1000, 500] }];
+		const configServiceSpy = spyOn(configService, 'getValueAsPath').withArgs('BACKEND_URL').and.returnValue(`${backendUrl}/`);
+		const httpServiceSpy = spyOn(httpService, 'get').withArgs(`${backendUrl}/print/info`).and.resolveTo(new Response(
+			JSON.stringify(mockResponse))
+		);
+
+		const mfpCapabilities = await loadBvvMfpCapabilities();
+
+		expect(configServiceSpy).toHaveBeenCalled();
+		expect(httpServiceSpy).toHaveBeenCalled();
+		expect(mfpCapabilities).toEqual(expectedResult);
+	});
+
+	it('throws error on failed request', async () => {
+
+		const backendUrl = 'https://backend.url';
+		const configServiceSpy = spyOn(configService, 'getValueAsPath').withArgs('BACKEND_URL').and.returnValue(`${backendUrl}/`);
+		const httpServiceSpy = spyOn(httpService, 'get').withArgs(`${backendUrl}/print/info`).and.resolveTo(
+			new Response(JSON.stringify({}), { status: 500 })
+		);
+
+		await expectAsync(loadBvvMfpCapabilities()).toBeRejectedWithError('MfpCapabilties could not be loaded: Http-Status 500');
+		expect(configServiceSpy).toHaveBeenCalled();
+		expect(httpServiceSpy).toHaveBeenCalled();
+	});
+});

--- a/test/service/mfp.provider.test.js
+++ b/test/service/mfp.provider.test.js
@@ -19,8 +19,8 @@ describe('bvvMfpCapabilitiesProvider', () => {
 
 	it('loads an array of MfpCapabilities', async () => {
 		const backendUrl = 'https://backend.url';
-		const mockResponse = [{ 'id': 'A4 landscape', 'urlId': 0, 'mapSize': { 'width': 785, 'height': 475 }, 'dpis': [72, 120, 200], 'scales': [2000000, 1000000, 500000, 200000, 100000, 50000, 25000, 10000, 5000, 2500, 1250, 1000, 500] }, { 'id': 'A3 portrait', 'urlId': 0, 'mapSize': { 'width': 786, 'height': 1041 }, 'dpis': [72, 120, 200], 'scales': [2000000, 1000000, 500000, 200000, 100000, 50000, 25000, 10000, 5000, 2500, 1250, 1000, 500] }];
-		const expectedResult = [{ id: 'A4 landscape', urlId: 0, mapSize: { width: 785, height: 475 }, dpis: [72, 120, 200], scales: [2000000, 1000000, 500000, 200000, 100000, 50000, 25000, 10000, 5000, 2500, 1250, 1000, 500] }, { id: 'A3 portrait', urlId: 0, mapSize: { width: 786, height: 1041 }, dpis: [72, 120, 200], scales: [2000000, 1000000, 500000, 200000, 100000, 50000, 25000, 10000, 5000, 2500, 1250, 1000, 500] }];
+		const mockResponse = [{ 'id': 'a4_landscape', 'urlId': 0, 'mapSize': { 'width': 785, 'height': 475 }, 'dpis': [72, 120, 200], 'scales': [2000000, 1000000, 500000, 200000, 100000, 50000, 25000, 10000, 5000, 2500, 1250, 1000, 500] }, { 'id': 'a3_portrait', 'urlId': 0, 'mapSize': { 'width': 786, 'height': 1041 }, 'dpis': [72, 120, 200], 'scales': [2000000, 1000000, 500000, 200000, 100000, 50000, 25000, 10000, 5000, 2500, 1250, 1000, 500] }];
+		const expectedResult = [{ id: 'a4_landscape', urlId: 0, mapSize: { width: 785, height: 475 }, dpis: [72, 120, 200], scales: [2000000, 1000000, 500000, 200000, 100000, 50000, 25000, 10000, 5000, 2500, 1250, 1000, 500] }, { id: 'a3_portrait', urlId: 0, mapSize: { width: 786, height: 1041 }, dpis: [72, 120, 200], scales: [2000000, 1000000, 500000, 200000, 100000, 50000, 25000, 10000, 5000, 2500, 1250, 1000, 500] }];
 		const configServiceSpy = spyOn(configService, 'getValueAsPath').withArgs('BACKEND_URL').and.returnValue(`${backendUrl}/`);
 		const httpServiceSpy = spyOn(httpService, 'get').withArgs(`${backendUrl}/print/info`).and.resolveTo(new Response(
 			JSON.stringify(mockResponse))

--- a/test/service/mfp.provider.test.js
+++ b/test/service/mfp.provider.test.js
@@ -19,7 +19,7 @@ describe('bvvMfpCapabilitiesProvider', () => {
 
 	it('loads an array of MfpCapabilities', async () => {
 		const backendUrl = 'https://backend.url';
-		const mockResponse = [{ 'name': 'A4 landscape', 'urlId': 0, 'map': { 'width': 785, 'height': 475 }, 'dpis': [72, 120, 200], 'scales': [2000000, 1000000, 500000, 200000, 100000, 50000, 25000, 10000, 5000, 2500, 1250, 1000, 500] }, { 'name': 'A3 portrait', 'urlId': 0, 'map': { 'width': 786, 'height': 1041 }, 'dpis': [72, 120, 200], 'scales': [2000000, 1000000, 500000, 200000, 100000, 50000, 25000, 10000, 5000, 2500, 1250, 1000, 500] }];
+		const mockResponse = [{ 'id': 'A4 landscape', 'urlId': 0, 'mapSize': { 'width': 785, 'height': 475 }, 'dpis': [72, 120, 200], 'scales': [2000000, 1000000, 500000, 200000, 100000, 50000, 25000, 10000, 5000, 2500, 1250, 1000, 500] }, { 'id': 'A3 portrait', 'urlId': 0, 'mapSize': { 'width': 786, 'height': 1041 }, 'dpis': [72, 120, 200], 'scales': [2000000, 1000000, 500000, 200000, 100000, 50000, 25000, 10000, 5000, 2500, 1250, 1000, 500] }];
 		const expectedResult = [{ id: 'A4 landscape', urlId: 0, mapSize: { width: 785, height: 475 }, dpis: [72, 120, 200], scales: [2000000, 1000000, 500000, 200000, 100000, 50000, 25000, 10000, 5000, 2500, 1250, 1000, 500] }, { id: 'A3 portrait', urlId: 0, mapSize: { width: 786, height: 1041 }, dpis: [72, 120, 200], scales: [2000000, 1000000, 500000, 200000, 100000, 50000, 25000, 10000, 5000, 2500, 1250, 1000, 500] }];
 		const configServiceSpy = spyOn(configService, 'getValueAsPath').withArgs('BACKEND_URL').and.returnValue(`${backendUrl}/`);
 		const httpServiceSpy = spyOn(httpService, 'get').withArgs(`${backendUrl}/print/info`).and.resolveTo(new Response(


### PR DESCRIPTION
For the present just  `MfpService#getCapabilities()` has been implemented, the other methods will be done in a second PR and are still mocked.