### PR TITLE
Attribution data: adjust to backend changes

### DIFF
--- a/src/domain/geoResources.js
+++ b/src/domain/geoResources.js
@@ -3,7 +3,7 @@ import { getDefaultAttribution } from '../services/provider/attribution.provider
 
 /**
  * Attribution data of a GeoResource.
- * It contains at least a copyright label.
+ * Usually it contains at least a copyright label.
  * @typedef Attribution
  * @property {Copyright|Array<Copyright>|null} copyright
  * @property {string} [description] description

--- a/src/domain/geoResources.js
+++ b/src/domain/geoResources.js
@@ -5,7 +5,7 @@ import { getDefaultAttribution } from '../services/provider/attribution.provider
  * Attribution data of a GeoResource.
  * It contains at least a copyright label.
  * @typedef Attribution
- * @property {Copyright|Array<Copyright>} copyright
+ * @property {Copyright|Array<Copyright>|null} copyright
  * @property {string} [description] description
  */
 

--- a/src/domain/geoResources.js
+++ b/src/domain/geoResources.js
@@ -151,7 +151,7 @@ export class GeoResource {
 
 	/**
 	 * Sets the attribution for this GeoResource.
-	 * @param {Attribution|string|null} attribution
+	 * @param {Attribution|Array<Attribution>|string|null} attribution
 	 * @returns `this` for chaining
 	 */
 	setAttribution(attribution) {

--- a/src/modules/map/components/attributionInfo/AttributionInfo.js
+++ b/src/modules/map/components/attributionInfo/AttributionInfo.js
@@ -53,7 +53,7 @@ export class AttributionInfo extends MvuElement {
 			.filter(attr => !!attr)
 			.flat()
 			.reverse()
-			.map(attr => Array.isArray(attr.copyright) ? attr.copyright : [attr?.copyright]) // copyright property may be an array
+			.map(attr => Array.isArray(attr.copyright) ? attr.copyright : [attr?.copyright]) // copyright property may be an array or null
 			.flat()
 			//remove null/undefined
 			.filter(copyr => !!copyr);

--- a/src/services/provider/geoResource.provider.js
+++ b/src/services/provider/geoResource.provider.js
@@ -95,28 +95,14 @@ export const _parseBvvAttributionDefinition = (definition) => {
 	if (Array.isArray(definition.extendedAttributions)) {
 		return definition
 			.extendedAttributions
-			.map(extAtt => {
-				//supplement each attribution with basic attribution values if needed
-				return {
-					copyright: {
-						label: extAtt.copyright ?? definition?.attribution?.copyright ?? null,
-						url: extAtt.href ?? definition?.attribution?.href ?? null
-					},
+			.map(extAtt =>
+				({
+					copyright: extAtt.copyright ?? definition?.attribution?.copyright ?? null,
 					description: extAtt.description ?? definition?.attribution?.description ?? null
-				};
-			});
+				})
+			);
 	}
-	else if (definition.attribution) {
-		const { description, copyright, href } = definition.attribution;
-		return [{
-			copyright: {
-				label: copyright,
-				url: href
-			},
-			description: description
-		}];
-	}
-	return null;
+	return definition.attribution ?? null;
 };
 
 /**

--- a/test/modules/map/components/attributionInfo/AttributionInfo.test.js
+++ b/test/modules/map/components/attributionInfo/AttributionInfo.test.js
@@ -17,8 +17,8 @@ describe('AttributionInfo', () => {
 		byId: () => { }
 	};
 	const mapServiceMock = {
-		getMinZoomLevel: () => {},
-		getMaxZoomLevel: () => {}
+		getMinZoomLevel: () => { },
+		getMaxZoomLevel: () => { }
 	};
 
 	const setup = (state) => {
@@ -35,7 +35,7 @@ describe('AttributionInfo', () => {
 	};
 
 
-	describe('_getAttributions', () => {
+	describe('_getCopyrights', () => {
 
 		it('return a set of valid attributions', async () => {
 
@@ -44,9 +44,14 @@ describe('AttributionInfo', () => {
 					case '0':
 						return new XyzGeoResource(geoResourceId, '', '').setAttributionProvider((geoResourceId, zoomLevel) => getMinimalAttribution(`foo_${zoomLevel}`));
 					case '1':
-						return new XyzGeoResource(geoResourceId, '', '').setAttributionProvider((geoResourceId, zoomLevel) => getMinimalAttribution(`foo_${zoomLevel}`));
+						return new XyzGeoResource(geoResourceId, '', '').setAttributionProvider((geoResourceId, zoomLevel) => ({
+							copyright: [
+								{ label: `foo_${zoomLevel}` },
+								{ label: `bar_${zoomLevel}` }
+							]
+						}));
 					case '2':
-						return new XyzGeoResource(geoResourceId, '', '').setAttributionProvider((geoResourceId, zoomLevel) => [getMinimalAttribution(`foo_${zoomLevel}`)]);
+						return new XyzGeoResource(geoResourceId, '', '').setAttributionProvider((geoResourceId, zoomLevel) => [getMinimalAttribution(`foo_${zoomLevel}`), getMinimalAttribution(`foo_${zoomLevel}`)]);
 					case '3':
 						return new XyzGeoResource(geoResourceId, '', '').setAttributionProvider(() => null);
 					case '4':
@@ -65,11 +70,11 @@ describe('AttributionInfo', () => {
 			];
 
 			const element = await setup();
-			const attributions = element._getAttributions(layer, 5);
+			const copyrights = element._getCopyrights(layer, 5);
 
-			expect(attributions).toHaveSize(2);
-			expect(attributions[0].copyright.label).toBe('bar_5');
-			expect(attributions[1].copyright.label).toBe('foo_5');
+			expect(copyrights).toHaveSize(2);
+			expect(copyrights[0].label).toBe('bar_5');
+			expect(copyrights[1].label).toBe('foo_5');
 		});
 	});
 

--- a/test/modules/map/components/attributionInfo/AttributionInfo.test.js
+++ b/test/modules/map/components/attributionInfo/AttributionInfo.test.js
@@ -44,6 +44,7 @@ describe('AttributionInfo', () => {
 					case '0':
 						return new XyzGeoResource(geoResourceId, '', '').setAttributionProvider((geoResourceId, zoomLevel) => getMinimalAttribution(`foo_${zoomLevel}`));
 					case '1':
+						//array of copyright
 						return new XyzGeoResource(geoResourceId, '', '').setAttributionProvider((geoResourceId, zoomLevel) => ({
 							copyright: [
 								{ label: `foo_${zoomLevel}` },
@@ -51,12 +52,18 @@ describe('AttributionInfo', () => {
 							]
 						}));
 					case '2':
+						// array of attribution
 						return new XyzGeoResource(geoResourceId, '', '').setAttributionProvider((geoResourceId, zoomLevel) => [getMinimalAttribution(`foo_${zoomLevel}`), getMinimalAttribution(`foo_${zoomLevel}`)]);
 					case '3':
+						// attribution is null
 						return new XyzGeoResource(geoResourceId, '', '').setAttributionProvider(() => null);
 					case '4':
-						return new XyzGeoResource(geoResourceId, '', '').setAttributionProvider((geoResourceId, zoomLevel) => getMinimalAttribution(`bar_${zoomLevel}`));
+						// copyright is null
+						return new XyzGeoResource(geoResourceId, '', '').setAttributionProvider(() => ({ copyright: null }));
 					case '5':
+						return new XyzGeoResource(geoResourceId, '', '').setAttributionProvider((geoResourceId, zoomLevel) => getMinimalAttribution(`bar_${zoomLevel}`));
+					case '6':
+						// layer is not visisble
 						return new XyzGeoResource(geoResourceId, '', '').setAttributionProvider((geoResourceId, zoomLevel) => getMinimalAttribution(`not_visible_${zoomLevel}`));
 				}
 			});
@@ -66,7 +73,8 @@ describe('AttributionInfo', () => {
 				{ ...createDefaultLayerProperties(), id: 'id2', geoResourceId: '2' },
 				{ ...createDefaultLayerProperties(), id: 'id3', geoResourceId: '3' },
 				{ ...createDefaultLayerProperties(), id: 'id4', geoResourceId: '4' },
-				{ ...createDefaultLayerProperties(), id: 'id5', geoResourceId: '5', visible: false }
+				{ ...createDefaultLayerProperties(), id: 'id4', geoResourceId: '5' },
+				{ ...createDefaultLayerProperties(), id: 'id5', geoResourceId: '6', visible: false }
 			];
 
 			const element = await setup();

--- a/test/service/provider/geoResource.provider.test.js
+++ b/test/service/provider/geoResource.provider.test.js
@@ -164,40 +164,35 @@ describe('BVV GeoResource provider', () => {
 
 	describe('_parseBvvAttributionDefinition', () => {
 
-		it('it returns null when basic attribution definition is missing', () => {
+		it('returns null when basic attribution definition is missing', () => {
 
 			const result = _parseBvvAttributionDefinition({});
 
 			expect(result).toBeNull();
 		});
 
-		it('it parses a basic attribution definition', () => {
+		it('parses a basic attribution definition', () => {
 
 			const attribution = {
-				copyright: {
+				copyright: [{
 					label: 'label',
 					url: 'url'
-				},
+				}],
 				description: 'description'
 			};
-			const attributionDefinition = {
-				attribution: {
-					copyright: attribution.copyright.label,
-					href: attribution.copyright.url,
-					description: attribution.description
-				}
-			};
-			const result = _parseBvvAttributionDefinition(attributionDefinition);
+			const result = _parseBvvAttributionDefinition({ attribution });
 
-			expect(result).toEqual([attribution]);
+			expect(result).toEqual(attribution);
 		});
 
-		it('it parses extended attribution definitions', () => {
+		it('parses extended attribution definitions', () => {
 
 			const attributionDefinition = {
 				attribution: {
-					copyright: 'label',
-					href: 'url',
+					copyright: [{
+						label: 'label',
+						url: 'url'
+					}],
 					description: 'description'
 				},
 				extendedAttributions: [
@@ -205,8 +200,10 @@ describe('BVV GeoResource provider', () => {
 
 					},
 					{
-						copyright: 'label1',
-						href: 'url1',
+						copyright: [{
+							label: 'label1',
+							url: 'url1'
+						}],
 						description: 'description1'
 					},
 					{
@@ -220,31 +217,31 @@ describe('BVV GeoResource provider', () => {
 			expect(result.length).toBe(3);
 			//completely from basic attribution definition
 			expect(result[0]).toEqual({
-				copyright: {
+				copyright: [{
 					label: 'label',
 					url: 'url'
-				},
+				}],
 				description: 'description'
 			});
 			//completely from extended attribution definition
 			expect(result[1]).toEqual({
-				copyright: {
+				copyright: [{
 					label: 'label1',
 					url: 'url1'
-				},
+				}],
 				description: 'description1'
 			});
 			//partially from extended attribution definition
 			expect(result[2]).toEqual({
-				copyright: {
+				copyright: [{
 					label: 'label',
 					url: 'url'
-				},
+				}],
 				description: 'description2'
 			});
 		});
 
-		it('it set extended attribution properties to NULL when not available', () => {
+		it('sets extended attribution properties to NULL when not available', () => {
 
 			const attributionDefinition = {
 				attribution: {
@@ -259,10 +256,7 @@ describe('BVV GeoResource provider', () => {
 
 			expect(result.length).toBe(1);
 			expect(result[0]).toEqual({
-				copyright: {
-					label: null,
-					url: null
-				},
+				copyright: null,
 				description: null
 			});
 

--- a/test/service/provider/geoResource.provider.test.js
+++ b/test/service/provider/geoResource.provider.test.js
@@ -378,7 +378,7 @@ describe('BVV GeoResource provider', () => {
 			expect(geoResource.id).toBe(wmsDefinition.id);
 		});
 
-		it('rejects when type is unknwon', async () => {
+		it('rejects when type is unknown', async () => {
 			const id = 'foo';
 			const backendUrl = 'https://backend.url';
 			spyOn(configService, 'getValueAsPath').and.returnValue(backendUrl);


### PR DESCRIPTION
An `attribution` object can contain also an array of  `copyright` objects now.