### PR TITLE
remove usage of HTML Entities

### DIFF
--- a/src/modules/toolbox/components/measureToolContent/MeasureToolContent.js
+++ b/src/modules/toolbox/components/measureToolContent/MeasureToolContent.js
@@ -8,7 +8,6 @@ import { finish, remove, reset } from '../../../../store/measurement/measurement
 import css from './measureToolContent.css';
 import { AbstractToolContent } from '../toolContainer/AbstractToolContent';
 import { emitNotification, LevelTypes } from '../../../../store/notifications/notifications.action';
-import { decodeHtmlEntities } from '../../../../utils/markup';
 
 const Update = 'update';
 const Update_FileSaveResult = 'update_fileSaveResult';
@@ -74,10 +73,8 @@ export class MeasureToolContent extends AbstractToolContent {
 		const formattedDistancePackage = buildPackage(formattedDistance);
 		const formattedAreaPackage = buildPackage(formattedArea);
 
-		// unit-strings could contain encoded special characters (i.e. [²]->[&sup2;]); to copy these
-		// characters to clipboard, we must use the decoded values
-		const onCopyDistanceToClipboard = async () => this._copyValueToClipboard(decodeHtmlEntities(formattedDistance), 'distance');
-		const onCopyAreaToClipboard = async () => this._copyValueToClipboard(decodeHtmlEntities(formattedArea), 'area');
+		const onCopyDistanceToClipboard = async () => this._copyValueToClipboard(formattedDistance, 'distance');
+		const onCopyAreaToClipboard = async () => this._copyValueToClipboard(formattedArea, 'area');
 
 		return html`
         <style>${css}</style>

--- a/src/services/provider/units.provider.js
+++ b/src/services/provider/units.provider.js
@@ -35,13 +35,13 @@ export const bvvDistanceUnitsProvider = (distance) => {
 export const bvvAreaUnitsProvider = (area) => {
 	const locales = getLocales();
 	const asSquaredKilometer = (areaValue) => {
-		return (Math.round((areaValue / Squaredkilometer_In_Squaredmeters) * 100) / 100).toLocaleString(locales, { minimumFractionDigits: 3, maximumFractionDigits: 3 }) + ' ' + 'km&sup2;';
+		return (Math.round((areaValue / Squaredkilometer_In_Squaredmeters) * 100) / 100).toLocaleString(locales, { minimumFractionDigits: 3, maximumFractionDigits: 3 }) + ' ' + 'km²';
 	};
 	const asSquaredMeter = (areaValue) => {
-		return areaValue > 1 ? (Math.round(areaValue * 100) / 100).toLocaleString(locales, { minimumFractionDigits: 0, maximumFractionDigits: 0 }) + ' ' + 'm&sup2;' : '1 m&sup2;';
+		return areaValue > 1 ? (Math.round(areaValue * 100) / 100).toLocaleString(locales, { minimumFractionDigits: 0, maximumFractionDigits: 0 }) + ' ' + 'm²' : '1 m²';
 	};
 	if (area < 0.5) {
-		return '0 m&sup2;';
+		return '0 m²';
 	}
 	return area >= Squaredkilometer_In_Squaredmeters ? asSquaredKilometer(area) : asSquaredMeter(area);
 };
@@ -84,18 +84,18 @@ export const areaUnitsProvider = (area, decimals) => {
 	let formatted;
 	if (area >= Squaredkilometer_In_Squaredmeters) {
 		if (decimals) {
-			formatted = (Math.round((area / Squaredkilometer_In_Squaredmeters) * 100) / 100).toFixed(decimals) + ' ' + 'km&sup2;';
+			formatted = (Math.round((area / Squaredkilometer_In_Squaredmeters) * 100) / 100).toFixed(decimals) + ' ' + 'km²';
 		}
 		else {
-			formatted = (Math.round((area / Squaredkilometer_In_Squaredmeters) * 100) / 100) + ' ' + 'km&sup2;';
+			formatted = (Math.round((area / Squaredkilometer_In_Squaredmeters) * 100) / 100) + ' ' + 'km²';
 		}
 	}
 	else {
 		if (decimals) {
-			formatted = (Math.round(area * 100) / 100).toFixed(decimals) + ' ' + 'm&sup2;';
+			formatted = (Math.round(area * 100) / 100).toFixed(decimals) + ' ' + 'm²';
 		}
 		else {
-			formatted = (Math.round(area * 100) / 100) + ' ' + 'm&sup2;';
+			formatted = (Math.round(area * 100) / 100) + ' ' + 'm²';
 		}
 	}
 	return formatted;

--- a/test/modules/toolbox/components/measureToolContent/MeasureToolContent.test.js
+++ b/test/modules/toolbox/components/measureToolContent/MeasureToolContent.test.js
@@ -69,7 +69,7 @@ describe('MeasureToolContent', () => {
 			}
 
 			formatArea(area, decimals) {
-				return new Intl.NumberFormat('de-DE', { maximumSignificantDigits: decimals }).format(area) + ' m&sup2;';
+				return new Intl.NumberFormat('de-DE', { maximumSignificantDigits: decimals }).format(area) + ' m²';
 			}
 		}
 

--- a/test/service/UnitsService.test.js
+++ b/test/service/UnitsService.test.js
@@ -19,7 +19,7 @@ describe('UnitsService', () => {
 
 	it('provides default formatted area', () => {
 		const instanceUnderTest = new UnitsService();
-		expect(instanceUnderTest.formatArea(42)).toBe('42 m&sup2;');
+		expect(instanceUnderTest.formatArea(42)).toBe('42 m²');
 	});
 
 	it('provides formatted distance for metric system as default', () => {
@@ -31,6 +31,6 @@ describe('UnitsService', () => {
 	it('provides formatted area for bvv metric system as default', () => {
 		const instanceUnderTest = new UnitsService();
 
-		expect(instanceUnderTest.formatArea(42, 0)).toContain('m&sup2;');
+		expect(instanceUnderTest.formatArea(42, 0)).toContain('m²');
 	});
 });

--- a/test/service/provider/units.provider.test.js
+++ b/test/service/provider/units.provider.test.js
@@ -27,16 +27,16 @@ describe('Units provider', () => {
 	});
 
 	it('provides formatted area for metric system', () => {
-		expect(areaUnitsProvider(42, 0)).toBe('42 m&sup2;');
-		expect(areaUnitsProvider(999, 0)).toBe('999 m&sup2;');
-		expect(areaUnitsProvider(1000000, 0)).toBe('1 km&sup2;');
-		expect(areaUnitsProvider(1234567, 0)).toBe('1.23 km&sup2;');
-		expect(areaUnitsProvider(1234567, 2)).toBe('1.23 km&sup2;');
-		expect(areaUnitsProvider(100000, 0)).toBe('100000 m&sup2;');
-		expect(areaUnitsProvider(12345, 0)).toBe('12345 m&sup2;');
-		expect(areaUnitsProvider(12345, 2)).toBe('12345.00 m&sup2;');
-		expect(areaUnitsProvider(10000000, 0)).toBe('10 km&sup2;');
-		expect(bvvAreaUnitsProvider(1234567891234, 2)).toBe('1,234,567.890 km&sup2;');
+		expect(areaUnitsProvider(42, 0)).toBe('42 m²');
+		expect(areaUnitsProvider(999, 0)).toBe('999 m²');
+		expect(areaUnitsProvider(1000000, 0)).toBe('1 km²');
+		expect(areaUnitsProvider(1234567, 0)).toBe('1.23 km²');
+		expect(areaUnitsProvider(1234567, 2)).toBe('1.23 km²');
+		expect(areaUnitsProvider(100000, 0)).toBe('100000 m²');
+		expect(areaUnitsProvider(12345, 0)).toBe('12345 m²');
+		expect(areaUnitsProvider(12345, 2)).toBe('12345.00 m²');
+		expect(areaUnitsProvider(10000000, 0)).toBe('10 km²');
+		expect(bvvAreaUnitsProvider(1234567891234, 2)).toBe('1,234,567.890 km²');
 	});
 
 	it('provides formatted distance for bvv-metric system with default-locales (en)', () => {
@@ -54,19 +54,19 @@ describe('Units provider', () => {
 	});
 
 	it('provides formatted area for bvv-metric system with default-locales (en)', () => {
-		expect(bvvAreaUnitsProvider(0, 0)).toBe('0 m&sup2;');
-		expect(bvvAreaUnitsProvider(0.3, 0)).toBe('0 m&sup2;');
-		expect(bvvAreaUnitsProvider(0.6, 0)).toBe('1 m&sup2;');
-		expect(bvvAreaUnitsProvider(42, 0)).toBe('42 m&sup2;');
-		expect(bvvAreaUnitsProvider(999, 0)).toBe('999 m&sup2;');
-		expect(bvvAreaUnitsProvider(1000000, 0)).toBe('1.000 km&sup2;');
-		expect(bvvAreaUnitsProvider(1234567, 0)).toBe('1.230 km&sup2;');
-		expect(bvvAreaUnitsProvider(1234567, 2)).toBe('1.230 km&sup2;');
-		expect(bvvAreaUnitsProvider(100000, 0)).toBe('100,000 m&sup2;');
-		expect(bvvAreaUnitsProvider(12345, 0)).toBe('12,345 m&sup2;');
-		expect(bvvAreaUnitsProvider(12345, 2)).toBe('12,345 m&sup2;');
-		expect(bvvAreaUnitsProvider(10000000, 0)).toBe('10.000 km&sup2;');
-		expect(bvvAreaUnitsProvider(1234567891234, 2)).toBe('1,234,567.890 km&sup2;');
+		expect(bvvAreaUnitsProvider(0, 0)).toBe('0 m²');
+		expect(bvvAreaUnitsProvider(0.3, 0)).toBe('0 m²');
+		expect(bvvAreaUnitsProvider(0.6, 0)).toBe('1 m²');
+		expect(bvvAreaUnitsProvider(42, 0)).toBe('42 m²');
+		expect(bvvAreaUnitsProvider(999, 0)).toBe('999 m²');
+		expect(bvvAreaUnitsProvider(1000000, 0)).toBe('1.000 km²');
+		expect(bvvAreaUnitsProvider(1234567, 0)).toBe('1.230 km²');
+		expect(bvvAreaUnitsProvider(1234567, 2)).toBe('1.230 km²');
+		expect(bvvAreaUnitsProvider(100000, 0)).toBe('100,000 m²');
+		expect(bvvAreaUnitsProvider(12345, 0)).toBe('12,345 m²');
+		expect(bvvAreaUnitsProvider(12345, 2)).toBe('12,345 m²');
+		expect(bvvAreaUnitsProvider(10000000, 0)).toBe('10.000 km²');
+		expect(bvvAreaUnitsProvider(1234567891234, 2)).toBe('1,234,567.890 km²');
 	});
 
 	it('provides formatted distance for bvv-metric system with de-locales', () => {
@@ -86,19 +86,19 @@ describe('Units provider', () => {
 
 	it('provides formatted area for bvv-metric system with de-locales', () => {
 		spyOn(configService, 'getValue').withArgs('DEFAULT_LANG', 'en').and.returnValue('de');
-		expect(bvvAreaUnitsProvider(0, 0)).toBe('0 m&sup2;');
-		expect(bvvAreaUnitsProvider(0.3, 0)).toBe('0 m&sup2;');
-		expect(bvvAreaUnitsProvider(0.6, 0)).toBe('1 m&sup2;');
-		expect(bvvAreaUnitsProvider(42, 0)).toBe('42 m&sup2;');
-		expect(bvvAreaUnitsProvider(999, 0)).toBe('999 m&sup2;');
-		expect(bvvAreaUnitsProvider(1000000, 0)).toBe('1,000 km&sup2;');
-		expect(bvvAreaUnitsProvider(1234567, 0)).toBe('1,230 km&sup2;');
-		expect(bvvAreaUnitsProvider(1234567, 2)).toBe('1,230 km&sup2;');
-		expect(bvvAreaUnitsProvider(100000, 0)).toBe('100.000 m&sup2;');
-		expect(bvvAreaUnitsProvider(12345, 0)).toBe('12.345 m&sup2;');
-		expect(bvvAreaUnitsProvider(12345, 2)).toBe('12.345 m&sup2;');
-		expect(bvvAreaUnitsProvider(10000000, 0)).toBe('10,000 km&sup2;');
-		expect(bvvAreaUnitsProvider(1234567891234, 2)).toBe('1.234.567,890 km&sup2;');
+		expect(bvvAreaUnitsProvider(0, 0)).toBe('0 m²');
+		expect(bvvAreaUnitsProvider(0.3, 0)).toBe('0 m²');
+		expect(bvvAreaUnitsProvider(0.6, 0)).toBe('1 m²');
+		expect(bvvAreaUnitsProvider(42, 0)).toBe('42 m²');
+		expect(bvvAreaUnitsProvider(999, 0)).toBe('999 m²');
+		expect(bvvAreaUnitsProvider(1000000, 0)).toBe('1,000 km²');
+		expect(bvvAreaUnitsProvider(1234567, 0)).toBe('1,230 km²');
+		expect(bvvAreaUnitsProvider(1234567, 2)).toBe('1,230 km²');
+		expect(bvvAreaUnitsProvider(100000, 0)).toBe('100.000 m²');
+		expect(bvvAreaUnitsProvider(12345, 0)).toBe('12.345 m²');
+		expect(bvvAreaUnitsProvider(12345, 2)).toBe('12.345 m²');
+		expect(bvvAreaUnitsProvider(10000000, 0)).toBe('10,000 km²');
+		expect(bvvAreaUnitsProvider(1234567891234, 2)).toBe('1.234.567,890 km²');
 	});
 
 	it('provides formatted distance for bvv-metric system with fallback-locales (en)', () => {
@@ -108,6 +108,6 @@ describe('Units provider', () => {
 
 	it('provides formatted area for bvv-metric system with fallback-locales (en)', () => {
 		spyOn(configService, 'getValue').withArgs('DEFAULT_LANG', 'en').and.returnValue('xx');
-		expect(bvvAreaUnitsProvider(1234567891234, 2)).toBe('1,234,567.890 km&sup2;');
+		expect(bvvAreaUnitsProvider(1234567891234, 2)).toBe('1,234,567.890 km²');
 	});
 });


### PR DESCRIPTION
remove usage of `&sup2;` to prevent unnecessary encode- and decode-calls 