### PR TITLE
revert order of attributions

### DIFF
--- a/src/modules/map/components/attributionInfo/AttributionInfo.js
+++ b/src/modules/map/components/attributionInfo/AttributionInfo.js
@@ -50,7 +50,8 @@ export class AttributionInfo extends MvuElement {
 			.map(l => this._georesourceService.byId(l.geoResourceId)?.getAttribution(zoomLevel))
 			//remove null 'attr'
 			.filter(attr => !!attr)
-			.flat();
+			.flat()
+			.reverse();
 
 		// make attributions unique by 'label'
 		const labels = rawAttributions.map(a => a?.copyright?.label); //attr.copyright.label should be guaranteed

--- a/test/modules/map/components/attributionInfo/AttributionInfo.test.js
+++ b/test/modules/map/components/attributionInfo/AttributionInfo.test.js
@@ -68,8 +68,8 @@ describe('AttributionInfo', () => {
 			const attributions = element._getAttributions(layer, 5);
 
 			expect(attributions).toHaveSize(2);
-			expect(attributions[0].copyright.label).toBe('foo_5');
-			expect(attributions[1].copyright.label).toBe('bar_5');
+			expect(attributions[0].copyright.label).toBe('bar_5');
+			expect(attributions[1].copyright.label).toBe('foo_5');
 		});
 	});
 
@@ -135,7 +135,7 @@ describe('AttributionInfo', () => {
 
 			// we expect two kinds of attribution: a <span> containing a plain string and two <a> elements
 			expect(element.shadowRoot.querySelectorAll('span.attribution')).toHaveSize(1);
-			expect(element.shadowRoot.querySelector('span.attribution').innerText).toBe(layerId0 + ','); //should contain also a separator
+			expect(element.shadowRoot.querySelector('span.attribution').innerText).toBe(layerId0);
 
 			expect(element.shadowRoot.querySelector('.attribution-container').innerText).toContain('© map_attributionInfo_label');
 			expect(element.shadowRoot.querySelectorAll('a.attribution.attribution-link')).toHaveSize(2);
@@ -144,7 +144,7 @@ describe('AttributionInfo', () => {
 			expect(element.shadowRoot.querySelectorAll('a.attribution.attribution-link')[0].innerText).toBe(layerId1 + ',');
 			expect(element.shadowRoot.querySelectorAll('a.attribution.attribution-link')[1].href).toBe(url2);
 			expect(element.shadowRoot.querySelectorAll('a.attribution.attribution-link')[1].target).toBe('_blank');
-			expect(element.shadowRoot.querySelectorAll('a.attribution.attribution-link')[1].innerText).toBe(layerId1 + '_2');
+			expect(element.shadowRoot.querySelectorAll('a.attribution.attribution-link')[1].innerText).toBe(layerId1 + '_2' + ','); //should contain also a separator
 
 			expect(element.shadowRoot.querySelectorAll('.collapse-button')).toHaveSize(1);
 		});

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -239,10 +239,10 @@ export class TestUtils {
 	 * Returns a Promise that either resolves as soon as the check is successful or rejects
 	 * when the amount of time defined by the timeout argument passed
 	 * @param {Function} checkFn the check function. Must return `true` to resolve the Promise
-	 * @param {Number} timeout timeout in ms. Default is `3000`
+	 * @param {Number} timeout timeout in ms. Default is `5000`
 	 * @returns {Promise}
 	 */
-	static async waitFor(checkFn, timeout = 3000) {
+	static async waitFor(checkFn, timeout = 5000) {
 
 		return new Promise((resolve, reject) => {
 			const clear = () => {


### PR DESCRIPTION
The order of attributions should basically reflect the order of map layers now.

Resolves #1345

![grafik](https://user-images.githubusercontent.com/49945713/207066349-2b350bc4-2b9a-4614-95a1-76a297e49e37.png)
