### PR TITLE
Export2Pdf: add a default parameter to encoded WMS

### DIFF
--- a/src/modules/olMap/services/Mfp3Encoder.js
+++ b/src/modules/olMap/services/Mfp3Encoder.js
@@ -256,7 +256,7 @@ export class BvvMfp3Encoder {
 			new Array(layers.length).join(',').split(',');
 
 		const url = source.getUrl && source.getUrl();
-
+		const defaultCustomParams = { transparent: true }; // similar to OpenLayers TRANSPARENT-Parameter is set by default
 		return {
 			type: 'wms',
 			baseURL: url,
@@ -265,6 +265,7 @@ export class BvvMfp3Encoder {
 			name: wmsGeoResource.id,
 			opacity: olLayer.getOpacity(),
 			styles: styles,
+			customParams: defaultCustomParams,
 			attribution: wmsGeoResource.importedByUser ? null : wmsGeoResource.attribution,
 			thirdPartyAttribution: wmsGeoResource.importedByUser ? wmsGeoResource.attribution : null
 		};

--- a/test/modules/olMap/formats/Mfp3Encoder.test.js
+++ b/test/modules/olMap/formats/Mfp3Encoder.test.js
@@ -576,6 +576,7 @@ describe('BvvMfp3Encoder', () => {
 				baseURL: 'https://some.url/to/wms',
 				layers: ['foo', 'bar'],
 				styles: ['baz'],
+				customParams: { transparent: true },
 				attribution: { copyright: { label: 'Foo CopyRight' } },
 				thirdPartyAttribution: null
 			});


### PR DESCRIPTION
adding transparent:true to encoded MFP  specs of a WMS layer, by adding the customParams property