### PR TITLE
update button-behavior

### DIFF
--- a/src/modules/toolbox/components/exportMfpToolContent/ExportMfpToolContent.js
+++ b/src/modules/toolbox/components/exportMfpToolContent/ExportMfpToolContent.js
@@ -48,9 +48,10 @@ export class ExportMfpToolContent extends AbstractToolContent {
 		const translate = (key) => this._translationService.translate(key);
 		const capabilities = this._mfpService.getCapabilities();
 
-		const onClickAction = isJobStarted ? () => cancelJob() : () => 	requestJob();
+		const onClickAction = isJobStarted ? () => cancelJob() : () => requestJob();
 		const btnLabel = isJobStarted ? translate('toolbox_exportMfp_cancel') : translate('toolbox_exportMfp_submit');
 		const btnId = isJobStarted ? 'btn_cancel' : 'btn_submit';
+		const btnType = isJobStarted ? 'loading' : 'primary';
 
 		const areSettingsComplete = (capabilities && scale && id);
 		return html`
@@ -62,7 +63,7 @@ export class ExportMfpToolContent extends AbstractToolContent {
 				${areSettingsComplete ? this._getContent(id, scale, capabilities.layouts) : this._getSpinner()}				
 			</div>
 			<div class="ba-tool-container__actions"> 
-				<ba-button id='${btnId}' class="tool-container__button" .label=${btnLabel} @click=${onClickAction} .disabled=${!areSettingsComplete}></ba-button>
+				<ba-button id='${btnId}' class="tool-container__button" .label=${btnLabel} @click=${onClickAction} .type=${btnType} .disabled=${!areSettingsComplete}></ba-button>
 			</div>			
 		</div>`;
 	}

--- a/test/modules/toolbox/components/exportMfpToolContent/ExportMfpToolContent.test.js
+++ b/test/modules/toolbox/components/exportMfpToolContent/ExportMfpToolContent.test.js
@@ -247,6 +247,7 @@ describe('ExportMfpToolContent', () => {
 
 			expect(element.shadowRoot.querySelectorAll('#btn_cancel')).toHaveSize(1);
 			expect(element.shadowRoot.querySelectorAll('#btn_submit')).toHaveSize(0);
+			expect(element.shadowRoot.querySelectorAll('#btn_cancel')[0].type).toBe('loading');
 		});
 	});
 
@@ -274,6 +275,7 @@ describe('ExportMfpToolContent', () => {
 
 			expect(element.shadowRoot.querySelectorAll('#btn_cancel')).toHaveSize(0);
 			expect(element.shadowRoot.querySelectorAll('#btn_submit')).toHaveSize(1);
+			expect(element.shadowRoot.querySelectorAll('#btn_submit')[0].type).toBe('primary');
 		});
 	});
 });

--- a/test/modules/toolbox/components/exportMfpToolContent/ExportMfpToolContent.test.js
+++ b/test/modules/toolbox/components/exportMfpToolContent/ExportMfpToolContent.test.js
@@ -239,7 +239,7 @@ describe('ExportMfpToolContent', () => {
 			expect(store.getState().mfp.jobRequest).toEqual(jasmine.any(EventLike));
 		});
 
-		it('it displays the cancel-button', async () => {
+		it('displays the cancel-button', async () => {
 			spyOn(mfpServiceMock, 'getCapabilities').and.returnValue(capabilities);
 			const element = await setup({ ...mfpDefaultState, current: initialCurrent });
 
@@ -264,7 +264,7 @@ describe('ExportMfpToolContent', () => {
 			expect(store.getState().mfp.jobSpec.payload).toBeNull();
 		});
 
-		it('it displays the submit-button again', async () => {
+		it('displays the submit-button again', async () => {
 			spyOn(mfpServiceMock, 'getCapabilities').and.returnValue(capabilities);
 			const element = await setup({ ...mfpDefaultState, current: initialCurrent });
 


### PR DESCRIPTION
Update button behavior to show with a marquee-animation, that the export-job is running (but cancable)

![button_style](https://user-images.githubusercontent.com/2117317/199437210-68223fb7-80f3-4523-8a3e-d398a130cf24.png)
