### PR TITLE
fix content of thumbnailLabel

### DIFF
--- a/src/modules/olMap/services/Mfp3Encoder.js
+++ b/src/modules/olMap/services/Mfp3Encoder.js
@@ -237,7 +237,7 @@ export class BvvMfp3Encoder {
 		};
 
 		const createEmptySpecsAndWarn = () => {
-			console.warn(`Missing substitution georesource for layer '${olLayer.id}' and georesource '${wmtsGeoResource.id}'.`);
+			console.warn(`Missing substitution for GeoResource '${wmtsGeoResource.id}'.`);
 			return [];
 		};
 

--- a/test/modules/olMap/formats/Mfp3Encoder.test.js
+++ b/test/modules/olMap/formats/Mfp3Encoder.test.js
@@ -473,7 +473,7 @@ describe('BvvMfp3Encoder', () => {
 
 			const actualSpec = encoder._encodeWMTS(wmtsLayerMock, wmtsGeoResource);
 
-			expect(warnSpy).toHaveBeenCalledOnceWith('Missing substitution georesource for layer \'wmts\' and georesource \'test_something\'.');
+			expect(warnSpy).toHaveBeenCalledOnceWith('Missing substitution for GeoResource \'test_something\'.');
 			expect(actualSpec).toEqual([]);
 			expect(geoResourceServiceSpy).not.toHaveBeenCalled();
 			expect(layerServiceSpy).not.toHaveBeenCalled();


### PR DESCRIPTION
Fixes a misbehavior where the label content of the thumbnail-style was not updated, after the mfp settings are changed.
The thumbnail-style is used to display the currently selected mfp-settings and extent as preview for the export.