### PR TITLE
add life-cycle logging for MvuElements

### DIFF
--- a/src/utils/markup.js
+++ b/src/utils/markup.js
@@ -11,6 +11,11 @@ export const TEST_ID_ATTRIBUTE_NAME = 'data-test-id';
 export const REGISTER_FOR_VIEWPORT_CALCULATION_ATTRIBUTE_NAME = 'data-register-for-viewport-calc';
 
 /**
+ * An element containing this attribute will be logging its lifecycle.
+ */
+export const LOG_LIFECYLE_ATTRIBUTE_NAME = 'data-log-lifecycle';
+
+/**
  * Sets the value of the `data-test-id` attribute for a MvuElement and all of its children.
  * The Test-Id is derived from the DOM hierarchy of the current MvuElement following its parent MvuElements
  *(BaElements are also supported).

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -2,6 +2,7 @@ import { render } from 'lit-html';
 import { combineReducers, createStore } from 'redux';
 import { $injector } from '../src/injection';
 import { isTemplateResult } from '../src/utils/checks';
+import { LOG_LIFECYLE_ATTRIBUTE_NAME } from '../src/utils/markup';
 
 class TestableBlob extends Blob {
 
@@ -25,15 +26,31 @@ class TestableBlob extends Blob {
 }
 export class TestUtils {
 	/**
-	 * Renders a given element with provided attributes
-	 * and returns a promise which resolves as soon as
+	 * Renders an already registered {@link HTMLElement}
+	 * and returns a promise which resolves as soon as the
 	 * rendered element becomes available.
-	 * @param {string} tag
-	 * @param {object} attributes
+	 * @param {string} tag the tag of the HTMLElement
+	 * @param {object} [attributes]
+	 * @param {object} [slotContent]
 	 * @returns {Promise<HTMLElement>}
 	 */
-	static render(tag, attributes = {}, slotContent = '') {
+	static async render(tag, attributes = {}, slotContent = '') {
 		TestUtils._renderToDocument(tag, attributes, slotContent);
+		return TestUtils._waitForComponentToRender(tag);
+	}
+
+	/**
+	 * Renders an already registered {@link HTMLElement}
+	 * and returns a promise which resolves as soon as the
+	 * rendered element becomes available.
+	 * Additionally enables logging of the elements lifecycle (if available).
+	 * @param {string} tag the tag of the MvuElement
+	 * @param {object} [attributes]
+	 * @param {object} [slotContent]
+	 * @returns {Promise<HTMLElement>}
+	 */
+	static async renderAndLogLifecycle(tag, attributes = {}, slotContent = '') {
+		TestUtils._renderToDocument(tag, { [LOG_LIFECYLE_ATTRIBUTE_NAME]: '', ...attributes }, slotContent);
 		return TestUtils._waitForComponentToRender(tag);
 	}
 

--- a/test/utils/markup.test.js
+++ b/test/utils/markup.test.js
@@ -1,7 +1,7 @@
 import { html } from 'lit-html';
 import { BaElement } from '../../src/modules/BaElement';
 import { MvuElement } from '../../src/modules/MvuElement';
-import { decodeHtmlEntities, findAllByAttribute, forEachByAttribute, REGISTER_FOR_VIEWPORT_CALCULATION_ATTRIBUTE_NAME, TEST_ID_ATTRIBUTE_NAME } from '../../src/utils/markup';
+import { decodeHtmlEntities, findAllByAttribute, forEachByAttribute, LOG_LIFECYLE_ATTRIBUTE_NAME, REGISTER_FOR_VIEWPORT_CALCULATION_ATTRIBUTE_NAME, TEST_ID_ATTRIBUTE_NAME } from '../../src/utils/markup';
 import { TestUtils } from '../test-utils';
 
 class MvuElementParent extends MvuElement {
@@ -82,6 +82,10 @@ describe('markup utils', () => {
 
 		it('provides an attribute name to register for viewport calculation', () => {
 			expect(REGISTER_FOR_VIEWPORT_CALCULATION_ATTRIBUTE_NAME).toBe('data-register-for-viewport-calc');
+		});
+
+		it('provides an attribute name to enable lifecycle logging', () => {
+			expect(LOG_LIFECYLE_ATTRIBUTE_NAME).toBe('data-log-lifecycle');
 		});
 	});
 


### PR DESCRIPTION
Add possibility to enable logging of  a components life-cycle in order to help tracing its changes of state
according to the underlying MVU pattern.

A possible result would be:
```
LOG: '📦 MvuElementImpl#constructor: {"foo":"foo","index":null}'
LOG: '🎺 MvuElementImpl#signal: "update_index", 21'
LOG: '📌 MvuElementImpl#onModelChanged: {"foo":"foo","index":21}'
LOG: '📌 MvuElementImpl#onInitialize'
LOG: '📌 MvuElementImpl#onBeforeRender'
LOG: '🧪 MvuElementImpl#render: {"foo":"foo","index":21}'
LOG: '📌 MvuElementImpl#onAfterRender'
LOG: '📌 MvuElementImpl#onDisconnect'
```
How to enable the life-cycle logging?

- during runtime / in production:  by appending the `data-log-lifecycle` attribute, e.g. `<my-element data-log-lifecycle></my-element>`
- in tests:  use `TestUtils#renderAndLogLifecycle` instead of  `TestUtils#render`
