### PR TITLE
adjust single test report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ coverage
 .env~
 nbproject
 reports
-
+console.log

--- a/karma.conf.single.js
+++ b/karma.conf.single.js
@@ -50,6 +50,8 @@ module.exports = function (config) {
 		preprocessors: {
 			'test/**/*.test.js': ['webpack']
 		},
-		browsers: [browser]
+		reporters: ['mocha', 'coverage-istanbul'],
+		browsers: [browser],
+		browserConsoleLogOptions: { level: 'debug', format: '%b %T: %m', terminal: false, path: 'console.log' }
 	});
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,6 @@
         "karma-jasmine": "5.1.0",
         "karma-junit-reporter": "2.0.1",
         "karma-script-launcher": "1.0.0",
-        "karma-spec-reporter": "0.0.34",
         "karma-webkit-launcher": "1.1.0",
         "karma-webpack": "5.0.0",
         "playwright": "1.27.1 ",
@@ -1934,15 +1933,6 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
       "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
       "dev": true
-    },
-    "node_modules/colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.1.90"
-      }
     },
     "node_modules/colorspace": {
       "version": "1.1.4",
@@ -5666,18 +5656,6 @@
       "resolved": "https://registry.npmjs.org/karma-script-launcher/-/karma-script-launcher-1.0.0.tgz",
       "integrity": "sha1-zQF8TeXvCeWp2nkydhdhCN1LVC0=",
       "dev": true,
-      "peerDependencies": {
-        "karma": ">=0.9"
-      }
-    },
-    "node_modules/karma-spec-reporter": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/karma-spec-reporter/-/karma-spec-reporter-0.0.34.tgz",
-      "integrity": "sha512-l5H/Nh9q4g2Ysx2CDU2m+NIPyLQpCVbk9c4V02BTZHw3NM6RO1dq3eRpKXCSSdPt4RGfhHk8jDt3XYkGp+5PWg==",
-      "dev": true,
-      "dependencies": {
-        "colors": "1.4.0"
-      },
       "peerDependencies": {
         "karma": ">=0.9"
       }
@@ -11263,12 +11241,6 @@
       "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
       "dev": true
     },
-    "colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "dev": true
-    },
     "colorspace": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
@@ -14071,15 +14043,6 @@
       "integrity": "sha1-zQF8TeXvCeWp2nkydhdhCN1LVC0=",
       "dev": true,
       "requires": {}
-    },
-    "karma-spec-reporter": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/karma-spec-reporter/-/karma-spec-reporter-0.0.34.tgz",
-      "integrity": "sha512-l5H/Nh9q4g2Ysx2CDU2m+NIPyLQpCVbk9c4V02BTZHw3NM6RO1dq3eRpKXCSSdPt4RGfhHk8jDt3XYkGp+5PWg==",
-      "dev": true,
-      "requires": {
-        "colors": "1.4.0"
-      }
     },
     "karma-webkit-launcher": {
       "version": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "karma-iframes": "1.3.1",
         "karma-jasmine": "5.1.0",
         "karma-junit-reporter": "2.0.1",
+        "karma-mocha-reporter": "2.2.5",
         "karma-script-launcher": "1.0.0",
         "karma-webkit-launcher": "1.1.0",
         "karma-webpack": "5.0.0",
@@ -5651,6 +5652,41 @@
         "karma": ">=0.9"
       }
     },
+    "node_modules/karma-mocha-reporter": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/karma-mocha-reporter/-/karma-mocha-reporter-2.2.5.tgz",
+      "integrity": "sha512-Hr6nhkIp0GIJJrvzY8JFeHpQZNseuIakGac4bpw8K1+5F0tLb6l7uvXRa8mt2Z+NVwYgCct4QAfp2R2QP6o00w==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.1.0",
+        "log-symbols": "^2.1.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "peerDependencies": {
+        "karma": ">=0.13"
+      }
+    },
+    "node_modules/karma-mocha-reporter/node_modules/ansi-regex": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/karma-mocha-reporter/node_modules/strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/karma-script-launcher": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/karma-script-launcher/-/karma-script-launcher-1.0.0.tgz",
@@ -5906,6 +5942,18 @@
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
       "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
       "dev": true
+    },
+    "node_modules/log-symbols": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/log4js": {
       "version": "6.4.1",
@@ -14037,6 +14085,34 @@
         "xmlbuilder": "12.0.0"
       }
     },
+    "karma-mocha-reporter": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/karma-mocha-reporter/-/karma-mocha-reporter-2.2.5.tgz",
+      "integrity": "sha512-Hr6nhkIp0GIJJrvzY8JFeHpQZNseuIakGac4bpw8K1+5F0tLb6l7uvXRa8mt2Z+NVwYgCct4QAfp2R2QP6o00w==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.1.0",
+        "log-symbols": "^2.1.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+          "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
     "karma-script-launcher": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/karma-script-launcher/-/karma-script-launcher-1.0.0.tgz",
@@ -14197,6 +14273,15 @@
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
       "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
       "dev": true
+    },
+    "log-symbols": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1"
+      }
     },
     "log4js": {
       "version": "6.4.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "karma-jasmine": "5.1.0",
     "karma-junit-reporter": "2.0.1",
     "karma-script-launcher": "1.0.0",
-    "karma-spec-reporter": "0.0.34",
     "karma-webkit-launcher": "1.1.0",
     "karma-webpack": "5.0.0",
     "playwright": "1.27.1 ",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "karma-iframes": "1.3.1",
     "karma-jasmine": "5.1.0",
     "karma-junit-reporter": "2.0.1",
+    "karma-mocha-reporter": "2.2.5",
     "karma-script-launcher": "1.0.0",
     "karma-webkit-launcher": "1.1.0",
     "karma-webpack": "5.0.0",


### PR DESCRIPTION
Use a reporter for mocha-style logging (https://github.com/litixsoft/karma-mocha-reporter) and redirect all console output to the dedicated file `console.log`.  Affects only the single-test mode.

Background:
By separating the test report from the console output,  we get a better overview of the current test setup on one hand, on the other hand, we have a clean and duplicate-free view of all console log statements.

Examples:
- Test report
![grafik](https://user-images.githubusercontent.com/49945713/205860276-561ec450-c75b-44be-a179-534455e02ecc.png)

- console.log:
![grafik](https://user-images.githubusercontent.com/49945713/205860434-01158e4b-0644-449c-99e4-2878d86a94eb.png)
