### PR TITLE
improve usage of GeoResourceFuture

### DIFF
--- a/src/domain/geoResources.js
+++ b/src/domain/geoResources.js
@@ -234,8 +234,8 @@ export class GeoResourceFuture extends GeoResource {
 	 * @param {string} id
 	 * @param {asyncGeoResourceLoader} loader
 	 */
-	constructor(id, loader, label = '') {
-		super(id, label);
+	constructor(id, loader) {
+		super(id);
 		this._loader = loader;
 		this._onResolve = [];
 		this._onReject = [];

--- a/src/domain/geoResources.js
+++ b/src/domain/geoResources.js
@@ -190,6 +190,14 @@ export class GeoResource {
 	}
 
 	/**
+	 * Checks if this GeoResource contains a non-default value as label
+	 * @returns `true` if the label is a non-default value
+	 */
+	hasLabel() {
+		return !!this._label;
+	}
+
+	/**
 	 * Returns an array of attibutions determined by the attributionProvider (optionally for a specific zoom level)
 	 * for this GeoResource.
 	 * It returns `null` when no attributions are available.
@@ -386,6 +394,29 @@ export class VectorGeoResource extends GeoResource {
 		this._srid = null;
 	}
 
+	/**
+	 *
+	 * @returns `true` if this GeoResource contains an non empty string as label
+	 */
+	_getFallbackLabel() {
+		if (this._label) {
+			return this._label;
+		}
+		switch (this.sourceType) {
+			case VectorSourceType.KML:
+				return 'KML';
+			case VectorSourceType.GPX:
+				return 'GPX';
+			case VectorSourceType.GEOJSON:
+				return 'GeoJSON';
+			default: return '';
+		}
+	}
+
+	get label() {
+		return this._label ? this._label : this._getFallbackLabel();
+	}
+
 	get url() {
 		return this._url;
 	}
@@ -429,10 +460,19 @@ export class VectorGeoResource extends GeoResource {
 
 	/**
 	 * @override
+	 * @returns `true` if this GeoResource contains an non empty string and no fallback as label
+	 */
+	hasLabel() {
+		return !!this._label || this.label !== this._getFallbackLabel();
+	}
+
+	/**
+	 * @override
 	 */
 	getType() {
 		return GeoResourceTypes.VECTOR;
 	}
+
 }
 
 /**

--- a/src/modules/layerManager/components/LayerItem.js
+++ b/src/modules/layerManager/components/LayerItem.js
@@ -13,7 +13,7 @@ import { AbstractMvuContentPanel } from '../../menu/components/mainMenu/content/
 import { openModal } from '../../../../src/store/modal/modal.action';
 import { createUniqueId } from '../../../utils/numberUtils';
 import { fitLayer } from '../../../store/position/position.action';
-import { VectorGeoResource } from '../../../domain/geoResources';
+import { GeoResourceFuture, VectorGeoResource } from '../../../domain/geoResources';
 import { MenuTypes } from '../../commons/components/overflowMenu/OverflowMenu';
 
 
@@ -60,14 +60,24 @@ export class LayerItem extends AbstractMvuContentPanel {
 					...model,
 					layer: {
 						...data,
-						visible: data && data.visible != null ? data.visible : true,
-						collapsed: data && data.collapsed != null ? data.collapsed : true,
-						opacity: data && data.opacity != null ? data.opacity : 1
+						visible: data?.visible ?? true,
+						collapsed: data?.collapsed ?? true,
+						opacity: data?.opacity ?? 1,
+						loading: data?.loading ?? false
 					}
 				};
 			case Update_Layer_Collapsed:
 				return { ...model, layer: { ...model.layer, collapsed: data } };
 		}
+	}
+
+	onInitialize() {
+		this.observe(state => state.geoResources.changed, (changed) => {
+			if (this.getModel().layer.geoResourceId === changed.payload) {
+				const geoResource = this._geoResourceService.byId(changed.payload);
+				this.signal(Update_Layer, { ...this.getModel().layer, label: geoResource.label });
+			}
+		}, false);
 	}
 
 
@@ -108,7 +118,9 @@ export class LayerItem extends AbstractMvuContentPanel {
 		if (!layer) {
 			return nothing;
 		}
-		const currentLabel = layer.label === '' ? layer.id : layer.label;
+		const geoResource = this._geoResourceService.byId(layer.geoResourceId);
+		// const currentLabel = (geoResource instanceof GeoResourceFuture) ? 'Loading Toddo i18n' : geoResource.label;
+		const currentLabel = layer.label;
 		const getCollapseTitle = () => {
 			return layer.collapsed ? translate('layerManager_expand') : translate('layerManager_collapse');
 		};
@@ -197,7 +209,7 @@ export class LayerItem extends AbstractMvuContentPanel {
 		const getMenuItems = () => {
 			return [
 				{ id: 'copy', label: translate('layerManager_to_copy'), icon: cloneSvg, action: cloneLayer, disabled: !layer.constraints?.cloneable },
-				{ id: 'zoomToExtent', label: translate('layerManager_zoom_to_extent'), icon: zoomToExtentSvg, action: zoomToExtent, disabled: !(this._geoResourceService.byId(layer.geoResourceId) instanceof VectorGeoResource) },
+				{ id: 'zoomToExtent', label: translate('layerManager_zoom_to_extent'), icon: zoomToExtentSvg, action: zoomToExtent, disabled: !(geoResource instanceof VectorGeoResource) },
 				{ id: 'info', label: 'Info', icon: infoSvg, action: openGeoResourceInfoPanel, disabled: !layer.constraints?.metaData }
 			];
 		};
@@ -207,7 +219,7 @@ export class LayerItem extends AbstractMvuContentPanel {
         <div class='ba-section divider'>
             <div class='ba-list-item'>          
 
-                    <ba-checkbox .title='${getVisibilityTitle()}'  class='ba-list-item__text' tabindex='0' .checked=${layer.visible} @toggle=${toggleVisibility}>${currentLabel}</ba-checkbox>                                                   
+                    <ba-checkbox .title='${getVisibilityTitle()}'  class='ba-list-item__text' tabindex='0' .checked=${layer.visible} @toggle=${toggleVisibility}>${currentLabel}${layer.loading ? html`<ba-spinner .label=${' '}></ba-spinner>` : nothing}</ba-checkbox>                                                   
                                        
                 <button id='button-detail' data-test-id class='ba-list-item__after' title="${getCollapseTitle()}" @click="${toggleCollapse}">
                     <i class='icon chevron icon-rotate-90 ${classMap(iconCollapseClass)}'></i>
@@ -234,7 +246,22 @@ export class LayerItem extends AbstractMvuContentPanel {
 	}
 
 	set layer(value) {
-		this.signal(Update_Layer, value);
+		const translate = (key) => this._translationService.translate(key);
+		const geoResource = this._geoResourceService.byId(value.geoResourceId);
+
+		if (geoResource instanceof GeoResourceFuture) {
+			geoResource.onResolve(resolvedGeoR => this.signal(Update_Layer,
+				{
+					...value,
+					label: resolvedGeoR.label,
+					loading: false
+				}));
+		}
+		this.signal(Update_Layer, {
+			...value,
+			label: geoResource instanceof GeoResourceFuture ? translate('layerManager_loading_hint') : geoResource.label,
+			loading: geoResource instanceof GeoResourceFuture
+		});
 	}
 
 	/**

--- a/src/modules/layerManager/components/LayerItem.js
+++ b/src/modules/layerManager/components/LayerItem.js
@@ -124,7 +124,6 @@ export class LayerItem extends AbstractMvuContentPanel {
 			return nothing;
 		}
 		const geoResource = this._geoResourceService.byId(layer.geoResourceId);
-		// const currentLabel = (geoResource instanceof GeoResourceFuture) ? 'Loading Toddo i18n' : geoResource.label;
 		const currentLabel = layer.label;
 		const getCollapseTitle = () => {
 			return layer.collapsed ? translate('layerManager_expand') : translate('layerManager_collapse');

--- a/src/modules/layerManager/components/LayerItem.js
+++ b/src/modules/layerManager/components/LayerItem.js
@@ -19,6 +19,11 @@ import { MenuTypes } from '../../commons/components/overflowMenu/OverflowMenu';
 
 const Update_Layer = 'update_layer';
 const Update_Layer_Collapsed = 'update_layer_collapsed';
+const Default_Extra_Property_Values = {
+	collapsed: true,
+	opacity: 1,
+	loading: false
+};
 
 /**
  * Child element of the LayerManager. Represents one layer and its state.
@@ -60,10 +65,10 @@ export class LayerItem extends AbstractMvuContentPanel {
 					...model,
 					layer: {
 						...data,
-						visible: data?.visible ?? true,
-						collapsed: data?.collapsed ?? true,
-						opacity: data?.opacity ?? 1,
-						loading: data?.loading ?? false
+						visible: data.visible,
+						collapsed: data.collapsed,
+						opacity: data.opacity,
+						loading: data.loading
 					}
 				};
 			case Update_Layer_Collapsed:
@@ -252,12 +257,14 @@ export class LayerItem extends AbstractMvuContentPanel {
 		if (geoResource instanceof GeoResourceFuture) {
 			geoResource.onResolve(resolvedGeoR => this.signal(Update_Layer,
 				{
+					...Default_Extra_Property_Values,
 					...value,
 					label: resolvedGeoR.label,
 					loading: false
 				}));
 		}
 		this.signal(Update_Layer, {
+			Default_Extra_Property_Values,
 			...value,
 			label: geoResource instanceof GeoResourceFuture ? translate('layerManager_loading_hint') : geoResource.label,
 			loading: geoResource instanceof GeoResourceFuture

--- a/src/modules/layerManager/i18n/layerManager.provider.js
+++ b/src/modules/layerManager/i18n/layerManager.provider.js
@@ -17,7 +17,8 @@ export const provide = (lang) => {
 				layerManager_layer_copy: 'copy',
 				layerManager_expand_all: 'expand all',
 				layerManager_collapse_all: 'collapse all',
-				layerManager_remove_all: 'remove all'
+				layerManager_remove_all: 'remove all',
+				layerManager_loading_hint: 'Loading'
 			};
 
 		case 'de':
@@ -36,7 +37,8 @@ export const provide = (lang) => {
 				layerManager_layer_copy: 'Kopie',
 				layerManager_expand_all: 'Alle ausklappen',
 				layerManager_collapse_all: 'Alle einklappen',
-				layerManager_remove_all: 'Alle entfernen'
+				layerManager_remove_all: 'Alle entfernen',
+				layerManager_loading_hint: 'Wird geladen'
 			};
 
 		default:

--- a/src/modules/olMap/i18n/olMap.provider.js
+++ b/src/modules/olMap/i18n/olMap.provider.js
@@ -30,7 +30,8 @@ export const provide = (lang) => {
 				olMap_handler_mfp_id_a4_landscape: 'DIN A4 landscape',
 				olMap_handler_mfp_id_a4_portrait: 'DIN A4 portrait',
 				olMap_handler_mfp_id_a3_landscape: 'DIN A3 landscape',
-				olMap_handler_mfp_id_a3_portrait: 'DIN A3 portrait'
+				olMap_handler_mfp_id_a3_portrait: 'DIN A3 portrait',
+				olMap_vectorLayerService_default_layer_name_vector: 'Data'
 			};
 
 		case 'de':
@@ -62,7 +63,8 @@ export const provide = (lang) => {
 				olMap_handler_mfp_id_a4_landscape: 'DIN A4 Querformat',
 				olMap_handler_mfp_id_a4_portrait: 'DIN A4 Hochformat',
 				olMap_handler_mfp_id_a3_landscape: 'DIN A3 Querformat',
-				olMap_handler_mfp_id_a3_portrait: 'DIN A3 Hochformat'
+				olMap_handler_mfp_id_a3_portrait: 'DIN A3 Hochformat',
+				olMap_vectorLayerService_default_layer_name_vector: 'Daten'
 			};
 
 		default:

--- a/src/modules/olMap/services/VectorLayerService.js
+++ b/src/modules/olMap/services/VectorLayerService.js
@@ -4,6 +4,7 @@ import { $injector } from '../../../injection';
 import { load as featureLoader } from '../utils/feature.provider';
 import { KML, GPX, GeoJSON } from 'ol/format';
 import VectorLayer from 'ol/layer/Vector';
+import { propertyChanged } from '../../../store/geoResources/geoResources.action';
 
 
 
@@ -164,10 +165,13 @@ export class VectorLayerService {
 		 * At this moment an olLayer and its source are about to be added to the map.
 		 * To avoid conflicts, we have to delay the update of the GeoResource (and subsequent possible modifications of the connected layer).
 		 */
-		if (!geoResource.label) {
+		if (!geoResource.hasLabel()) {
 			switch (geoResource.sourceType) {
 				case VectorSourceType.KML:
-					setTimeout(() => geoResource.setLabel(format.readName(data)));
+					setTimeout(() => {
+						geoResource.setLabel(format.readName(data));
+						propertyChanged(geoResource.id);
+					});
 					break;
 			}
 		}

--- a/src/modules/olMap/services/VectorLayerService.js
+++ b/src/modules/olMap/services/VectorLayerService.js
@@ -170,7 +170,7 @@ export class VectorLayerService {
 				case VectorSourceType.KML:
 					setTimeout(() => {
 						geoResource.setLabel(format.readName(data));
-						propertyChanged(geoResource.id);
+						propertyChanged(geoResource);
 					});
 					break;
 			}

--- a/src/modules/olMap/services/VectorLayerService.js
+++ b/src/modules/olMap/services/VectorLayerService.js
@@ -142,10 +142,9 @@ export class VectorLayerService {
 	_vectorSourceForData(geoResource) {
 
 		const {
-			MapService: mapService, TranslationService: translationService
-		} = $injector.inject('MapService', 'TranslationService');
+			MapService: mapService
+		} = $injector.inject('MapService');
 
-		const translate = (key) => translationService.translate(key);
 		const destinationSrid = mapService.getSrid();
 		const vectorSource = new VectorSource();
 
@@ -168,10 +167,8 @@ export class VectorLayerService {
 		if (!geoResource.label) {
 			switch (geoResource.sourceType) {
 				case VectorSourceType.KML:
-					setTimeout(() => geoResource.setLabel(format.readName(data) ?? translate('olMap_vectorLayerService_default_layer_name_vector')));
+					setTimeout(() => geoResource.setLabel(format.readName(data)));
 					break;
-				default:
-					setTimeout(() => geoResource.setLabel(translate('olMap_vectorLayerService_default_layer_name_vector')));
 			}
 		}
 		return vectorSource;

--- a/src/modules/olMap/services/VectorLayerService.js
+++ b/src/modules/olMap/services/VectorLayerService.js
@@ -142,9 +142,10 @@ export class VectorLayerService {
 	_vectorSourceForData(geoResource) {
 
 		const {
-			MapService: mapService
-		} = $injector.inject('MapService');
+			MapService: mapService, TranslationService: translationService
+		} = $injector.inject('MapService', 'TranslationService');
 
+		const translate = (key) => translationService.translate(key);
 		const destinationSrid = mapService.getSrid();
 		const vectorSource = new VectorSource();
 
@@ -160,14 +161,18 @@ export class VectorLayerService {
 		vectorSource.addFeatures(features);
 
 		/**
-		 * If we know a better name for the geoResource now, we update the geoResource's label.
+		 * If we know a name for the GeoResource now, we update the geoResource's label.
 		 * At this moment an olLayer and its source are about to be added to the map.
-		 * To avoid conflicts, we have to delay the update of the geoResouece (and subsequent possible modifications of the connected layer).
+		 * To avoid conflicts, we have to delay the update of the GeoResource (and subsequent possible modifications of the connected layer).
 		 */
-		switch (geoResource.sourceType) {
-			case VectorSourceType.KML:
-				setTimeout(() => geoResource.setLabel(format.readName(data) ?? geoResource.label));
-				break;
+		if (!geoResource.label) {
+			switch (geoResource.sourceType) {
+				case VectorSourceType.KML:
+					setTimeout(() => geoResource.setLabel(format.readName(data) ?? translate('olMap_vectorLayerService_default_layer_name_vector')));
+					break;
+				default:
+					setTimeout(() => geoResource.setLabel(translate('olMap_vectorLayerService_default_layer_name_vector')));
+			}
 		}
 		return vectorSource;
 	}

--- a/src/modules/search/components/menu/types/geoResource/GeoResourceResultItem.js
+++ b/src/modules/search/components/menu/types/geoResource/GeoResourceResultItem.js
@@ -7,14 +7,16 @@ import { MvuElement } from '../../../../../MvuElement';
 import { $injector } from '../../../../../../injection';
 import { createUniqueId } from '../../../../../../utils/numberUtils';
 import { fitLayer } from '../../../../../../store/position/position.action';
+import { GeoResourceFuture } from '../../../../../../domain/geoResources';
 
 const Update_IsPortrait = 'update_isPortrait';
 const Update_GeoResourceSearchResult = 'update_geoResourceSearchResult';
+const Update_LoadingPreviewFlag = 'update_loadingPreviewFlag';
 
 /**
  * Amount of time waiting before adding a layer in ms.
  */
-export const LAYER_ADDING_DELAY_MS = 500;
+export const LOADING_PREVIEW_DELAY_MS = 500;
 
 /**
  * Renders a search result item for a geoResource.
@@ -30,12 +32,14 @@ export class GeoResourceResultItem extends MvuElement {
 	constructor() {
 		super({
 			geoResourceSearchResult: null,
-			isPortrait: false
+			isPortrait: false,
+			loadingPreview: false
 		});
 
 		const { GeoResourceService: geoResourceService }
 			= $injector.inject('GeoResourceService');
 		this._geoResourceService = geoResourceService;
+		this._timeoutId = null;
 	}
 
 	update(type, data, model) {
@@ -44,6 +48,8 @@ export class GeoResourceResultItem extends MvuElement {
 				return { ...model, geoResourceSearchResult: data };
 			case Update_IsPortrait:
 				return { ...model, isPortrait: data };
+			case Update_LoadingPreviewFlag:
+				return { ...model, loadingPreview: data };
 		}
 	}
 
@@ -60,7 +66,7 @@ export class GeoResourceResultItem extends MvuElement {
 	}
 
 	createView(model) {
-		const { isPortrait, geoResourceSearchResult } = model;
+		const { isPortrait, geoResourceSearchResult, loadingPreview } = model;
 		/**
 		 * Uses mouseenter and mouseleave events for adding/removing a preview layer.
 		 * These events are not fired on touch devices, so there's no extra handling needed.
@@ -68,24 +74,38 @@ export class GeoResourceResultItem extends MvuElement {
 		const onMouseEnter = (result) => {
 			const id = GeoResourceResultItem._tmpLayerId(result.geoResourceId);
 			//add a preview layer
-			addLayer(id,
-				{ label: result.label, geoResourceId: result.geoResourceId, constraints: { hidden: true, alwaysTop: true } });
-			fitLayer(id);
+			this._timeoutId = setTimeout(() => {
+
+
+				addLayer(id,
+					{ label: result.label, geoResourceId: result.geoResourceId, constraints: { hidden: true, alwaysTop: true } });
+
+				const geoRes = this._geoResourceService.byId(result.geoResourceId);
+
+				if (geoRes instanceof GeoResourceFuture) {
+					this.signal(Update_LoadingPreviewFlag, true);
+					geoRes.onResolve(() => this.signal(Update_LoadingPreviewFlag, false));
+				}
+				fitLayer(id);
+				this._timeoutId = null;
+			}, LOADING_PREVIEW_DELAY_MS);
 		};
 		const onMouseLeave = (result) => {
 			//remove the preview layer
 			removeLayer(GeoResourceResultItem._tmpLayerId(result.geoResourceId));
+			if (this._timeoutId) {
+				clearTimeout(this._timeoutId);
+				this._timeoutId = null;
+			}
+			this.signal(Update_LoadingPreviewFlag, false);
 		};
 		const onClick = (result) => {
 			//remove the preview layer
 			removeLayer(GeoResourceResultItem._tmpLayerId(result.geoResourceId));
 			//add the "real" layer after some delay, which gives the user a better feedback
-			setTimeout(() => {
-				const id = `${result.geoResourceId}_${createUniqueId()}`;
-				//we ask the GeoResourceService for an optionally updated label
-				addLayer(id, { geoResourceId: result.geoResourceId, label: this._geoResourceService.byId(result.geoResourceId)?.label ?? result.label });
-				fitLayer(id);
-			}, LAYER_ADDING_DELAY_MS);
+			const id = `${result.geoResourceId}_${createUniqueId()}`;
+			//we ask the GeoResourceService for an optionally updated label
+			addLayer(id, { geoResourceId: result.geoResourceId, label: this._geoResourceService.byId(result.geoResourceId)?.label ?? result.label });
 
 			if (isPortrait) {
 				//close the main menu
@@ -110,7 +130,7 @@ export class GeoResourceResultItem extends MvuElement {
 							</span>
 						</span>
 						<span class="ba-list-item__text ">
-						${unsafeHTML(geoResourceSearchResult.labelFormatted)}
+						${unsafeHTML(geoResourceSearchResult.labelFormatted)} ${loadingPreview ? html`<ba-spinner .label=${' '}></ba-spinner>` : nothing}
 						</span>
 				</li>				
             `;

--- a/src/plugins/LayersPlugin.js
+++ b/src/plugins/LayersPlugin.js
@@ -1,11 +1,9 @@
 import { $injector } from '../injection';
-import { GeoResourceTypes } from '../domain/geoResources';
 import { QueryParameters } from '../domain/queryParameters';
 import { BaPlugin } from './BaPlugin';
-import { addLayer, modifyLayer, setReady } from '../store/layers/layers.action';
+import { addLayer, setReady } from '../store/layers/layers.action';
 import { provide as provider } from './i18n/layersPlugin.provider';
 import { createUniqueId } from '../utils/numberUtils';
-import { propertyChanged } from '../store/geoResources/geoResources.action';
 
 /**
  * @class

--- a/src/plugins/LayersPlugin.js
+++ b/src/plugins/LayersPlugin.js
@@ -5,6 +5,7 @@ import { BaPlugin } from './BaPlugin';
 import { addLayer, modifyLayer, setReady } from '../store/layers/layers.action';
 import { provide as provider } from './i18n/layersPlugin.provider';
 import { createUniqueId } from '../utils/numberUtils';
+import { propertyChanged } from '../store/geoResources/geoResources.action';
 
 /**
  * @class
@@ -36,12 +37,6 @@ export class LayersPlugin extends BaPlugin {
 						const layerId = `${id}_${createUniqueId()}`;
 
 						if (geoResource) {
-							//if we have a GeoResource future, we update the label property after we know it
-							if (geoResource.getType() === GeoResourceTypes.FUTURE) {
-								geoResource.onResolve((geoResource) => {
-									modifyLayer(layerId, { label: geoResource.label });
-								});
-							}
 
 							const layerProperties = { geoResourceId: geoResource.id };
 							layerProperties.label = geoResource.label;

--- a/src/plugins/i18n/layersPlugin.provider.js
+++ b/src/plugins/i18n/layersPlugin.provider.js
@@ -5,15 +5,13 @@ export const provide = (lang) => {
 		case 'en':
 			return {
 				//the first part of the snake_case key should be the name of the related plugin
-				layersPlugin_store_layer_default_layer_name_vector: 'Data',
-				layersPlugin_store_layer_default_layer_name_future: 'Loading...'
+				layersPlugin_store_layer_default_layer_name_vector: 'Data'
 			};
 
 		case 'de':
 			return {
 				//the first part of the snake_case key should be the name of the related plugin
-				layersPlugin_store_layer_default_layer_name_vector: 'Daten',
-				layersPlugin_store_layer_default_layer_name_future: 'Wird geladen...'
+				layersPlugin_store_layer_default_layer_name_vector: 'Daten'
 			};
 
 		default:

--- a/src/services/GeoResourceService.js
+++ b/src/services/GeoResourceService.js
@@ -94,12 +94,15 @@ export class GeoResourceService {
 	/**
 	 * Returns the corresponding  {@link GeoResource} for an id.
 	 * @public
-	 * @param {string} id Id of the desired {@link GeoResource}
+	 * @param {string|null|undefined} id Id of the desired {@link GeoResource}
 	 * @returns {GeoResource | null}
 	 */
 	byId(id) {
 		if (!this._georesources) {
 			console.warn('GeoResourceService not yet initialized');
+			return null;
+		}
+		if (!id) {
 			return null;
 		}
 		const geoResource = this._georesources.find(georesource => georesource.id === id);

--- a/src/services/ImportVectorDataService.js
+++ b/src/services/ImportVectorDataService.js
@@ -97,7 +97,7 @@ export class ImportVectorDataService {
 		const resultingSourceType = this._mapSourceTypeToVectorSourceType(sourceType) ?? this._mapSourceTypeToVectorSourceType(this._sourceTypeService.forData(data).sourceType);
 		if (resultingSourceType) {
 			const vgr = new VectorGeoResource(id, label, resultingSourceType);
-			vgr.setSource(data, 4326 /**valid for kml, gpx an geoJson**/);
+			vgr.setSource(data, 4326 /**valid for kml, gpx and geoJson**/);
 			this._geoResourceService.addOrReplace(vgr);
 			return vgr;
 		}

--- a/src/services/ImportVectorDataService.js
+++ b/src/services/ImportVectorDataService.js
@@ -21,13 +21,12 @@ import { SourceType, SourceTypeName } from './../domain/sourceType';
 export class ImportVectorDataService {
 
 	constructor() {
-		const { HttpService: httpService, GeoResourceService: geoResourceService, UrlService: urlService, TranslationService: translationService,
+		const { HttpService: httpService, GeoResourceService: geoResourceService, UrlService: urlService,
 			SourceTypeService: sourceTypeService }
-			= $injector.inject('HttpService', 'GeoResourceService', 'UrlService', 'TranslationService', 'SourceTypeService');
+			= $injector.inject('HttpService', 'GeoResourceService', 'UrlService', 'SourceTypeService');
 		this._httpService = httpService;
 		this._geoResourceService = geoResourceService;
 		this._urlService = urlService;
-		this._translationService = translationService;
 		this._sourceTypeService = sourceTypeService;
 	}
 
@@ -72,7 +71,7 @@ export class ImportVectorDataService {
 				 **/
 				const resultingSourceType = this._mapSourceTypeToVectorSourceType(this._sourceTypeService.forData(data).sourceType);
 				if (resultingSourceType) {
-					const vgr = observable(new VectorGeoResource(id, label ?? this._translationService.translate('layersPlugin_store_layer_default_layer_name_vector'), resultingSourceType),
+					const vgr = observable(new VectorGeoResource(id, label, resultingSourceType),
 						this._newUpdateLayerCallbackFn(id));
 					vgr.setSource(data, 4326 /**valid for kml, gpx an geoJson**/);
 					return vgr;
@@ -82,7 +81,7 @@ export class ImportVectorDataService {
 			throw new Error(`GeoResource for '${url}' could not be loaded: Http-Status ${result.status}`);
 		};
 
-		const geoResource = new GeoResourceFuture(id, loader, label ?? this._translationService.translate('layersPlugin_store_layer_default_layer_name_future'));
+		const geoResource = new GeoResourceFuture(id, loader, label);
 		this._geoResourceService.addOrReplace(geoResource);
 		return geoResource;
 	}
@@ -99,7 +98,7 @@ export class ImportVectorDataService {
 
 		const resultingSourceType = this._mapSourceTypeToVectorSourceType(sourceType) ?? this._mapSourceTypeToVectorSourceType(this._sourceTypeService.forData(data).sourceType);
 		if (resultingSourceType) {
-			const vgr = observable(new VectorGeoResource(id, label ?? this._translationService.translate('layersPlugin_store_layer_default_layer_name_vector'), resultingSourceType),
+			const vgr = observable(new VectorGeoResource(id, label, resultingSourceType),
 				this._newUpdateLayerCallbackFn(id));
 			vgr.setSource(data, 4326 /**valid for kml, gpx an geoJson**/);
 			this._geoResourceService.addOrReplace(vgr);

--- a/src/services/ImportVectorDataService.js
+++ b/src/services/ImportVectorDataService.js
@@ -81,7 +81,7 @@ export class ImportVectorDataService {
 			throw new Error(`GeoResource for '${url}' could not be loaded: Http-Status ${result.status}`);
 		};
 
-		const geoResource = new GeoResourceFuture(id, loader, label);
+		const geoResource = new GeoResourceFuture(id, loader);
 		this._geoResourceService.addOrReplace(geoResource);
 		return geoResource;
 	}

--- a/src/services/ImportVectorDataService.js
+++ b/src/services/ImportVectorDataService.js
@@ -1,7 +1,6 @@
 import { $injector } from '../injection';
-import { modifyLayer } from '../store/layers/layers.action';
 import { createUniqueId } from '../utils/numberUtils';
-import { GeoResourceFuture, observable, VectorGeoResource, VectorSourceType } from '../domain/geoResources';
+import { GeoResourceFuture, VectorGeoResource, VectorSourceType } from '../domain/geoResources';
 import { SourceType, SourceTypeName } from './../domain/sourceType';
 
 /**
@@ -71,8 +70,7 @@ export class ImportVectorDataService {
 				 **/
 				const resultingSourceType = this._mapSourceTypeToVectorSourceType(this._sourceTypeService.forData(data).sourceType);
 				if (resultingSourceType) {
-					const vgr = observable(new VectorGeoResource(id, label, resultingSourceType),
-						this._newUpdateLayerCallbackFn(id));
+					const vgr = new VectorGeoResource(id, label, resultingSourceType);
 					vgr.setSource(data, 4326 /**valid for kml, gpx an geoJson**/);
 					return vgr;
 				}
@@ -98,8 +96,7 @@ export class ImportVectorDataService {
 
 		const resultingSourceType = this._mapSourceTypeToVectorSourceType(sourceType) ?? this._mapSourceTypeToVectorSourceType(this._sourceTypeService.forData(data).sourceType);
 		if (resultingSourceType) {
-			const vgr = observable(new VectorGeoResource(id, label, resultingSourceType),
-				this._newUpdateLayerCallbackFn(id));
+			const vgr = new VectorGeoResource(id, label, resultingSourceType);
 			vgr.setSource(data, 4326 /**valid for kml, gpx an geoJson**/);
 			this._geoResourceService.addOrReplace(vgr);
 			return vgr;
@@ -134,30 +131,6 @@ export class ImportVectorDataService {
 			}
 		}
 		return null;
-	}
-
-	/**
-	 * Returns a callback fn for a GeoResource observer which synchronizes
-	 * changes of the GeoResource properties to all relevant layers.
-	 * @param {String} geoResourceId
-	 * @returns callback fn for observer
-	 */
-	_newUpdateLayerCallbackFn(geoResourceId) {
-		const {
-			StoreService: storeService
-		} = $injector.inject('StoreService');
-
-		return (prop, value) => {
-			if (prop === '_label') {
-				const { layers: { active: activeLayers } } = storeService.getStore().getState();
-
-				activeLayers.forEach(l => {
-					if (l.geoResourceId === geoResourceId) {
-						modifyLayer(l.id, { label: value });
-					}
-				});
-			}
-		};
 	}
 }
 

--- a/src/services/StoreService.js
+++ b/src/services/StoreService.js
@@ -22,6 +22,7 @@ import { createMainMenuReducer } from '../store/mainMenu/mainMenu.reducer';
 import { featureInfoReducer } from '../store/featureInfo/featureInfo.reducer';
 import { importReducer } from '../store/import/import.reducer';
 import { mfpReducer } from '../store/mfp/mfp.reducer';
+import { geoResourcesReducer } from '../store/geoResources/geoResources.reducer';
 
 
 
@@ -60,7 +61,8 @@ export class StoreService {
 			featureInfo: featureInfoReducer,
 			media: createMediaReducer(),
 			import: importReducer,
-			mfp: mfpReducer
+			mfp: mfpReducer,
+			geoResources: geoResourcesReducer
 		});
 
 		this._store = createStore(rootReducer);

--- a/src/services/provider/fileStorage.provider.js
+++ b/src/services/provider/fileStorage.provider.js
@@ -33,12 +33,12 @@ export const _newLoader = id => {
  */
 export const loadBvvFileStorageResourceById = id => {
 
-	const { FileStorageService: fileStorageService, TranslationService: translationService }
-		= $injector.inject('FileStorageService', 'TranslationService');
+	const { FileStorageService: fileStorageService }
+		= $injector.inject('FileStorageService');
 
 	if (fileStorageService.isAdminId(id) || fileStorageService.isFileId(id)) {
 
-		return new GeoResourceFuture(id, _newLoader(id), translationService.translate('layersPlugin_store_layer_default_layer_name_future'));
+		return new GeoResourceFuture(id, _newLoader(id));
 	}
 	return null;
 };

--- a/src/services/provider/geoResource.provider.js
+++ b/src/services/provider/geoResource.provider.js
@@ -146,10 +146,9 @@ export const loadBvvGeoResourceById = id => {
 
 	const {
 		HttpService: httpService,
-		ConfigService: configService,
-		TranslationService: translationService
+		ConfigService: configService
 	}
-		= $injector.inject('HttpService', 'ConfigService', 'TranslationService');
+		= $injector.inject('HttpService', 'ConfigService');
 
 	const loader = async id => {
 		const url = `${configService.getValueAsPath('BACKEND_URL')}georesources/byId/${id}`;
@@ -166,5 +165,5 @@ export const loadBvvGeoResourceById = id => {
 		throw new Error(`GeoResource for id '${id}' could not be loaded`);
 	};
 
-	return new GeoResourceFuture(id, loader, translationService.translate('layersPlugin_store_layer_default_layer_name_future'));
+	return new GeoResourceFuture(id, loader);
 };

--- a/src/services/provider/geoResource.provider.js
+++ b/src/services/provider/geoResource.provider.js
@@ -24,6 +24,7 @@ export const _definitionToGeoResource = definition => {
 			case 'vt':
 				return new VTGeoResource(def.id, def.label, def.url);
 			case 'vector':
+				//Todo: Let's try to load it as GeoResourceFuture, than we can use the onResolve callback
 				return new VectorGeoResource(def.id, def.label, Symbol.for(def.sourceType))
 					//set specific optional values
 					.setUrl(def.url);

--- a/src/store/geoResources/geoResources.action.js
+++ b/src/store/geoResources/geoResources.action.js
@@ -5,6 +5,7 @@
 import { GEORESOURCE_CHANGED } from './geoResources.reducer';
 import { $injector } from '../../injection';
 import { EventLike } from '../../utils/storeUtils';
+import { GeoResource } from '../../domain/geoResources';
 
 const getStore = () => {
 	const { StoreService } = $injector.inject('StoreService');
@@ -13,13 +14,13 @@ const getStore = () => {
 
 
 /**
-  * Announces the change of one or more properties of a GeoResource
+  * Announces that one or more properties of a GeoResource were changed.
   * @function
-  * @param {string} id id of the changed GeoResource
+  * @param {GeoResource|string} grOrId GeoResource or its id
   */
-export const propertyChanged = (id) => {
+export const propertyChanged = (grOrId) => {
 	getStore().dispatch({
 		type: GEORESOURCE_CHANGED,
-		payload: new EventLike(id)
+		payload: new EventLike(grOrId instanceof GeoResource ? grOrId.id : grOrId)
 	});
 };

--- a/src/store/geoResources/geoResources.action.js
+++ b/src/store/geoResources/geoResources.action.js
@@ -1,0 +1,25 @@
+/**
+ * Action creators to indicate changes of a GeoResource.
+ * @module geoResources/action
+ */
+import { GEORESOURCE_CHANGED } from './geoResources.reducer';
+import { $injector } from '../../injection';
+import { EventLike } from '../../utils/storeUtils';
+
+const getStore = () => {
+	const { StoreService } = $injector.inject('StoreService');
+	return StoreService.getStore();
+};
+
+
+/**
+  * Announces the change of one or more properties of a GeoResource
+  * @function
+  * @param {string} id id of the changed GeoResource
+  */
+export const propertyChanged = (id) => {
+	getStore().dispatch({
+		type: GEORESOURCE_CHANGED,
+		payload: new EventLike(id)
+	});
+};

--- a/src/store/geoResources/geoResources.reducer.js
+++ b/src/store/geoResources/geoResources.reducer.js
@@ -1,6 +1,6 @@
 import { EventLike } from '../../utils/storeUtils';
 
-export const GEORESOURCE_CHANGED = 'georesources/changed';
+export const GEORESOURCE_CHANGED = 'geoResources/changed';
 
 export const initialState = {
 	changed: new EventLike(null)

--- a/src/store/geoResources/geoResources.reducer.js
+++ b/src/store/geoResources/geoResources.reducer.js
@@ -1,0 +1,22 @@
+import { EventLike } from '../../utils/storeUtils';
+
+export const GEORESOURCE_CHANGED = 'georesources/changed';
+
+export const initialState = {
+	changed: new EventLike(null)
+};
+
+export const geoResourcesReducer = (state = initialState, action) => {
+	const { type, payload } = action;
+	switch (type) {
+
+		case GEORESOURCE_CHANGED: {
+
+			return {
+				...state,
+				changed: payload
+			};
+		}
+	}
+	return state;
+};

--- a/test/domain/geoResources.test.js
+++ b/test/domain/geoResources.test.js
@@ -180,12 +180,12 @@ describe('GeoResource', () => {
 		it('instantiates a GeoResourceFuture', () => {
 			const loader = async () => { };
 
-			const future = new GeoResourceFuture('id', loader, 'label');
+			const future = new GeoResourceFuture('id', loader);
 			const futureWithoutLabel = new GeoResourceFuture('id', loader);
 
 			expect(future.getType()).toEqual(GeoResourceTypes.FUTURE);
 			expect(future._loader).toBe(loader);
-			expect(future.label).toBe('label');
+			expect(future.label).toBe('');
 			expect(futureWithoutLabel.label).toHaveSize(0);
 		});
 

--- a/test/domain/geoResources.test.js
+++ b/test/domain/geoResources.test.js
@@ -36,8 +36,8 @@ describe('GeoResource', () => {
 		}
 
 		class GeoResourceImpl extends GeoResource {
-			constructor(id) {
-				super(id);
+			constructor(id, label) {
+				super(id, label);
 			}
 		}
 
@@ -55,6 +55,15 @@ describe('GeoResource', () => {
 
 			it('throws exception when abstract #getType is called without overriding', () => {
 				expect(() => new GeoResourceNoImpl('some').getType()).toThrowError(TypeError, 'Please implement abstract method #getType or do not call super.getType from child.');
+			});
+
+
+			it('provides a check for containing a non-default value as label', () => {
+
+				expect(new GeoResourceImpl('id').hasLabel()).toBeFalse();
+				expect(new GeoResourceImpl('id', null).hasLabel()).toBeFalse();
+				expect(new GeoResourceImpl('id', '').hasLabel()).toBeFalse();
+				expect(new GeoResourceImpl('id', 'foo').hasLabel()).toBeTrue();
 			});
 
 			it('sets the attribution provider', () => {
@@ -322,6 +331,22 @@ describe('GeoResource', () => {
 			expect(vectorGeoResource.srid).toBeNull();
 			expect(vectorGeoResource.sourceType).toEqual(VectorSourceType.KML);
 			expect(vectorGeoResource.data).toBeNull();
+		});
+
+		it('provides the source type as fallback label', () => {
+
+			expect(new VectorGeoResource('id', null, VectorSourceType.KML).label).toBe('KML');
+			expect(new VectorGeoResource('id', null, VectorSourceType.GPX).label).toBe('GPX');
+			expect(new VectorGeoResource('id', null, VectorSourceType.GEOJSON).label).toBe('GeoJSON');
+			expect(new VectorGeoResource('id', null, 'unknown').label).toBe('');
+		});
+
+
+		it('provides a check for containing a non-default value as label', () => {
+
+			expect(new VectorGeoResource('id', null, VectorSourceType.KML).hasLabel()).toBeFalse();
+			expect(new VectorGeoResource('id', '', VectorSourceType.KML).hasLabel()).toBeFalse();
+			expect(new VectorGeoResource('id', 'foo', VectorSourceType.KML).hasLabel()).toBeTrue();
 		});
 
 		it('sets the url of an external VectorGeoResource', () => {

--- a/test/modules/layerManager/components/LayerItem.test.js
+++ b/test/modules/layerManager/components/LayerItem.test.js
@@ -10,6 +10,7 @@ import { TEST_ID_ATTRIBUTE_NAME } from '../../../../src/utils/markup';
 import { EventLike } from '../../../../src/utils/storeUtils';
 import { positionReducer } from '../../../../src/store/position/position.reducer';
 import { VectorGeoResource, VectorSourceType, WmsGeoResource } from '../../../../src/domain/geoResources';
+import { geoResourcesReducer } from '../../../../src/store/geoResources/geoResources.reducer';
 
 
 window.customElements.define(LayerItem.tag, LayerItem);
@@ -49,11 +50,18 @@ describe('LayerItem', () => {
 		const geoResourceService = { byId: () => { } };
 
 		const setup = async (layer) => {
-			TestUtils.setupStoreAndDi({}, { layers: layersReducer });
-			$injector.registerSingleton('TranslationService', { translate: (key) => key });
-			$injector.registerSingleton('GeoResourceService', geoResourceService);
+			TestUtils.setupStoreAndDi({}, {
+				layers: layersReducer,
+				geoResources: geoResourcesReducer
+			}
+			);
+			$injector
+				.registerSingleton('TranslationService', { translate: (key) => key })
+				.registerSingleton('GeoResourceService', geoResourceService);
 			const element = await TestUtils.render(LayerItem.tag);
-			element.layer = layer;
+			if (layer) {
+				element.layer = layer;
+			}
 			return element;
 		};
 
@@ -63,24 +71,18 @@ describe('LayerItem', () => {
 			expect(element.innerHTML).toBe('');
 		});
 
-		it('displays label-property in label', async () => {
-			const layer = { ...createDefaultLayerProperties(), id: 'id0', label: 'label0', visible: true, zIndex: 0, opacity: 1, collapsed: true };
+		it('displays the GeoResource label as label', async () => {
+			spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(new VectorGeoResource('geoResourceId0', 'label0', VectorSourceType.KML));
+			const layer = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0', visible: true, zIndex: 0, opacity: 1, collapsed: true };
 			const element = await setup(layer);
 			const label = element.shadowRoot.querySelector('.ba-list-item__text');
 
 			expect(label.innerText).toBe('label0');
 		});
 
-		it('displays id-property when label is empty in label', async () => {
-			const layer = { ...createDefaultLayerProperties(), id: 'id0', label: '', visible: true, zIndex: 0, opacity: 1, collapsed: true };
-			const element = await setup(layer);
-			const label = element.shadowRoot.querySelector('.ba-list-item__text');
-
-			expect(label.innerText).toBe('id0');
-		});
-
 		it('use layer.label property in checkbox-title ', async () => {
-			const layer = { ...createDefaultLayerProperties(), id: 'id0', label: 'label0', visible: true, zIndex: 0, opacity: 1, collapsed: true };
+			spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(new VectorGeoResource('geoResourceId0', 'label0', VectorSourceType.KML));
+			const layer = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0', visible: true, zIndex: 0, opacity: 1, collapsed: true };
 			const element = await setup(layer);
 			const toggle = element.shadowRoot.querySelector('ba-checkbox');
 
@@ -88,7 +90,8 @@ describe('LayerItem', () => {
 		});
 
 		it('use layer.opacity-property in slider ', async () => {
-			const layer = { ...createDefaultLayerProperties(), id: 'id0', label: 'label0', visible: true, zIndex: 0, opacity: 0.55, collapsed: true };
+			spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(new VectorGeoResource('geoResourceId0', 'label0', VectorSourceType.KML));
+			const layer = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0', visible: true, zIndex: 0, opacity: 0.55, collapsed: true };
 			const element = await setup(layer);
 
 			const slider = element.shadowRoot.querySelector('.opacity-slider');
@@ -96,7 +99,8 @@ describe('LayerItem', () => {
 		});
 
 		it('use layer.visible-property in checkbox ', async () => {
-			const layer = { ...createDefaultLayerProperties(), id: 'id0', label: 'label0', visible: false, zIndex: 0, opacity: 1, collapsed: true };
+			spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(new VectorGeoResource('geoResourceId0', 'label0', VectorSourceType.KML));
+			const layer = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0', visible: false, zIndex: 0, opacity: 1, collapsed: true };
 			const element = await setup(layer);
 			const toggle = element.shadowRoot.querySelector('ba-checkbox');
 
@@ -104,7 +108,8 @@ describe('LayerItem', () => {
 		});
 
 		it('use layer.collapsed-property in element style ', async () => {
-			const layer = { ...createDefaultLayerProperties(), id: 'id0', label: 'label0', visible: true, zIndex: 0, opacity: 1, collapsed: false };
+			spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(new VectorGeoResource('geoResourceId0', 'label0', VectorSourceType.KML));
+			const layer = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0', visible: true, zIndex: 0, opacity: 1, collapsed: false };
 			const element = await setup(layer);
 			const layerBody = element.shadowRoot.querySelector('.collapse-content');
 			const collapseButton = element.shadowRoot.querySelector('.ba-list-item button');
@@ -118,7 +123,8 @@ describe('LayerItem', () => {
 		});
 
 		it('slider-elements stops dragstart-event propagation ', async () => {
-			const layer = { ...createDefaultLayerProperties(), id: 'id0', label: 'label0', visible: true, zIndex: 0, opacity: 1, collapsed: false };
+			spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(new VectorGeoResource('geoResourceId0', 'label0', VectorSourceType.KML));
+			const layer = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0', visible: true, zIndex: 0, opacity: 1, collapsed: false };
 			const element = await setup(layer);
 
 			const slider = element.shadowRoot.querySelector('.opacity-slider');
@@ -140,14 +146,16 @@ describe('LayerItem', () => {
 		});
 
 		it('displays a overflow-menu', async () => {
-			const layer = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0', label: 'label0', visible: true, zIndex: 0, opacity: 1, collapsed: true };
-			spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(new VectorGeoResource('geoResourceId0', 'id0', VectorSourceType.KML));
+			spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(new VectorGeoResource('geoResourceId0', 'label0', VectorSourceType.KML));
+			const layer = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0', visible: true, zIndex: 0, opacity: 1, collapsed: true };
 			const element = await setup(layer);
+
 			expect(element.shadowRoot.querySelector('ba-overflow-menu')).toBeTruthy();
 		});
 
 		it('contains a menu-item for info', async () => {
-			const layer = { ...createDefaultLayerProperties(), id: 'id0', label: 'label0', visible: true, zIndex: 0, opacity: 1, collapsed: true };
+			spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(new VectorGeoResource('geoResourceId0', 'label0', VectorSourceType.KML));
+			const layer = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0', visible: true, zIndex: 0, opacity: 1, collapsed: true };
 			const element = await setup(layer);
 
 			const menu = element.shadowRoot.querySelector('ba-overflow-menu');
@@ -161,7 +169,8 @@ describe('LayerItem', () => {
 		});
 
 		it('contains a disabled menu-item for info', async () => {
-			const layer = { ...createDefaultLayerProperties(), id: 'id0', label: 'label0', visible: true, zIndex: 0, opacity: 1, collapsed: true, constraints: { metaData: false } };
+			spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(new VectorGeoResource('geoResourceId0', 'label0', VectorSourceType.KML));
+			const layer = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0', visible: true, zIndex: 0, opacity: 1, collapsed: true, constraints: { metaData: false } };
 			const element = await setup(layer);
 
 			const menu = element.shadowRoot.querySelector('ba-overflow-menu');
@@ -175,7 +184,8 @@ describe('LayerItem', () => {
 		});
 
 		it('contains a menu-item for copy', async () => {
-			const layer = { ...createDefaultLayerProperties(), id: 'id0', label: 'label0', visible: true, zIndex: 0, opacity: 1, collapsed: true };
+			spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(new VectorGeoResource('geoResourceId0', 'label0', VectorSourceType.KML));
+			const layer = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0', visible: true, zIndex: 0, opacity: 1, collapsed: true };
 			const element = await setup(layer);
 
 			const menu = element.shadowRoot.querySelector('ba-overflow-menu');
@@ -189,7 +199,8 @@ describe('LayerItem', () => {
 		});
 
 		it('contains a disabled menu-item for copy', async () => {
-			const layer = { ...createDefaultLayerProperties(), id: 'id0', label: 'label0', visible: true, zIndex: 0, opacity: 1, collapsed: true, constraints: { cloneable: false } };
+			spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(new VectorGeoResource('geoResourceId0', 'label0', VectorSourceType.KML));
+			const layer = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0', visible: true, zIndex: 0, opacity: 1, collapsed: true, constraints: { cloneable: false } };
 			const element = await setup(layer);
 
 			const menu = element.shadowRoot.querySelector('ba-overflow-menu');
@@ -203,8 +214,8 @@ describe('LayerItem', () => {
 		});
 
 		it('contains a menu-item for zoomToExtent', async () => {
-			const layer = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0', label: 'label0', visible: true, zIndex: 0, opacity: 1, collapsed: true };
-			spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(new VectorGeoResource('geoResourceId0', 'id0', VectorSourceType.KML));
+			spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(new VectorGeoResource('geoResourceId0', 'label0', VectorSourceType.KML));
+			const layer = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0', visible: true, zIndex: 0, opacity: 1, collapsed: true };
 			const element = await setup(layer);
 
 			const menu = element.shadowRoot.querySelector('ba-overflow-menu');
@@ -218,7 +229,7 @@ describe('LayerItem', () => {
 		});
 
 		it('contains a disabled menu-item for zoomToExtent', async () => {
-			const layer = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0', label: 'label0', visible: true, zIndex: 0, opacity: 1, collapsed: true, constraints: { cloneable: false } };
+			const layer = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0', visible: true, zIndex: 0, opacity: 1, collapsed: true, constraints: { cloneable: false } };
 			spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(new WmsGeoResource('geoResourceId0', 'id0', '', [], ''));
 			const element = await setup(layer);
 
@@ -233,14 +244,16 @@ describe('LayerItem', () => {
 		});
 
 		it('contains test-id attributes', async () => {
-			const layer = { ...createDefaultLayerProperties(), id: 'id0', label: 'label0', visible: true, zIndex: 0, opacity: 1, collapsed: true };
+			spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(new VectorGeoResource('geoResourceId0', 'label0', VectorSourceType.KML));
+			const layer = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0', visible: true, zIndex: 0, opacity: 1, collapsed: true };
 			const element = await setup(layer);
 
 			expect(element.shadowRoot.querySelector('#button-detail').hasAttribute(TEST_ID_ATTRIBUTE_NAME)).toBeTrue();
 		});
 
 		it('uses geoResourceId for a InfoPanel ', async () => {
-			const layer = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0', label: 'label0', visible: true, zIndex: 0, opacity: 1, collapsed: true };
+			spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(new VectorGeoResource('geoResourceId0', 'label0', VectorSourceType.KML));
+			const layer = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0', visible: true, zIndex: 0, opacity: 1, collapsed: true };
 			const element = await setup(layer);
 			const spy = spyOn(element, '_getInfoPanelFor').and.callThrough();
 
@@ -254,9 +267,10 @@ describe('LayerItem', () => {
 	});
 
 	describe('when user interacts with layer item', () => {
+		const geoResourceService = { byId: () => { } };
 		const layer = {
 			...createDefaultLayerProperties(),
-			id: 'id0', label: 'label0', visible: true, zIndex: 0, opacity: 1
+			id: 'id0', geoResourceId: 'geoResourceId0', visible: true, zIndex: 0, opacity: 1
 		};
 
 		const setup = () => {
@@ -269,14 +283,21 @@ describe('LayerItem', () => {
 					fitRequest: new EventLike(null)
 				}
 			};
-			const store = TestUtils.setupStoreAndDi(state, { layers: layersReducer, modal: modalReducer, position: positionReducer });
-			$injector.registerSingleton('TranslationService', { translate: (key) => key });
-			$injector.registerSingleton('GeoResourceService', { byId: () => { } });
+			const store = TestUtils.setupStoreAndDi(state, {
+				layers: layersReducer,
+				geoResources: geoResourcesReducer,
+				modal: modalReducer,
+				position: positionReducer
+			});
+			$injector
+				.registerSingleton('TranslationService', { translate: (key) => key })
+				.registerSingleton('GeoResourceService', geoResourceService);
 			return store;
 		};
 
 		it('click on layer toggle change state in store', async () => {
 			const store = setup();
+			spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(new VectorGeoResource('geoResourceId0', 'label0', VectorSourceType.KML));
 			const element = await TestUtils.render(LayerItem.tag);
 			element.layer = { ...layer, collapsed: true };
 
@@ -289,6 +310,7 @@ describe('LayerItem', () => {
 
 		it('click on opacity slider change state in store', async () => {
 			const store = setup();
+			spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(new VectorGeoResource('geoResourceId0', 'label0', VectorSourceType.KML));
 			const element = await TestUtils.render(LayerItem.tag);
 			element.layer = { ...layer };
 
@@ -302,6 +324,7 @@ describe('LayerItem', () => {
 
 		it('click on opacity slider change style-property', async () => {
 			setup();
+			spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(new VectorGeoResource('geoResourceId0', 'label0', VectorSourceType.KML));
 			const element = await TestUtils.render(LayerItem.tag);
 			element.layer = { ...layer };
 
@@ -318,6 +341,7 @@ describe('LayerItem', () => {
 
 		it('click on opacity slider without \'max\'-attribute change style-property', async () => {
 			setup();
+			spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(new VectorGeoResource('geoResourceId0', 'label0', VectorSourceType.KML));
 			const element = await TestUtils.render(LayerItem.tag);
 			element.layer = { ...layer };
 
@@ -335,6 +359,7 @@ describe('LayerItem', () => {
 
 		it('click on layer collapse button change collapsed property', async () => {
 			setup();
+			spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(new VectorGeoResource('geoResourceId0', 'label0', VectorSourceType.KML));
 			const element = await TestUtils.render(LayerItem.tag);
 			element.layer = { ...layer, collapsed: true };
 
@@ -346,6 +371,7 @@ describe('LayerItem', () => {
 
 		it('click on info icon show georesourceinfo panel as modal', async () => {
 			const store = setup();
+			spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(new VectorGeoResource('geoResourceId0', 'label0', VectorSourceType.KML));
 			const element = await TestUtils.render(LayerItem.tag);
 			element.layer = { ...layer };
 
@@ -359,6 +385,7 @@ describe('LayerItem', () => {
 
 		it('click on zoomToExtent icon changes state in store', async () => {
 			const store = setup();
+			spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(new VectorGeoResource('geoResourceId0', 'label0', VectorSourceType.KML));
 			const element = await TestUtils.render(LayerItem.tag);
 			element.layer = { ...layer };
 
@@ -373,26 +400,29 @@ describe('LayerItem', () => {
 
 	describe('when user change order of layer in group', () => {
 
+		const geoResourceService = { byId: () => { } };
 		let store;
 		const setup = (state) => {
-			store = TestUtils.setupStoreAndDi(state, { layers: layersReducer });
-			$injector.registerSingleton('TranslationService', { translate: (key) => key });
-			$injector.registerSingleton('GeoResourceService', { byId: () => { } });
+			store = TestUtils.setupStoreAndDi(state, { layers: layersReducer, geoResources: geoResourcesReducer });
+			$injector
+				.registerSingleton('TranslationService', { translate: (key) => key })
+				.registerSingleton('GeoResourceService', geoResourceService);
 			return store;
 		};
 
 		it('click on increase-button change state in store', async () => {
+			spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(new VectorGeoResource('geoResourceId0', 'label0', VectorSourceType.KML));
 			const layer0 = {
 				...createDefaultLayerProperties(),
-				id: 'id0', label: 'label0', visible: true, zIndex: 0, opacity: 1
+				id: 'id0', geoResourceId: 'geoResourceId0', visible: true, zIndex: 0, opacity: 1
 			};
 			const layer1 = {
 				...createDefaultLayerProperties(),
-				id: 'id1', label: 'label1', visible: true, zIndex: 1, opacity: 1
+				id: 'id1', geoResourceId: 'geoResourceId0', visible: true, zIndex: 1, opacity: 1
 			};
 			const layer2 = {
 				...createDefaultLayerProperties(),
-				id: 'id2', label: 'label2', visible: true, zIndex: 2, opacity: 1
+				id: 'id2', geoResourceId: 'geoResourceId0', visible: true, zIndex: 2, opacity: 1
 			};
 			const state = {
 				layers: {
@@ -416,17 +446,18 @@ describe('LayerItem', () => {
 		});
 
 		it('click on decrease-button change state in store', async () => {
+			spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(new VectorGeoResource('geoResourceId0', 'label0', VectorSourceType.KML));
 			const layer0 = {
 				...createDefaultLayerProperties(),
-				id: 'id0', label: 'label0', visible: true, zIndex: 0, opacity: 1
+				id: 'id0', geoResourceId: 'geoResourceId0', visible: true, zIndex: 0, opacity: 1
 			};
 			const layer1 = {
 				...createDefaultLayerProperties(),
-				id: 'id1', label: 'label1', visible: true, zIndex: 1, opacity: 1
+				id: 'id1', geoResourceId: 'geoResourceId0', visible: true, zIndex: 1, opacity: 1
 			};
 			const layer2 = {
 				...createDefaultLayerProperties(),
-				id: 'id2', label: 'label2', visible: true, zIndex: 2, opacity: 1
+				id: 'id2', geoResourceId: 'geoResourceId0', visible: true, zIndex: 2, opacity: 1
 			};
 			const state = {
 				layers: {
@@ -450,17 +481,18 @@ describe('LayerItem', () => {
 		});
 
 		it('click on decrease-button for first layer change not state in store', async () => {
+			spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(new VectorGeoResource('geoResourceId0', 'label0', VectorSourceType.KML));
 			const layer0 = {
 				...createDefaultLayerProperties(),
-				id: 'id0', label: 'label0', visible: true, zIndex: 0, opacity: 1
+				id: 'id0', geoResourceId: 'geoResourceId0', visible: true, zIndex: 0, opacity: 1
 			};
 			const layer1 = {
 				...createDefaultLayerProperties(),
-				id: 'id1', label: 'label1', visible: true, zIndex: 1, opacity: 1
+				id: 'id1', geoResourceId: 'geoResourceId0', visible: true, zIndex: 1, opacity: 1
 			};
 			const layer2 = {
 				...createDefaultLayerProperties(),
-				id: 'id2', label: 'label2', visible: true, zIndex: 2, opacity: 1
+				id: 'id2', geoResourceId: 'geoResourceId0', visible: true, zIndex: 2, opacity: 1
 			};
 			const state = {
 				layers: {
@@ -484,9 +516,10 @@ describe('LayerItem', () => {
 		});
 
 		it('click on \'copy\' icon adds a layer copy', async () => {
+			spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(new VectorGeoResource('geoResourceId0', 'label0', VectorSourceType.KML));
 			const layer0 = {
 				...createDefaultLayerProperties(),
-				id: 'id0', label: 'label0', geoResourceId: 'geoResourceId0', visible: true, zIndex: 0, opacity: 1
+				id: 'id0', geoResourceId: 'geoResourceId0', visible: true, zIndex: 0, opacity: 1
 			};
 
 			const state = {
@@ -512,17 +545,18 @@ describe('LayerItem', () => {
 		});
 
 		it('click on remove-button change state in store', async () => {
+			spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(new VectorGeoResource('geoResourceId0', 'label0', VectorSourceType.KML));
 			const layer0 = {
 				...createDefaultLayerProperties(),
-				id: 'id0', label: 'label0', visible: true, zIndex: 0, opacity: 1
+				id: 'id0', geoResourceId: 'geoResourceId0', visible: true, zIndex: 0, opacity: 1
 			};
 			const layer1 = {
 				...createDefaultLayerProperties(),
-				id: 'id1', label: 'label1', visible: true, zIndex: 1, opacity: 1
+				id: 'id1', geoResourceId: 'geoResourceId0', visible: true, zIndex: 1, opacity: 1
 			};
 			const layer2 = {
 				...createDefaultLayerProperties(),
-				id: 'id2', label: 'label2', visible: true, zIndex: 2, opacity: 1
+				id: 'id2', geoResourceId: 'geoResourceId0', visible: true, zIndex: 2, opacity: 1
 			};
 			const state = {
 				layers: {
@@ -548,20 +582,23 @@ describe('LayerItem', () => {
 	describe('event handling', () => {
 		const layer = {
 			...createDefaultLayerProperties(),
-			id: 'id0', label: 'label0', visible: true, zIndex: 0, opacity: 1
+			id: 'id0', geoResourceId: 'geoResourceId0', visible: true, zIndex: 0, opacity: 1
 		};
+		const geoResourceService = { byId: () => { } };
 
 		const setup = () => {
 
-			const store = TestUtils.setupStoreAndDi({}, { layers: layersReducer, modal: modalReducer });
-			$injector.registerSingleton('TranslationService', { translate: (key) => key });
-			$injector.registerSingleton('GeoResourceService', { byId: () => { } });
+			const store = TestUtils.setupStoreAndDi({}, { layers: layersReducer, modal: modalReducer, geoResources: geoResourcesReducer });
+			$injector
+				.registerSingleton('TranslationService', { translate: (key) => key })
+				.registerSingleton('GeoResourceService', geoResourceService);
 			return store;
 		};
 		describe('on collapse', () => {
 
 			it('calls the onCollapse callback via property callback', async () => {
 				setup();
+				spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(new VectorGeoResource('geoResourceId0', 'label0', VectorSourceType.KML));
 				const element = await TestUtils.render(LayerItem.tag);
 
 				element.layer = { ...layer }; // collapsed = true is initialized

--- a/test/modules/layerManager/components/LayerItem.test.js
+++ b/test/modules/layerManager/components/LayerItem.test.js
@@ -582,7 +582,7 @@ describe('LayerItem', () => {
 	describe('event handling', () => {
 		const layer = {
 			...createDefaultLayerProperties(),
-			id: 'id0', geoResourceId: 'geoResourceId0', visible: true, zIndex: 0, opacity: 1
+			id: 'id0', geoResourceId: 'geoResourceId0', visible: true, zIndex: 0, opacity: 1, collapsed: true
 		};
 		const geoResourceService = { byId: () => { } };
 

--- a/test/modules/layerManager/components/LayerItem.test.js
+++ b/test/modules/layerManager/components/LayerItem.test.js
@@ -306,7 +306,7 @@ describe('LayerItem', () => {
 			return element;
 		};
 
-		it('it updates the label', async () => {
+		it('updates the label', async () => {
 			const gr = new VectorGeoResource('geoResourceId0', 'label0', VectorSourceType.KML);
 			spyOn(geoResourceService, 'byId').withArgs('geoResourceId0').and.returnValue(gr);
 			const layer = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0', visible: true, zIndex: 0, opacity: 1, collapsed: true };

--- a/test/modules/layerManager/components/LayerManager.test.js
+++ b/test/modules/layerManager/components/LayerManager.test.js
@@ -6,6 +6,8 @@ import { $injector } from '../../../../src/injection';
 import { LayerItem } from '../../../../src/modules/layerManager/components/LayerItem';
 import { modifyLayer } from '../../../../src/store/layers/layers.action';
 import { TEST_ID_ATTRIBUTE_NAME } from '../../../../src/utils/markup';
+import { VectorGeoResource, VectorSourceType } from '../../../../src/domain/geoResources';
+import { geoResourcesReducer } from '../../../../src/store/geoResources/geoResources.reducer';
 
 window.customElements.define(Checkbox.tag, Checkbox);
 window.customElements.define(LayerItem.tag, LayerItem);
@@ -18,12 +20,14 @@ describe('LayerManager', () => {
 	const environmentServiceMock = {
 		isTouch: () => false
 	};
+
+	const geoResourceServiceMock = { byId: () => new VectorGeoResource('geoResourceId0', 'label0', VectorSourceType.KML) };
 	const setup = async (state) => {
 
-		store = TestUtils.setupStoreAndDi(state, { layers: layersReducer });
+		store = TestUtils.setupStoreAndDi(state, { layers: layersReducer, geoResources: geoResourcesReducer });
 		$injector.registerSingleton('TranslationService', { translate: (key) => key });
 		$injector.registerSingleton('EnvironmentService', environmentServiceMock);
-		$injector.registerSingleton('GeoResourceService', { byId: () => { } });
+		$injector.registerSingleton('GeoResourceService', geoResourceServiceMock);
 		return TestUtils.render(LayerManager.tag);
 	};
 
@@ -43,7 +47,7 @@ describe('LayerManager', () => {
 		it('with one layer displays one layer item', async () => {
 			const layer = {
 				...createDefaultLayerProperties(),
-				id: 'id0', label: 'label0', visible: true, zIndex: 0
+				id: 'id0', geoResourceId: 'geoResourceId0', visible: true, zIndex: 0
 			};
 			const state = {
 				layers: {
@@ -61,7 +65,7 @@ describe('LayerManager', () => {
 		it('with one not visible layer displays one layer item', async () => {
 			const layer = {
 				...createDefaultLayerProperties(),
-				id: 'id0', label: 'label0', visible: false, zIndex: 0
+				id: 'id0', geoResourceId: 'geoResourceId0', visible: false, zIndex: 0
 			};
 			const state = {
 				layers: {
@@ -79,12 +83,12 @@ describe('LayerManager', () => {
 		it('displays one out of two layers - one is hidden', async () => {
 			const layer = {
 				...createDefaultLayerProperties(),
-				id: 'id0', label: 'label0', visible: true, zIndex: 0
+				id: 'id0', geoResourceId: 'geoResourceId0', visible: true, zIndex: 0
 			};
 
 			const hiddenLayer = {
 				...createDefaultLayerProperties(),
-				id: 'id1', label: 'label1', visible: false, zIndex: 0, constraints: { hidden: true, alwaysOnTop: false }
+				id: 'id1', geoResourceId: 'geoResourceId0', visible: false, zIndex: 0, constraints: { hidden: true, alwaysOnTop: false }
 			};
 			const state = {
 				layers: {
@@ -114,9 +118,9 @@ describe('LayerManager', () => {
 	describe('when layer items are rendered', () => {
 		let element;
 		beforeEach(async () => {
-			const layer0 = { ...createDefaultLayerProperties(), id: 'id0', label: '', visible: true, zIndex: 0, draggable: true };
-			const layer1 = { ...createDefaultLayerProperties(), id: 'id0', label: '', visible: true, zIndex: 1, draggable: true };
-			const layer2 = { ...createDefaultLayerProperties(), id: 'id0', label: '', visible: true, zIndex: 2, draggable: true };
+			const layer0 = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0', visible: true, zIndex: 0, draggable: true };
+			const layer1 = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0', visible: true, zIndex: 1, draggable: true };
+			const layer2 = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0', visible: true, zIndex: 2, draggable: true };
 			const state = {
 				layers: {
 					active: [layer0, layer1, layer2],
@@ -153,9 +157,9 @@ describe('LayerManager', () => {
 	describe('when layer items dragged', () => {
 		let element;
 		beforeEach(async () => {
-			const layer0 = { ...createDefaultLayerProperties(), id: 'id0', label: 'Label 0', visible: true, zIndex: 0 };
-			const layer1 = { ...createDefaultLayerProperties(), id: 'id1', label: 'Label 1', visible: true, zIndex: 1 };
-			const layer2 = { ...createDefaultLayerProperties(), id: 'id2', label: 'Label 2', visible: true, zIndex: 2 };
+			const layer0 = { ...createDefaultLayerProperties(), id: 'id0', geoResourceId: 'geoResourceId0', visible: true, zIndex: 0 };
+			const layer1 = { ...createDefaultLayerProperties(), id: 'id1', geoResourceId: 'geoResourceId0', visible: true, zIndex: 1 };
+			const layer2 = { ...createDefaultLayerProperties(), id: 'id2', geoResourceId: 'geoResourceId0', visible: true, zIndex: 2 };
 			const state = {
 				layers: {
 					active: [layer0, layer1, layer2],
@@ -426,29 +430,6 @@ describe('LayerManager', () => {
 	});
 
 	describe('when layers are modified', () => {
-
-		it('renders changed layer.label', async () => {
-			const layer = {
-				...createDefaultLayerProperties(),
-				id: 'id0', label: 'Foo'
-			};
-			const state = {
-				layers: {
-					active: [layer],
-					background: 'bg0'
-				}
-			};
-			const modifyableLayerProperties = { label: 'Bar' };
-
-			const element = await setup(state);
-			const layerItem = element.shadowRoot.querySelector('ba-layer-item');
-			const layerLabel = layerItem.shadowRoot.querySelector('.ba-list-item__text');
-			expect(layerLabel.innerText).toBe('Foo');
-
-			modifyLayer('id0', modifyableLayerProperties);
-			expect(store.getState().layers.active[0].label).toBe(modifyableLayerProperties.label);
-			expect(layerLabel.innerText).toBe(modifyableLayerProperties.label);
-		});
 
 		it('renders changed layer.opacity', async () => {
 			const layer = {

--- a/test/modules/layerManager/i18n/layerManager.provider.test.js
+++ b/test/modules/layerManager/i18n/layerManager.provider.test.js
@@ -20,6 +20,7 @@ describe('i18n for layer-manager', () => {
 		expect(map.layerManager_expand_all).toBe('Alle ausklappen');
 		expect(map.layerManager_collapse_all).toBe('Alle einklappen');
 		expect(map.layerManager_remove_all).toBe('Alle entfernen');
+		expect(map.layerManager_loading_hint).toBe('Wird geladen');
 	});
 
 	it('provides translation for en', () => {
@@ -40,10 +41,11 @@ describe('i18n for layer-manager', () => {
 		expect(map.layerManager_expand_all).toBe('expand all');
 		expect(map.layerManager_collapse_all).toBe('collapse all');
 		expect(map.layerManager_remove_all).toBe('remove all');
+		expect(map.layerManager_loading_hint).toBe('Loading');
 	});
 
 	it('have the expected amount of translations', () => {
-		const expectedSize = 14;
+		const expectedSize = 15;
 		const deMap = provide('de');
 		const enMap = provide('en');
 

--- a/test/modules/olMap/components/OlMap.test.js
+++ b/test/modules/olMap/components/OlMap.test.js
@@ -942,6 +942,48 @@ describe('OlMap', () => {
 			expect(viewSpy).not.toHaveBeenCalled();
 			expect(element._viewSyncBlocked).toBeUndefined();
 		});
+
+		it('adds an olLayer resolving a GeoResourceFuture', async () => {
+			const element = await setup();
+			const map = element._map;
+			const view = map.getView();
+			const extent = [38, 57, 39, 58];
+			const viewSpy = spyOn(view, 'fit').and.callThrough();
+			const spy = spyOn(element, '_syncStore').and.callThrough();
+			const olVectorSource = new VectorSource();
+			const geoResource = new VectorGeoResource(geoResourceId0, 'label', VectorSourceType.GEOJSON);
+			const olPlaceHolderLayer = new Layer({ id: id0, render: () => { } });
+			const olRealLayer = new VectorLayer({ id: id0, source: olVectorSource });
+			const future = new GeoResourceFuture(geoResourceId0, async () => geoResource);
+			spyOn(layerServiceMock, 'toOlLayer').withArgs(id0, jasmine.anything(), map).and.callFake((id, geoResource) => {
+				if (geoResource instanceof GeoResourceFuture) {
+					return olPlaceHolderLayer;
+				}
+				return olRealLayer;
+			});
+			spyOn(olVectorSource, 'getExtent').and.returnValue(extent);
+			spyOn(geoResourceServiceStub, 'byId').withArgs(geoResourceId0).and.returnValue(future);
+			spyOn(mapServiceStub, 'getVisibleViewport').withArgs(map.getTarget()).and.returnValue({ top: 10, right: 20, bottom: 30, left: 40 });
+
+			expect(element._viewSyncBlocked).toBeUndefined();
+
+			addLayer(id0, { geoResourceId: geoResourceId0 });
+			fitLayer(id0);
+
+			// we have to wait for two timeout calls!
+			await TestUtils.timeout();
+			await TestUtils.timeout();
+
+			expect(store.getState().position.fitLayerRequest.payload).not.toBeNull();
+			expect(viewSpy).toHaveBeenCalledOnceWith(extent, { maxZoom: view.getMaxZoom(), callback: jasmine.anything(), padding: [10 + OlMap.DEFAULT_PADDING_PX[0], 20 + OlMap.DEFAULT_PADDING_PX[1], 30 + OlMap.DEFAULT_PADDING_PX[2], 40 + OlMap.DEFAULT_PADDING_PX[3]] });
+			expect(element._viewSyncBlocked).toBeTrue();
+
+			await TestUtils.timeout();
+			//check if flag is reset
+			expect(element._viewSyncBlocked).toBeFalse();
+			//and store is in sync with view
+			expect(spy).toHaveBeenCalled();
+		});
 	});
 
 	describe('olLayer management', () => {

--- a/test/modules/olMap/i18n/olMap.provider.test.js
+++ b/test/modules/olMap/i18n/olMap.provider.test.js
@@ -34,6 +34,7 @@ describe('i18n for map module', () => {
 		expect(map.olMap_handler_mfp_id_a4_portrait).toBe('DIN A4 Hochformat');
 		expect(map.olMap_handler_mfp_id_a3_landscape).toBe('DIN A3 Querformat');
 		expect(map.olMap_handler_mfp_id_a3_portrait).toBe('DIN A3 Hochformat');
+		expect(map.olMap_vectorLayerService_default_layer_name_vector).toBe('Daten');
 	});
 
 	it('provides translation for en', () => {
@@ -67,10 +68,11 @@ describe('i18n for map module', () => {
 		expect(map.olMap_handler_mfp_id_a4_portrait).toBe('DIN A4 portrait');
 		expect(map.olMap_handler_mfp_id_a3_landscape).toBe('DIN A3 landscape');
 		expect(map.olMap_handler_mfp_id_a3_portrait).toBe('DIN A3 portrait');
+		expect(map.olMap_vectorLayerService_default_layer_name_vector).toBe('Data');
 	});
 
 	it('have the expected amount of translations', () => {
-		const expectedSize = 27;
+		const expectedSize = 28;
 		const deMap = provide('de');
 		const enMap = provide('en');
 

--- a/test/modules/olMap/services/VectorLayerService.test.js
+++ b/test/modules/olMap/services/VectorLayerService.test.js
@@ -111,15 +111,15 @@ describe('VectorLayerService', () => {
 				const sourceAsString = 'kml';
 				const olMap = new Map();
 				const olSource = new VectorSource();
-				const vectorGeoresource = new VectorGeoResource(geoResourceId, geoResourceLabel, VectorSourceType.KML).setSource(sourceAsString, 4326)
+				const vectorGeoResource = new VectorGeoResource(geoResourceId, geoResourceLabel, VectorSourceType.KML).setSource(sourceAsString, 4326)
 					.setOpacity(.5)
 					.setMinZoom(5)
 					.setMaxZoom(19);
-				spyOn(instanceUnderTest, '_vectorSourceForData').withArgs(vectorGeoresource).and.returnValue(olSource);
+				spyOn(instanceUnderTest, '_vectorSourceForData').withArgs(vectorGeoResource).and.returnValue(olSource);
 				spyOn(instanceUnderTest, '_applyStyles').withArgs(jasmine.anything(), olMap).and.callFake(layer => layer);
 				const vectorSourceForUrlSpy = spyOn(instanceUnderTest, '_vectorSourceForUrl');
 
-				const olVectorLayer = instanceUnderTest.createVectorLayer(id, vectorGeoresource, olMap);
+				const olVectorLayer = instanceUnderTest.createVectorLayer(id, vectorGeoResource, olMap);
 
 				expect(olVectorLayer.get('id')).toBe(id);
 				expect(olVectorLayer.get('geoResourceId')).toBe(geoResourceId);
@@ -184,22 +184,22 @@ describe('VectorLayerService', () => {
 
 		describe('_vectorSourceForData', () => {
 
-			it('builds an olVectorSource for an internal VectorGeoresource', async () => {
+			it('builds an olVectorSource for an internal VectorGeoResource', async () => {
 				const srid = 3857;
 				const kmlName = '';
 				const geoResourceLabel = 'geoResourceLabel';
 				spyOn(mapService, 'getSrid').and.returnValue(srid);
 				const sourceAsString = `<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/kml/2.2 https://developers.google.com/kml/schema/kml22gx.xsd"><Document><name>${kmlName}</name><Placemark id="line_1617976924317"><ExtendedData><Data name="type"><value>line</value></Data></ExtendedData><description></description><Style><LineStyle><color>ff0000ff</color><width>3</width></LineStyle><PolyStyle><color>660000ff</color></PolyStyle></Style><LineString><tessellate>1</tessellate><altitudeMode>clampToGround</altitudeMode><coordinates>10.713458946685412,49.70007647302964 11.714932179089468,48.34411758499924</coordinates></LineString></Placemark></Document></kml>`;
-				const vectorGeoresource = new VectorGeoResource('someId', geoResourceLabel, VectorSourceType.KML).setSource(sourceAsString, 4326);
+				const vectorGeoResource = new VectorGeoResource('someId', geoResourceLabel, VectorSourceType.KML).setSource(sourceAsString, 4326);
 
-				const olVectorSource = instanceUnderTest._vectorSourceForData(vectorGeoresource);
+				const olVectorSource = instanceUnderTest._vectorSourceForData(vectorGeoResource);
 
 				expect(olVectorSource.constructor.name).toBe('VectorSource');
 				expect(olVectorSource.getFeatures().length).toBe(1);
 				expect(olVectorSource.getFeatures()[0].get('srid')).toBe(srid);
 
 				await TestUtils.timeout();
-				expect(vectorGeoresource.label).toBe(geoResourceLabel);
+				expect(vectorGeoResource.label).toBe(geoResourceLabel);
 			});
 
 			it('filters out features without a geometry', () => {

--- a/test/modules/olMap/services/VectorLayerService.test.js
+++ b/test/modules/olMap/services/VectorLayerService.test.js
@@ -31,8 +31,7 @@ describe('VectorLayerService', () => {
 		$injector
 			.registerSingleton('UrlService', urlService)
 			.registerSingleton('MapService', mapService)
-			.registerSingleton('StyleService', styleService)
-			.registerSingleton('TranslationService', { translate: (key) => key });
+			.registerSingleton('StyleService', styleService);
 	});
 
 	describe('utils', () => {
@@ -222,33 +221,6 @@ describe('VectorLayerService', () => {
 
 					await TestUtils.timeout();
 					expect(vectorGeoresource.label).toBe(kmlName);
-				});
-
-				it('updates the label of an internal VectorGeoresource by using a fallback', async () => {
-					const srid = 3857;
-					spyOn(mapService, 'getSrid').and.returnValue(srid);
-					const sourceAsString = '<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/kml/2.2 https://developers.google.com/kml/schema/kml22gx.xsd"><Document><Placemark id="line_1617976924317"><ExtendedData><Data name="type"><value>line</value></Data></ExtendedData><description></description><Style><LineStyle><color>ff0000ff</color><width>3</width></LineStyle><PolyStyle><color>660000ff</color></PolyStyle></Style><LineString><tessellate>1</tessellate><altitudeMode>clampToGround</altitudeMode><coordinates>10.713458946685412,49.70007647302964 11.714932179089468,48.34411758499924</coordinates></LineString></Placemark></Document></kml>';
-					const vectorGeoresource = new VectorGeoResource('someId', null, VectorSourceType.KML).setSource(sourceAsString, 4326);
-
-					instanceUnderTest._vectorSourceForData(vectorGeoresource);
-
-					await TestUtils.timeout();
-					expect(vectorGeoresource.label).toBe('olMap_vectorLayerService_default_layer_name_vector');
-				});
-			});
-
-			describe('Non-KML VectorGeoresource has no label', () => {
-
-				it('updates the label of an internal VectorGeoresource by using a fallback', async () => {
-					const srid = 3857;
-					spyOn(mapService, 'getSrid').and.returnValue(srid);
-					const sourceAsString = '<gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd" version="1.1" creator="OpenLayers"><wpt lat="49.11012342157893" lon="11.13552777569367"><name></name><type>marker</type></wpt></gpx>';
-					const vectorGeoresource = new VectorGeoResource('someId', null, VectorSourceType.GPX).setSource(sourceAsString, 4326);
-
-					instanceUnderTest._vectorSourceForData(vectorGeoresource);
-
-					await TestUtils.timeout();
-					expect(vectorGeoresource.label).toBe('olMap_vectorLayerService_default_layer_name_vector');
 				});
 			});
 		});

--- a/test/modules/olMap/services/VectorLayerService.test.js
+++ b/test/modules/olMap/services/VectorLayerService.test.js
@@ -31,7 +31,8 @@ describe('VectorLayerService', () => {
 		$injector
 			.registerSingleton('UrlService', urlService)
 			.registerSingleton('MapService', mapService)
-			.registerSingleton('StyleService', styleService);
+			.registerSingleton('StyleService', styleService)
+			.registerSingleton('TranslationService', { translate: (key) => key });
 	});
 
 	describe('utils', () => {
@@ -175,7 +176,7 @@ describe('VectorLayerService', () => {
 
 		describe('_vectorSourceForData', () => {
 
-			it('builds an olVectorSource for an internal VectorGeoresource', () => {
+			it('builds an olVectorSource for an internal VectorGeoresource', async () => {
 				const srid = 3857;
 				const kmlName = '';
 				const geoResourceLabel = 'geoResourceLabel';
@@ -188,6 +189,9 @@ describe('VectorLayerService', () => {
 				expect(olVectorSource.constructor.name).toBe('VectorSource');
 				expect(olVectorSource.getFeatures().length).toBe(1);
 				expect(olVectorSource.getFeatures()[0].get('srid')).toBe(srid);
+
+				await TestUtils.timeout();
+				expect(vectorGeoresource.label).toBe(geoResourceLabel);
 			});
 
 			it('filters out features without a geometry', () => {
@@ -205,18 +209,47 @@ describe('VectorLayerService', () => {
 				expect(olVectorSource.getFeatures()[0].get('srid')).toBe(srid);
 			});
 
-			it('updates the label of an internal VectorGeoresource if possible', async () => {
-				const srid = 3857;
-				const kmlName = 'kmlName';
-				const geoResourceLabel = 'geoResourceLabel';
-				spyOn(mapService, 'getSrid').and.returnValue(srid);
-				const sourceAsString = `<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/kml/2.2 https://developers.google.com/kml/schema/kml22gx.xsd"><Document><name>${kmlName}</name><Placemark id="line_1617976924317"><ExtendedData><Data name="type"><value>line</value></Data></ExtendedData><description></description><Style><LineStyle><color>ff0000ff</color><width>3</width></LineStyle><PolyStyle><color>660000ff</color></PolyStyle></Style><LineString><tessellate>1</tessellate><altitudeMode>clampToGround</altitudeMode><coordinates>10.713458946685412,49.70007647302964 11.714932179089468,48.34411758499924</coordinates></LineString></Placemark></Document></kml>`;
-				const vectorGeoresource = new VectorGeoResource('someId', geoResourceLabel, VectorSourceType.KML).setSource(sourceAsString, 4326);
+			describe('KML VectorGeoresource has no label', () => {
 
-				instanceUnderTest._vectorSourceForData(vectorGeoresource);
+				it('updates the label of an internal VectorGeoresource by calling the ol format', async () => {
+					const srid = 3857;
+					const kmlName = 'kmlName';
+					spyOn(mapService, 'getSrid').and.returnValue(srid);
+					const sourceAsString = `<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/kml/2.2 https://developers.google.com/kml/schema/kml22gx.xsd"><Document><name>${kmlName}</name><Placemark id="line_1617976924317"><ExtendedData><Data name="type"><value>line</value></Data></ExtendedData><description></description><Style><LineStyle><color>ff0000ff</color><width>3</width></LineStyle><PolyStyle><color>660000ff</color></PolyStyle></Style><LineString><tessellate>1</tessellate><altitudeMode>clampToGround</altitudeMode><coordinates>10.713458946685412,49.70007647302964 11.714932179089468,48.34411758499924</coordinates></LineString></Placemark></Document></kml>`;
+					const vectorGeoresource = new VectorGeoResource('someId', null, VectorSourceType.KML).setSource(sourceAsString, 4326);
 
-				await TestUtils.timeout();
-				expect(vectorGeoresource.label).toBe(kmlName);
+					instanceUnderTest._vectorSourceForData(vectorGeoresource);
+
+					await TestUtils.timeout();
+					expect(vectorGeoresource.label).toBe(kmlName);
+				});
+
+				it('updates the label of an internal VectorGeoresource by using a fallback', async () => {
+					const srid = 3857;
+					spyOn(mapService, 'getSrid').and.returnValue(srid);
+					const sourceAsString = '<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/kml/2.2 https://developers.google.com/kml/schema/kml22gx.xsd"><Document><Placemark id="line_1617976924317"><ExtendedData><Data name="type"><value>line</value></Data></ExtendedData><description></description><Style><LineStyle><color>ff0000ff</color><width>3</width></LineStyle><PolyStyle><color>660000ff</color></PolyStyle></Style><LineString><tessellate>1</tessellate><altitudeMode>clampToGround</altitudeMode><coordinates>10.713458946685412,49.70007647302964 11.714932179089468,48.34411758499924</coordinates></LineString></Placemark></Document></kml>';
+					const vectorGeoresource = new VectorGeoResource('someId', null, VectorSourceType.KML).setSource(sourceAsString, 4326);
+
+					instanceUnderTest._vectorSourceForData(vectorGeoresource);
+
+					await TestUtils.timeout();
+					expect(vectorGeoresource.label).toBe('olMap_vectorLayerService_default_layer_name_vector');
+				});
+			});
+
+			describe('Non-KML VectorGeoresource has no label', () => {
+
+				it('updates the label of an internal VectorGeoresource by using a fallback', async () => {
+					const srid = 3857;
+					spyOn(mapService, 'getSrid').and.returnValue(srid);
+					const sourceAsString = '<gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd" version="1.1" creator="OpenLayers"><wpt lat="49.11012342157893" lon="11.13552777569367"><name></name><type>marker</type></wpt></gpx>';
+					const vectorGeoresource = new VectorGeoResource('someId', null, VectorSourceType.GPX).setSource(sourceAsString, 4326);
+
+					instanceUnderTest._vectorSourceForData(vectorGeoresource);
+
+					await TestUtils.timeout();
+					expect(vectorGeoresource.label).toBe('olMap_vectorLayerService_default_layer_name_vector');
+				});
 			});
 		});
 

--- a/test/modules/search/services/SearchResultService.test.js
+++ b/test/modules/search/services/SearchResultService.test.js
@@ -231,8 +231,8 @@ describe('SearchResultService', () => {
 			spyOn(environmentService, 'isStandalone').and.returnValue(false);
 			spyOn(sourceTypeService, 'forData').and.returnValue(new SourceTypeResult(SourceTypeResultStatus.UNSUPPORTED_TYPE));
 			const provider = jasmine.createSpy().and.resolveTo([
-				new GeoResourceSearchResult('geoResouceId0', 'foo'),
-				new GeoResourceSearchResult('geoResouceId1', 'bar')
+				new GeoResourceSearchResult('geoResourceId0', 'foo'),
+				new GeoResourceSearchResult('geoResourceId1', 'bar')
 			]);
 			const instanceUnderTest = setup(null, provider);
 
@@ -247,8 +247,8 @@ describe('SearchResultService', () => {
 			spyOn(environmentService, 'isStandalone').and.returnValue(false);
 			const instanceUnderTest = setup();
 			spyOn(instanceUnderTest, '_getGeoResourcesForUrl').withArgs(term).and.resolveTo([
-				new GeoResourceSearchResult('geoResouceId0', 'foo'),
-				new GeoResourceSearchResult('geoResouceId1', 'bar')
+				new GeoResourceSearchResult('geoResourceId0', 'foo'),
+				new GeoResourceSearchResult('geoResourceId1', 'bar')
 			]);
 
 			const results = await instanceUnderTest.geoResourcesByTerm(term);

--- a/test/modules/search/services/SearchResultService.test.js
+++ b/test/modules/search/services/SearchResultService.test.js
@@ -107,7 +107,7 @@ describe('SearchResultService', () => {
 
 		const checkGeoResourceSearchResultForVectorSource = async (sourceTypeName) => {
 			const geoResourceId = 'id';
-			const geoResource = new GeoResourceFuture(geoResourceId, () => { }, 'label');
+			const geoResource = new GeoResourceFuture(geoResourceId, () => { });
 			const sourceType = new SourceType(sourceTypeName);
 			const url = 'http://foo.bar';
 			const label = 'label';
@@ -264,7 +264,7 @@ describe('SearchResultService', () => {
 			spyOn(environmentService, 'isStandalone').and.returnValue(false);
 			spyOn(sourceTypeService, 'forData').and.returnValue(new SourceTypeResult(SourceTypeResultStatus.OK, SourceTypeName.GPX));
 			spyOn(importVectorDataService, 'forData').withArgs(term, { sourceType: SourceTypeName.GPX })
-				.and.returnValue(new GeoResourceFuture(geoResourceId, () => { }, 'label'));
+				.and.returnValue(new GeoResourceFuture(geoResourceId, () => { }));
 			const instanceUnderTest = setup();
 			spyOn(instanceUnderTest, '_mapSourceTypeToLabel').withArgs(SourceTypeName.GPX).and.returnValue(label);
 

--- a/test/plugins/LayersPlugin.test.js
+++ b/test/plugins/LayersPlugin.test.js
@@ -310,27 +310,6 @@ describe('LayersPlugin', () => {
 
 				expect(store.getState().layers.active.length).toBe(0);
 			});
-
-			it('updates the layers label for on-demand geoResources', async () => {
-				const queryParam = `${QueryParameters.LAYER}=some0`;
-				const store = setup();
-				const instanceUnderTest = new LayersPlugin();
-				const id = 'id';
-				const labelBefore = 'labelBefore';
-				const labelAfter = 'labelAfter';
-				const geoResource0 = new XyzGeoResource(id, labelAfter, 'someUrl0');
-				const future0 = new GeoResourceFuture('some0', async () => geoResource0);
-				future0.setLabel(labelBefore);
-				spyOnProperty(windowMock.location, 'search').and.returnValue(queryParam);
-				spyOn(geoResourceServiceMock, 'asyncById').and.returnValue(future0);
-
-				instanceUnderTest._addLayersFromQueryParams(new URLSearchParams(queryParam));
-
-				expect(store.getState().layers.active[0].label).toBe(labelBefore);
-				//Let's resolve the future
-				await future0.get();
-				expect(store.getState().layers.active[0].label).toBe(labelAfter);
-			});
 		});
 	});
 });

--- a/test/plugins/i18n/layersPlugin.provider.test.js
+++ b/test/plugins/i18n/layersPlugin.provider.test.js
@@ -8,7 +8,6 @@ describe('i18n for LayersPlugin', () => {
 		const map = provide('en');
 
 		expect(map.layersPlugin_store_layer_default_layer_name_vector).toBe('Data');
-		expect(map.layersPlugin_store_layer_default_layer_name_future).toBe('Loading...');
 	});
 
 	it('provides translation for de', () => {
@@ -16,12 +15,11 @@ describe('i18n for LayersPlugin', () => {
 		const map = provide('de');
 
 		expect(map.layersPlugin_store_layer_default_layer_name_vector).toBe('Daten');
-		expect(map.layersPlugin_store_layer_default_layer_name_future).toBe('Wird geladen...');
 	});
 
 	it('have the expected amount of translations', () => {
 
-		const expectedSize = 2;
+		const expectedSize = 1;
 		const deMap = provide('de');
 		const enMap = provide('en');
 

--- a/test/service/GeoResourceService.test.js
+++ b/test/service/GeoResourceService.test.js
@@ -144,7 +144,7 @@ describe('GeoResourceService', () => {
 
 	describe('byId', () => {
 
-		it('provides a GeoResource by id', () => {
+		it('provides a GeoResource by its id', () => {
 
 			const instanceUnderTest = setup();
 			instanceUnderTest._georesources = [xyzGeoResource];
@@ -163,6 +163,15 @@ describe('GeoResourceService', () => {
 			const geoResource = instanceUnderTest.byId('something');
 
 			expect(geoResource).toBeNull();
+		});
+
+		it('provides null if for null or undefined id', () => {
+
+			const instanceUnderTest = setup();
+			instanceUnderTest._georesources = [xyzGeoResource];
+
+			expect(instanceUnderTest.byId(null)).toBeNull();
+			expect(instanceUnderTest.byId(undefined)).toBeNull();
 		});
 
 		it('logs a warn statement when when service hat not been initialized', () => {

--- a/test/service/ImportVectorDataService.test.js
+++ b/test/service/ImportVectorDataService.test.js
@@ -3,9 +3,6 @@ import { VectorGeoResource, VectorSourceType } from '../../src/domain/geoResourc
 import { SourceType, SourceTypeName, SourceTypeResult, SourceTypeResultStatus } from '../../src/domain/sourceType';
 import { MediaType } from '../../src/services/HttpService';
 import { ImportVectorDataService } from '../../src/services/ImportVectorDataService';
-import { addLayer } from '../../src/store/layers/layers.action';
-import { layersReducer } from '../../src/store/layers/layers.reducer';
-import { TestUtils } from '../test-utils';
 
 describe('ImportVectorDataService', () => {
 
@@ -21,12 +18,9 @@ describe('ImportVectorDataService', () => {
 	const sourceTypeService = {
 		forData() { }
 	};
-	let store;
 
 	const setup = () => {
-		store = TestUtils.setupStoreAndDi({}, {
-			layers: layersReducer
-		});
+
 		$injector
 			.registerSingleton('HttpService', httpService)
 			.registerSingleton('GeoResourceService', geoResourceService)

--- a/test/service/ImportVectorDataService.test.js
+++ b/test/service/ImportVectorDataService.test.js
@@ -31,7 +31,6 @@ describe('ImportVectorDataService', () => {
 			.registerSingleton('HttpService', httpService)
 			.registerSingleton('GeoResourceService', geoResourceService)
 			.registerSingleton('UrlService', urlService)
-			.registerSingleton('TranslationService', { translate: (key) => key })
 			.registerSingleton('SourceTypeService', sourceTypeService);
 		return new ImportVectorDataService();
 	};
@@ -72,7 +71,7 @@ describe('ImportVectorDataService', () => {
 			expect(geoResourceServiceSpy).toHaveBeenCalledWith(geoResourceFuture);
 		});
 
-		it('returns a GeoResourceFuture automatically setting id and label', () => {
+		it('returns a GeoResourceFuture automatically setting id', () => {
 			const instanceUnderTest = setup();
 			const url = 'http://my.url';
 			const geoResourceServiceSpy = spyOn(geoResourceService, 'addOrReplace');
@@ -80,7 +79,7 @@ describe('ImportVectorDataService', () => {
 			const geoResourceFuture = instanceUnderTest.forUrl(url);
 
 			expect(geoResourceFuture.id).toEqual(jasmine.any(String));
-			expect(geoResourceFuture.label).toBe('layersPlugin_store_layer_default_layer_name_future');
+			expect(geoResourceFuture.label).toBeNull();
 			expect(geoResourceServiceSpy).toHaveBeenCalledWith(geoResourceFuture);
 		});
 
@@ -136,7 +135,7 @@ describe('ImportVectorDataService', () => {
 				expect(updateLayerCallbackFnSpy).toHaveBeenCalledWith(geoResourceId);
 			});
 
-			it('loads the data and returns a VectorGeoresource automatically setting id, label and sourceType', async () => {
+			it('loads the data and returns a VectorGeoresource automatically setting id and sourceType', async () => {
 				const url = 'http://my.url';
 				const data = 'data';
 				const mediaType = MediaType.GeoJSON;
@@ -159,7 +158,7 @@ describe('ImportVectorDataService', () => {
 				expect(vgr).toEqual(jasmine.any(VectorGeoResource));
 				expect(vgr.sourceType).toEqual(VectorSourceType.GEOJSON);
 				expect(vgr.id).toBe(geoResourceFuture.id);
-				expect(vgr.label).toBe('layersPlugin_store_layer_default_layer_name_vector');
+				expect(vgr.label).toBeNull();
 				expect(vgr.data).toBe(data);
 				expect(vgr.srid).toBe(4326);
 			});
@@ -285,7 +284,7 @@ describe('ImportVectorDataService', () => {
 			expect(geoResourceServiceSpy).toHaveBeenCalledWith(vgr);
 		});
 
-		it('returns a VectorGeoResource automatically setting id, label and sourceType', () => {
+		it('returns a VectorGeoResource automatically setting id and sourceType', () => {
 			const data = 'data';
 			const geoResourceServiceSpy = spyOn(geoResourceService, 'addOrReplace');
 			const instanceUnderTest = setup();
@@ -299,7 +298,7 @@ describe('ImportVectorDataService', () => {
 			expect(vgr).toEqual(jasmine.any(VectorGeoResource));
 			expect(vgr.sourceType).toEqual(VectorSourceType.GEOJSON);
 			expect(vgr.id).toEqual(jasmine.any(String));
-			expect(vgr.label).toBe('layersPlugin_store_layer_default_layer_name_vector');
+			expect(vgr.label).toBeNull();
 			expect(vgr.data).toBe(data);
 			expect(vgr.srid).toBe(4326);
 			expect(geoResourceServiceSpy).toHaveBeenCalledWith(vgr);

--- a/test/service/ImportVectorDataService.test.js
+++ b/test/service/ImportVectorDataService.test.js
@@ -50,7 +50,7 @@ describe('ImportVectorDataService', () => {
 			const geoResourceFuture = instanceUnderTest.forUrl(url, options);
 
 			expect(geoResourceFuture.id).toBe(options.id);
-			expect(geoResourceFuture.label).toBe(options.label);
+			expect(geoResourceFuture.label).toBe('');
 			expect(geoResourceServiceSpy).toHaveBeenCalledWith(geoResourceFuture);
 		});
 
@@ -67,7 +67,7 @@ describe('ImportVectorDataService', () => {
 			const geoResourceFuture = instanceUnderTest.forUrl(url, options);
 
 			expect(geoResourceFuture.id).toBe(options.id);
-			expect(geoResourceFuture.label).toBe(options.label);
+			expect(geoResourceFuture.label).toBe('');
 			expect(geoResourceServiceSpy).toHaveBeenCalledWith(geoResourceFuture);
 		});
 
@@ -79,7 +79,7 @@ describe('ImportVectorDataService', () => {
 			const geoResourceFuture = instanceUnderTest.forUrl(url);
 
 			expect(geoResourceFuture.id).toEqual(jasmine.any(String));
-			expect(geoResourceFuture.label).toBeNull();
+			expect(geoResourceFuture.label).toBe('');
 			expect(geoResourceServiceSpy).toHaveBeenCalledWith(geoResourceFuture);
 		});
 

--- a/test/service/ImportVectorDataService.test.js
+++ b/test/service/ImportVectorDataService.test.js
@@ -29,6 +29,10 @@ describe('ImportVectorDataService', () => {
 		return new ImportVectorDataService();
 	};
 
+	afterEach(() => {
+		$injector.reset();
+	});
+
 	describe('forUrl', () => {
 
 		it('returns a GeoResourceFuture for given VectorSourceType', () => {

--- a/test/service/StoreService.test.js
+++ b/test/service/StoreService.test.js
@@ -89,7 +89,7 @@ describe('StoreService', () => {
 			expect(store).toBeDefined();
 
 			const reducerKeys = Object.keys(store.getState());
-			expect(reducerKeys.length).toBe(22);
+			expect(reducerKeys.length).toBe(23);
 			expect(reducerKeys.includes('map')).toBeTrue();
 			expect(reducerKeys.includes('pointer')).toBeTrue();
 			expect(reducerKeys.includes('position')).toBeTrue();
@@ -112,6 +112,7 @@ describe('StoreService', () => {
 			expect(reducerKeys.includes('media')).toBeTrue();
 			expect(reducerKeys.includes('import')).toBeTrue();
 			expect(reducerKeys.includes('mfp')).toBeTrue();
+			expect(reducerKeys.includes('geoResources')).toBeTrue();
 		});
 
 		it('registers all plugins', async () => {

--- a/test/service/provider/fileStorage.provider.test.js
+++ b/test/service/provider/fileStorage.provider.test.js
@@ -37,7 +37,7 @@ describe('BVV GeoResource provider', () => {
 
 				expect(future instanceof GeoResourceFuture).toBeTrue();
 				expect(future.id).toBe(id);
-				expect(future.label).toBe('layersPlugin_store_layer_default_layer_name_future');
+				expect(future.label).toBe('');
 				expect(future._loader).toBeDefined();
 			});
 		});
@@ -52,7 +52,7 @@ describe('BVV GeoResource provider', () => {
 
 				expect(future instanceof GeoResourceFuture).toBeTrue();
 				expect(future.id).toBe(id);
-				expect(future.label).toBe('layersPlugin_store_layer_default_layer_name_future');
+				expect(future.label).toBe('');
 				expect(future._loader).toBeDefined();
 			});
 		});

--- a/test/service/provider/geoResource.provider.test.js
+++ b/test/service/provider/geoResource.provider.test.js
@@ -14,8 +14,7 @@ describe('BVV GeoResource provider', () => {
 	beforeAll(() => {
 		$injector
 			.registerSingleton('ConfigService', configService)
-			.registerSingleton('HttpService', httpService)
-			.registerSingleton('TranslationService', { translate: (key) => key });
+			.registerSingleton('HttpService', httpService);
 	});
 
 	const basicAttribution = {
@@ -370,7 +369,7 @@ describe('BVV GeoResource provider', () => {
 			const geoResource = await future.get();
 
 			expect(future.id).toBe(wmsDefinition.id);
-			expect(future.label).toBe('layersPlugin_store_layer_default_layer_name_future');
+			expect(future.label).toBe('');
 			expect(configServiceSpy).toHaveBeenCalled();
 			expect(httpServiceSpy).toHaveBeenCalled();
 			expect(geoResource.id).toBe(wmsDefinition.id);

--- a/test/store/geoResources/geoResources.reducer.test.js
+++ b/test/store/geoResources/geoResources.reducer.test.js
@@ -1,3 +1,4 @@
+import { GeoResourceFuture } from '../../../src/domain/geoResources.js';
 import { propertyChanged } from '../../../src/store/geoResources/geoResources.action.js';
 import { geoResourcesReducer } from '../../../src/store/geoResources/geoResources.reducer.js';
 import { TestUtils } from '../../test-utils.js';
@@ -23,5 +24,9 @@ describe('geoResourcesReducer', () => {
 		propertyChanged('foo');
 
 		expect(store.getState().geoResources.changed.payload).toBe('foo');
+
+		propertyChanged(new GeoResourceFuture('bar', () => { }));
+
+		expect(store.getState().geoResources.changed.payload).toBe('bar');
 	});
 });

--- a/test/store/geoResources/geoResources.reducer.test.js
+++ b/test/store/geoResources/geoResources.reducer.test.js
@@ -1,7 +1,5 @@
 import { propertyChanged } from '../../../src/store/geoResources/geoResources.action.js';
 import { geoResourcesReducer } from '../../../src/store/geoResources/geoResources.reducer.js';
-import { closeModal, openModal } from '../../../src/store/modal/modal.action.js';
-import { modalReducer } from '../../../src/store/modal/modal.reducer.js';
 import { TestUtils } from '../../test-utils.js';
 
 

--- a/test/store/geoResources/geoResources.reducer.test.js
+++ b/test/store/geoResources/geoResources.reducer.test.js
@@ -1,0 +1,29 @@
+import { propertyChanged } from '../../../src/store/geoResources/geoResources.action.js';
+import { geoResourcesReducer } from '../../../src/store/geoResources/geoResources.reducer.js';
+import { closeModal, openModal } from '../../../src/store/modal/modal.action.js';
+import { modalReducer } from '../../../src/store/modal/modal.reducer.js';
+import { TestUtils } from '../../test-utils.js';
+
+
+describe('geoResourcesReducer', () => {
+
+	const setup = (state) => {
+		return TestUtils.setupStoreAndDi(state, {
+			geoResources: geoResourcesReducer
+		});
+	};
+
+	it('initiales the store with default values', () => {
+		const store = setup();
+
+		expect(store.getState().geoResources.changed.payload).toBeNull();
+	});
+
+	it('updates the stores properties', () => {
+		const store = setup();
+
+		propertyChanged('foo');
+
+		expect(store.getState().geoResources.changed.payload).toBe('foo');
+	});
+});


### PR DESCRIPTION
- [x]  wait for performing `fit` until GeoResourceFuture has been resolved (fixes #1279)
- [x]  `GeoResourceFuture` instances never contain a label
- [x] add a new slice of state (`geoResources`) for indicating changes of a GeoResource
- [x]  GeoResourceResultItem: improve preview UX when importing vector data in 
- [x] LayerItem: indicate ongoing import progress

Removing the property `label` from `LayerProperties` will be done in an extra following-up PR