### PR TITLE
OlMap: prevent double calls of map actions

### DIFF
--- a/src/modules/olMap/components/OlMap.js
+++ b/src/modules/olMap/components/OlMap.js
@@ -135,6 +135,7 @@ export class OlMap extends MvuElement {
 		});
 
 		this._map.on('movestart', () => {
+			this._viewSyncBlocked = true;
 			setMoveStart();
 			setBeingMoved(true);
 		});
@@ -146,6 +147,9 @@ export class OlMap extends MvuElement {
 			setBeingDragged(false);
 			setMoveEnd();
 			setBeingMoved(false);
+			setTimeout(() => {
+				this._viewSyncBlocked = false;
+			});
 		});
 
 		const singleClickOrShortPressHandler = (evt) => {

--- a/test/modules/olMap/components/OlMap.test.js
+++ b/test/modules/olMap/components/OlMap.test.js
@@ -373,8 +373,7 @@ describe('OlMap', () => {
 				simulateMapEvent(element._map, MapEventType.MOVEEND);
 
 				expect(store.getState().map.moveEnd.payload).toBe('moveend');
-				await TestUtils.timeout();
-				expect(element._viewSyncBlocked).toBeFalse();
+				await expectAsync(TestUtils.waitFor(() => element._viewSyncBlocked === false)).toBeResolved();
 			});
 
 			it('updates the position state properties', async () => {
@@ -749,10 +748,8 @@ describe('OlMap', () => {
 			expect(store.getState().position.fitRequest).not.toBeNull();
 			expect(viewSpy).toHaveBeenCalledOnceWith(extent, { maxZoom: view.getMaxZoom(), callback: jasmine.anything(), padding: [10 + OlMap.DEFAULT_PADDING_PX[0], 20 + OlMap.DEFAULT_PADDING_PX[1], 30 + OlMap.DEFAULT_PADDING_PX[2], 40 + OlMap.DEFAULT_PADDING_PX[3]] });
 			expect(element._viewSyncBlocked).toBeTrue();
-
-			await TestUtils.timeout();
 			//check if flag is reset
-			expect(element._viewSyncBlocked).toBeFalse();
+			await expectAsync(TestUtils.waitFor(() => element._viewSyncBlocked === false)).toBeResolved();
 			//and store is in sync with view
 			expect(spy).toHaveBeenCalled();
 		});
@@ -774,9 +771,8 @@ describe('OlMap', () => {
 			expect(store.getState().position.fitRequest).not.toBeNull();
 			expect(viewSpy).toHaveBeenCalledOnceWith(extent, { maxZoom: maxZoom, callback: jasmine.anything(), padding: [10 + OlMap.DEFAULT_PADDING_PX[0], 20 + OlMap.DEFAULT_PADDING_PX[1], 30 + OlMap.DEFAULT_PADDING_PX[2], 40 + OlMap.DEFAULT_PADDING_PX[3]] });
 			expect(element._viewSyncBlocked).toBeTrue();
-			await TestUtils.timeout();
 			//check if flag is reset
-			expect(element._viewSyncBlocked).toBeFalse();
+			await expectAsync(TestUtils.waitFor(() => element._viewSyncBlocked === false)).toBeResolved();
 			//and store is in sync with view
 			expect(spy).toHaveBeenCalled();
 		});
@@ -795,9 +791,8 @@ describe('OlMap', () => {
 			expect(store.getState().position.fitRequest).not.toBeNull();
 			expect(viewSpy).toHaveBeenCalledOnceWith(extent, { maxZoom: view.getMaxZoom(), callback: jasmine.anything(), padding: OlMap.DEFAULT_PADDING_PX });
 			expect(element._viewSyncBlocked).toBeTrue();
-			await TestUtils.timeout();
 			//check if flag is reset
-			expect(element._viewSyncBlocked).toBeFalse();
+			await expectAsync(TestUtils.waitFor(() => element._viewSyncBlocked === false)).toBeResolved();
 			//and store is in sync with view
 			expect(spy).toHaveBeenCalled();
 		});
@@ -822,10 +817,8 @@ describe('OlMap', () => {
 			expect(store.getState().position.fitLayerRequest.payload).not.toBeNull();
 			expect(viewSpy).toHaveBeenCalledOnceWith(extent, { maxZoom: view.getMaxZoom(), callback: jasmine.anything(), padding: [10 + OlMap.DEFAULT_PADDING_PX[0], 20 + OlMap.DEFAULT_PADDING_PX[1], 30 + OlMap.DEFAULT_PADDING_PX[2], 40 + OlMap.DEFAULT_PADDING_PX[3]] });
 			expect(element._viewSyncBlocked).toBeTrue();
-
-			await TestUtils.timeout();
 			//check if flag is reset
-			expect(element._viewSyncBlocked).toBeFalse();
+			await expectAsync(TestUtils.waitFor(() => element._viewSyncBlocked === false)).toBeResolved();
 			//and store is in sync with view
 			expect(spy).toHaveBeenCalled();
 		});
@@ -851,10 +844,8 @@ describe('OlMap', () => {
 			expect(store.getState().position.fitLayerRequest.payload).not.toBeNull();
 			expect(viewSpy).toHaveBeenCalledOnceWith(extent, { maxZoom: maxZoom, callback: jasmine.anything(), padding: [10 + OlMap.DEFAULT_PADDING_PX[0], 20 + OlMap.DEFAULT_PADDING_PX[1], 30 + OlMap.DEFAULT_PADDING_PX[2], 40 + OlMap.DEFAULT_PADDING_PX[3]] });
 			expect(element._viewSyncBlocked).toBeTrue();
-
-			await TestUtils.timeout();
 			//check if flag is reset
-			expect(element._viewSyncBlocked).toBeFalse();
+			await expectAsync(TestUtils.waitFor(() => element._viewSyncBlocked === false)).toBeResolved();
 			//and store is in sync with view
 			expect(spy).toHaveBeenCalled();
 		});
@@ -878,10 +869,8 @@ describe('OlMap', () => {
 			expect(store.getState().position.fitLayerRequest.payload).not.toBeNull();
 			expect(viewSpy).toHaveBeenCalledOnceWith(extent, { maxZoom: view.getMaxZoom(), callback: jasmine.anything(), padding: OlMap.DEFAULT_PADDING_PX });
 			expect(element._viewSyncBlocked).toBeTrue();
-
-			await TestUtils.timeout();
 			//check if flag is reset
-			expect(element._viewSyncBlocked).toBeFalse();
+			await expectAsync(TestUtils.waitFor(() => element._viewSyncBlocked === false)).toBeResolved();
 			//and store is in sync with view
 			expect(spy).toHaveBeenCalled();
 		});

--- a/test/modules/olMap/components/OlMap.test.js
+++ b/test/modules/olMap/components/OlMap.test.js
@@ -342,9 +342,12 @@ describe('OlMap', () => {
 			it('updates the \'movestart\' property in map store', async () => {
 				const element = await setup();
 
+				expect(element._viewSyncBlocked).toBeUndefined();
+
 				simulateMapEvent(element._map, MapEventType.MOVESTART);
 
 				expect(store.getState().map.moveStart.payload).toBe('movestart');
+				expect(element._viewSyncBlocked).toBeTrue();
 			});
 
 			it('updates the \'beingMoved\' property in pointer store', async () => {
@@ -365,9 +368,13 @@ describe('OlMap', () => {
 			it('updates the \'moveend\' property in map store', async () => {
 				const element = await setup();
 
+				expect(element._viewSyncBlocked).toBeUndefined();
+
 				simulateMapEvent(element._map, MapEventType.MOVEEND);
 
 				expect(store.getState().map.moveEnd.payload).toBe('moveend');
+				await TestUtils.timeout();
+				expect(element._viewSyncBlocked).toBeFalse();
 			});
 
 			it('updates the position state properties', async () => {

--- a/test/modules/olMap/components/OlMap.test.js
+++ b/test/modules/olMap/components/OlMap.test.js
@@ -978,18 +978,15 @@ describe('OlMap', () => {
 			addLayer(id0, { geoResourceId: geoResourceId0 });
 			fitLayer(id0);
 
-			// we have to wait for two timeout calls!
-			await TestUtils.timeout();
-			await TestUtils.timeout();
+			// we would have to wait for a couple of timeout calls, so to simply that we wait until the expected state is available
+			await expectAsync(TestUtils.waitFor(() => element._viewSyncBlocked === true)).toBeResolved();
 
 			expect(store.getState().position.fitLayerRequest.payload).not.toBeNull();
 			expect(viewSpy).toHaveBeenCalledOnceWith(extent, { maxZoom: view.getMaxZoom(), callback: jasmine.anything(), padding: [10 + OlMap.DEFAULT_PADDING_PX[0], 20 + OlMap.DEFAULT_PADDING_PX[1], 30 + OlMap.DEFAULT_PADDING_PX[2], 40 + OlMap.DEFAULT_PADDING_PX[3]] });
-			expect(element._viewSyncBlocked).toBeTrue();
 
-			await TestUtils.timeout();
-			//check if flag is reset
-			expect(element._viewSyncBlocked).toBeFalse();
-			//and store is in sync with view
+			// we would have to wait for a couple of timeout calls, so to simply that we wait until the expected state is available
+			await expectAsync(TestUtils.waitFor(() => element._viewSyncBlocked === false)).toBeResolved();
+			// store is in sync with view
 			expect(spy).toHaveBeenCalled();
 		});
 	});

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -239,10 +239,10 @@ export class TestUtils {
 	 * Returns a Promise that either resolves as soon as the check is successful or rejects
 	 * when the amount of time defined by the timeout argument passed
 	 * @param {Function} checkFn the check function. Must return `true` to resolve the Promise
-	 * @param {Number} ms timeout in ms. Default is `1000`
+	 * @param {Number} timeout timeout in ms. Default is `1000`
 	 * @returns {Promise}
 	 */
-	static async waitFor(checkFn, ms = 1000) {
+	static async waitFor(checkFn, timeout = 1000) {
 
 		return new Promise((resolve, reject) => {
 			const intervallId = setInterval(() => {
@@ -252,7 +252,7 @@ export class TestUtils {
 					resolve();
 				}
 			}, 10);
-			const timeOutId = setTimeout(reject, ms);
+			const timeOutId = setTimeout(reject, timeout);
 		});
 	}
 

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -235,4 +235,25 @@ export class TestUtils {
 		return new Promise(resolve => setTimeout(resolve, ms));
 	}
 
+	/**
+	 * Returns a Promise that resolves as soon as the check is successful or rejects
+	 * when the amount of time defined by the timeout argument passed
+	 * @param {Function} checkFn the check function. Must return `true` to resolve the Promise
+	 * @param {Number} ms timeout in ms. Default is `1000`
+	 * @returns {Promise}
+	 */
+	static async waitFor(checkFn, ms = 1000) {
+
+		return new Promise((resolve, reject) => {
+			const intervallId = setInterval(() => {
+				if (checkFn()) {
+					clearInterval(intervallId);
+					clearTimeout(timeOutId);
+					resolve();
+				}
+			}, 10);
+			const timeOutId = setTimeout(reject, ms);
+		});
+	}
+
 }

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -252,7 +252,7 @@ export class TestUtils {
 					resolve();
 				}
 			}, 10);
-			const timeOutId = setTimeout(reject, timeout);
+			const timeOutId = setTimeout(() => reject(`Aborted TestUtils#waitFor due to timeout of ${timeout}ms`), timeout);
 		});
 	}
 

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -236,7 +236,7 @@ export class TestUtils {
 	}
 
 	/**
-	 * Returns a Promise that resolves as soon as the check is successful or rejects
+	 * Returns a Promise that either resolves as soon as the check is successful or rejects
 	 * when the amount of time defined by the timeout argument passed
 	 * @param {Function} checkFn the check function. Must return `true` to resolve the Promise
 	 * @param {Number} ms timeout in ms. Default is `1000`

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -239,10 +239,10 @@ export class TestUtils {
 	 * Returns a Promise that either resolves as soon as the check is successful or rejects
 	 * when the amount of time defined by the timeout argument passed
 	 * @param {Function} checkFn the check function. Must return `true` to resolve the Promise
-	 * @param {Number} timeout timeout in ms. Default is `1000`
+	 * @param {Number} timeout timeout in ms. Default is `3000`
 	 * @returns {Promise}
 	 */
-	static async waitFor(checkFn, timeout = 1000) {
+	static async waitFor(checkFn, timeout = 3000) {
 
 		return new Promise((resolve, reject) => {
 			const clear = () => {

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -245,14 +245,20 @@ export class TestUtils {
 	static async waitFor(checkFn, timeout = 1000) {
 
 		return new Promise((resolve, reject) => {
+			const clear = () => {
+				clearInterval(intervallId);
+				clearTimeout(timeOutId);
+			};
 			const intervallId = setInterval(() => {
 				if (checkFn()) {
-					clearInterval(intervallId);
-					clearTimeout(timeOutId);
+					clear();
 					resolve();
 				}
 			}, 10);
-			const timeOutId = setTimeout(() => reject(`Aborted TestUtils#waitFor due to timeout of ${timeout}ms`), timeout);
+			const timeOutId = setTimeout(() => {
+				clear();
+				reject(`Aborted TestUtils#waitFor due to timeout of ${timeout}ms`);
+			}, timeout);
 		});
 	}
 


### PR DESCRIPTION
Prevent double calls of map actions (movestart, moving, moveend).