### PR TITLE
load URL-based GeoResources from QueryParameters

### DIFF
--- a/src/services/GeoResourceService.js
+++ b/src/services/GeoResourceService.js
@@ -15,7 +15,7 @@
 import { $injector } from '../injection';
 import { observable, VTGeoResource, XyzGeoResource } from '../domain/geoResources';
 import { loadBvvFileStorageResourceById } from './provider/fileStorage.provider';
-import { loadBvvGeoResourceById, loadBvvGeoResources } from './provider/geoResource.provider';
+import { loadBvvGeoResourceById, loadBvvGeoResources, loadGeoResourceByUrlBasedId } from './provider/geoResource.provider';
 import { geoResourceChanged } from '../store/layers/layers.action';
 
 export const FALLBACK_GEORESOURCE_ID_0 = 'tpo';
@@ -44,7 +44,7 @@ export class GeoResourceService {
 	 * @param {georesourceProvider} [georesourceProvider=loadBvvGeoResources]
 	 * @param {georesourceByIdProvider} [georesourceByIdProvider=[loadBvvFileStorageResourceById, loadBvvGeoResourceById]]
 	 */
-	constructor(provider = loadBvvGeoResources, byIdProvider = [loadBvvFileStorageResourceById, loadBvvGeoResourceById]) {
+	constructor(provider = loadBvvGeoResources, byIdProvider = [loadGeoResourceByUrlBasedId, loadBvvFileStorageResourceById, loadBvvGeoResourceById]) {
 		this._provider = provider;
 		this._byIdProvider = byIdProvider;
 		this._georesources = null;

--- a/src/services/ImportVectorDataService.js
+++ b/src/services/ImportVectorDataService.js
@@ -47,7 +47,7 @@ export class ImportVectorDataService {
 	* The GeoResourceFuture is registered on the {@link GeoResourceService}.
 	* @param {string} url
 	* @param {ImportVectorDataOptions} [options]
-	* @returns VectorGeoresource  or `null` when given source type is not supported
+	* @returns GeoResourceFuture or `null` when given source type is not supported
 	*/
 	forUrl(url, options = {}) {
 		const { id, label, sourceType } = { ...this._newDefaultImportVectorDataOptions(), ...options };

--- a/src/services/ImportWmsService.js
+++ b/src/services/ImportWmsService.js
@@ -16,8 +16,8 @@ import { getAttributionProviderForGeoResourceImportedByUrl } from './provider/at
  * @typedef {Object} ImportWmsOptions
  * @property {SourceType} [sourceType] the source type
  * @property {boolean} [isAuthenticated] Whether or not the wms needs a authentication.
- * @property {Array<String>} [layers] Desired subset of layers. Other available layers will be excluded.
- * @property {Array<String>} [ids] Desired ids of the created WmsGeoResources. Only in combination with `layers`. If not set, ids will be created automatically.
+ * @property {Array<String>} [layers] Return only WmsGeoResources matching the given layer names.
+ * @property {Array<String>} [ids] Desired ids of the created WmsGeoResources. If not set, ids will be created automatically.
  */
 
 /**

--- a/src/services/ImportWmsService.js
+++ b/src/services/ImportWmsService.js
@@ -8,7 +8,7 @@ import { getAttributionProviderForGeoResourceImportedByUrl } from './provider/at
  * An async function that provides an array of {@link WmsGeoResource}s.
  *
  * @async
- * @typedef {function():(Array<WmsGeoResource>)} wmsCapabilitiesProvider
+ * @typedef {function(ImportWmsOptions):(Array<WmsGeoResource>)} wmsCapabilitiesProvider
  */
 
 /**
@@ -55,8 +55,8 @@ export class ImportWmsService {
 	 * @throws Will pass through the error of the provider
 	 */
 	async forUrl(url, options = {}) {
-		const { isAuthenticated, sourceType } = { ...this._newDefaultImportWmsOptions(), ...options };
-		const geoResources = await this._wmsCapabilitiesProvider(this._urlService.originAndPathname(url), sourceType, isAuthenticated);
+		const completeOptions = { ...this._newDefaultImportWmsOptions(), ...options };
+		const geoResources = await this._wmsCapabilitiesProvider(this._urlService.originAndPathname(url), completeOptions);
 		return geoResources
 			.map(gr => gr.setImportedByUser(true))
 			.map(gr => gr.setAttributionProvider(getAttributionProviderForGeoResourceImportedByUrl(url)))

--- a/src/services/ImportWmsService.js
+++ b/src/services/ImportWmsService.js
@@ -16,6 +16,8 @@ import { getAttributionProviderForGeoResourceImportedByUrl } from './provider/at
  * @typedef {Object} ImportWmsOptions
  * @property {SourceType} [sourceType] the source type
  * @property {boolean} [isAuthenticated] Whether or not the wms needs a authentication.
+ * @property {Array<String>} [layers] Desired subset of layers. Other available layers will be excluded.
+ * @property {Array<String>} [ids] Desired ids of the created WmsGeoResources. Only in combination with `layers`. If not set, ids will be created automatically.
  */
 
 /**
@@ -43,7 +45,9 @@ export class ImportWmsService {
 	_newDefaultImportWmsOptions() {
 		return {
 			isAuthenticated: false,
-			sourceType: new SourceType(SourceTypeName.WMS, '1.1.1')
+			sourceType: new SourceType(SourceTypeName.WMS, '1.1.1'),
+			layers: [],
+			ids: []
 		};
 	}
 

--- a/src/services/ImportWmsService.js
+++ b/src/services/ImportWmsService.js
@@ -5,6 +5,13 @@ import { bvvCapabilitiesProvider } from './provider/wmsCapabilities.provider';
 import { getAttributionProviderForGeoResourceImportedByUrl } from './provider/attribution.provider';
 
 /**
+ * An async function that provides an array of {@link WmsGeoResource}s.
+ *
+ * @async
+ * @typedef {function():(Array<WmsGeoResource>)} wmsCapabilitiesProvider
+ */
+
+/**
  *
  * @typedef {Object} ImportWmsOptions
  * @property {SourceType} [sourceType] the source type

--- a/src/services/provider/geoResource.provider.js
+++ b/src/services/provider/geoResource.provider.js
@@ -159,7 +159,7 @@ export const loadBvvGeoResourceById = id => {
 
 /**
  * Loader for URL-based ID: An URL-based ID must match the following pattern:
- * `{SourceType}`||{Url}||{extraParams0}||||{extraParams1}
+ * `{SourceType}`||{Url}||{extraParams0}||{extraParams1}
  * @function
  * @implements geoResourceByIdProvider
  * @returns {GeoResourceFuture|null}

--- a/src/services/provider/geoResource.provider.js
+++ b/src/services/provider/geoResource.provider.js
@@ -158,8 +158,14 @@ export const loadBvvGeoResourceById = id => {
 };
 
 /**
- * Loader for URL-based ID: An URL-based ID must match the following pattern:
- * `{sourceType}`||{label}||{url}||{extraParam0}||{extraParam1}
+ * Loader for URL-based ID: An URL-based ID must basically match the following pattern:
+ * `{url}||{extraParam1}||extraParam1.
+ *
+ * In detail:
+ *
+ * KML,GPX,GEOJSON,EWKT: `{url}||[{label}]`
+ *
+ * WMS: `{url}||{layer}||[{label}]`
  * @function
  * @implements geoResourceByIdProvider
  * @returns {GeoResourceFuture|null}

--- a/src/services/provider/geoResource.provider.js
+++ b/src/services/provider/geoResource.provider.js
@@ -159,7 +159,7 @@ export const loadBvvGeoResourceById = id => {
 
 /**
  * Loader for URL-based ID: An URL-based ID must match the following pattern:
- * `{SourceType}`||{Url}||{extraParams0}||{extraParams1}
+ * `{SourceType}`||{Url}||{extraParam0}||{extraParam1}
  * @function
  * @implements geoResourceByIdProvider
  * @returns {GeoResourceFuture|null}

--- a/src/services/provider/wmsCapabilities.provider.js
+++ b/src/services/provider/wmsCapabilities.provider.js
@@ -29,7 +29,8 @@ export const _determinePreferredFormat = (arr) => {
  * @implements wmsCapabilitiesProvider
  * @returns {Array<WmsGeoResource>}
  */
-export const bvvCapabilitiesProvider = async (url, sourceType, isAuthenticated) => {
+export const bvvCapabilitiesProvider = async (url, options) => {
+	const { isAuthenticated } = options;
 	const { HttpService: httpService, ConfigService: configService } = $injector.inject('HttpService', 'ConfigService');
 	const endpoint = configService.getValueAsPath('BACKEND_URL') + 'wms/getCapabilities';
 
@@ -41,7 +42,7 @@ export const bvvCapabilitiesProvider = async (url, sourceType, isAuthenticated) 
 		return isBaaAuthenticated ? GeoResourceAuthenticationType.BAA : null;
 	};
 
-	const toWmsGeoResource = (layer, capabilities, isAuthenticated = false) => {
+	const toWmsGeoResource = (layer, capabilities, isAuthenticated) => {
 		const format = _determinePreferredFormat(capabilities.formatsGetMap);
 		return format.length > 0
 			? new WmsGeoResource(

--- a/src/services/provider/wmsCapabilities.provider.js
+++ b/src/services/provider/wmsCapabilities.provider.js
@@ -42,7 +42,7 @@ export const bvvCapabilitiesProvider = async (url, options) => {
 		return isBaaAuthenticated ? GeoResourceAuthenticationType.BAA : null;
 	};
 
-	const toWmsGeoResource = (layer, capabilities) => {
+	const toWmsGeoResource = (layer, capabilities, index) => {
 		const format = _determinePreferredFormat(capabilities.formatsGetMap);
 
 		// we filter unwanted layers out
@@ -52,7 +52,7 @@ export const bvvCapabilitiesProvider = async (url, options) => {
 
 		return format.length > 0
 			? new WmsGeoResource(
-				options.ids[options.layers.indexOf(layer.name)]/** if we have an id defined for this layer */ ?? createUniqueId().toString(),
+				options.ids[index] ?? createUniqueId().toString(),
 				layer.title,
 				`${capabilities.onlineResourceGetMap}`,
 				`${layer.name}`,
@@ -68,7 +68,7 @@ export const bvvCapabilitiesProvider = async (url, options) => {
 		const containsSRID = (layer, srid) => layer.referenceSystems.some(srs => srs.code === srid);
 		return capabilities.layers
 			?.filter((l) => containsSRID(l, mapService.getSrid()))
-			.map((layer) => toWmsGeoResource(layer, capabilities))
+			.map((layer, index) => toWmsGeoResource(layer, capabilities, index))
 			.filter(l => !!l); // toWmsGeoResource may return null
 	};
 

--- a/src/services/provider/wmsCapabilities.provider.js
+++ b/src/services/provider/wmsCapabilities.provider.js
@@ -25,7 +25,10 @@ export const _determinePreferredFormat = (arr) => {
 	return sorted;
 };
 
-
+/**
+ * @implements wmsCapabilitiesProvider
+ * @returns {Array<WmsGeoResource>}
+ */
 export const bvvCapabilitiesProvider = async (url, sourceType, isAuthenticated) => {
 	const { HttpService: httpService, ConfigService: configService } = $injector.inject('HttpService', 'ConfigService');
 	const endpoint = configService.getValueAsPath('BACKEND_URL') + 'wms/getCapabilities';

--- a/src/services/provider/wmsCapabilities.provider.js
+++ b/src/services/provider/wmsCapabilities.provider.js
@@ -45,11 +45,6 @@ export const bvvCapabilitiesProvider = async (url, options) => {
 	const toWmsGeoResource = (layer, capabilities, index) => {
 		const format = _determinePreferredFormat(capabilities.formatsGetMap);
 
-		// we filter unwanted layers out
-		if (options.layers.length && !options.layers.includes(layer.name)) {
-			return null;
-		}
-
 		return format.length > 0
 			? new WmsGeoResource(
 				options.ids[index] ?? createUniqueId().toString(),
@@ -68,6 +63,8 @@ export const bvvCapabilitiesProvider = async (url, options) => {
 		const containsSRID = (layer, srid) => layer.referenceSystems.some(srs => srs.code === srid);
 		return capabilities.layers
 			?.filter((l) => containsSRID(l, mapService.getSrid()))
+			// we filter unwanted layers (if defined by WmsImportOptions)
+			.filter(layer => (options.layers.length) ? options.layers.includes(layer.name) : true)
 			.map((layer, index) => toWmsGeoResource(layer, capabilities, index))
 			.filter(l => !!l); // toWmsGeoResource may return null
 	};

--- a/test/service/GeoResourceService.test.js
+++ b/test/service/GeoResourceService.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-undef */
 import { FALLBACK_GEORESOURCE_ID_0, FALLBACK_GEORESOURCE_ID_1, FALLBACK_GEORESOURCE_ID_2, FALLBACK_GEORESOURCE_ID_3, FALLBACK_GEORESOURCE_LABEL_0, FALLBACK_GEORESOURCE_LABEL_1, FALLBACK_GEORESOURCE_LABEL_2, FALLBACK_GEORESOURCE_LABEL_3, GeoResourceService } from '../../src/services/GeoResourceService';
 import { GeoResourceFuture, VectorGeoResource, VectorSourceType, WmsGeoResource, XyzGeoResource } from '../../src/domain/geoResources';
-import { loadBvvGeoResourceById, loadBvvGeoResources, loadExampleGeoResources } from '../../src/services/provider/geoResource.provider';
+import { loadBvvGeoResourceById, loadBvvGeoResources, loadExampleGeoResources, loadGeoResourceByUrlBasedId } from '../../src/services/provider/geoResource.provider';
 import { $injector } from '../../src/injection';
 import { loadBvvFileStorageResourceById } from '../../src/services/provider/fileStorage.provider';
 import { TestUtils } from '../test-utils';
@@ -56,7 +56,7 @@ describe('GeoResourceService', () => {
 			setup(); // provide required infrastructure
 			const instanceUnderTest = new GeoResourceService();
 			expect(instanceUnderTest._provider).toEqual(loadBvvGeoResources);
-			expect(instanceUnderTest._byIdProvider).toEqual([loadBvvFileStorageResourceById, loadBvvGeoResourceById]);
+			expect(instanceUnderTest._byIdProvider).toEqual([loadGeoResourceByUrlBasedId, loadBvvFileStorageResourceById, loadBvvGeoResourceById]);
 		});
 
 		it('initializes the service with custom provider', async () => {

--- a/test/service/ImportWmsService.test.js
+++ b/test/service/ImportWmsService.test.js
@@ -49,7 +49,7 @@ describe('ImportWmsService', () => {
 			const url = 'https://some.url/wms';
 			const options = getOptions();
 			const resultMock = [];
-			const providerSpy = jasmine.createSpy('provider').withArgs(url, options.sourceType, options.isAuthenticated).and.resolveTo(resultMock);
+			const providerSpy = jasmine.createSpy('provider').withArgs(url, options).and.resolveTo(resultMock);
 			spyOn(urlService, 'originAndPathname').withArgs(url).and.returnValue(url);
 			const instanceUnderTest = new ImportWmsService(providerSpy);
 
@@ -84,7 +84,12 @@ describe('ImportWmsService', () => {
 			const url = 'https://some.url/wms';
 
 			const resultMock = [];
-			const providerSpy = jasmine.createSpy('provider').withArgs(url, jasmine.any(SourceType), false).and.resolveTo(resultMock);
+			const providerSpy = jasmine.createSpy('provider').withArgs(url, {
+				// the default options
+				isAuthenticated: false,
+				sourceType: new SourceType(SourceTypeName.WMS, '1.1.1')
+			})
+				.and.resolveTo(resultMock);
 			spyOn(urlService, 'originAndPathname').withArgs(url).and.returnValue(url);
 			const instanceUnderTest = new ImportWmsService(providerSpy);
 

--- a/test/service/ImportWmsService.test.js
+++ b/test/service/ImportWmsService.test.js
@@ -41,27 +41,32 @@ describe('ImportWmsService', () => {
 	});
 
 	describe('forUrl', () => {
-		const getOptions = () => {
-			return { isAuthenticated: false, sourceType: new SourceType(SourceTypeName.WMS, '42') };
+		const getCompleteOptions = () => {
+			return {
+				isAuthenticated: false, sourceType: new SourceType(SourceTypeName.WMS, '42'), layers: [],
+				ids: []
+			};
 		};
 
-		it('calls the provider', async () => {
+		it('calls the provider with the whole set of options', async () => {
 			const url = 'https://some.url/wms';
-			const options = getOptions();
+			const subSetOfOptions = {
+				sourceType: new SourceType(SourceTypeName.WMS, '42')
+			};
 			const resultMock = [];
-			const providerSpy = jasmine.createSpy('provider').withArgs(url, options).and.resolveTo(resultMock);
+			const providerSpy = jasmine.createSpy('provider').withArgs(url, getCompleteOptions()).and.resolveTo(resultMock);
 			spyOn(urlService, 'originAndPathname').withArgs(url).and.returnValue(url);
 			const instanceUnderTest = new ImportWmsService(providerSpy);
 
-			const result = await instanceUnderTest.forUrl(url, options);
+			const result = await instanceUnderTest.forUrl(url, subSetOfOptions);
 
 			expect(result).toEqual([]);
 			expect(providerSpy).toHaveBeenCalled();
 		});
 
-		it('registers the georesources', async () => {
+		it('registers the WmsGeoResources', async () => {
 			const url = 'https://some.url/wms';
-			const options = getOptions();
+			const options = getCompleteOptions();
 			const resultMock = [new WmsGeoResource('0', '', '', '', ''), new WmsGeoResource('1', '', '', '', ''), new WmsGeoResource('2', '', '', '', '')];
 			const geoResourceServiceSpy = spyOn(geoResourceService, 'addOrReplace').and.callFake(addOrReplaceMethodMock);
 			const urlServiceSpy = spyOn(urlService, 'originAndPathname').withArgs(url).and.returnValue(url);
@@ -87,7 +92,9 @@ describe('ImportWmsService', () => {
 			const providerSpy = jasmine.createSpy('provider').withArgs(url, {
 				// the default options
 				isAuthenticated: false,
-				sourceType: new SourceType(SourceTypeName.WMS, '1.1.1')
+				sourceType: new SourceType(SourceTypeName.WMS, '1.1.1'),
+				layers: [],
+				ids: []
 			})
 				.and.resolveTo(resultMock);
 			spyOn(urlService, 'originAndPathname').withArgs(url).and.returnValue(url);

--- a/test/service/provider/geoResource.provider.test.js
+++ b/test/service/provider/geoResource.provider.test.js
@@ -1,4 +1,4 @@
-import { GeoResourceFuture, VectorGeoResource, VectorSourceType } from '../../../src/domain/geoResources';
+import { GeoResourceFuture, VectorGeoResource, VectorSourceType, WmsGeoResource } from '../../../src/domain/geoResources';
 import { SourceType, SourceTypeName, SourceTypeResult, SourceTypeResultStatus } from '../../../src/domain/sourceType';
 import { $injector } from '../../../src/injection';
 import { getBvvAttribution } from '../../../src/services/provider/attribution.provider';
@@ -21,6 +21,9 @@ describe('GeoResource provider', () => {
 	const importVectorDataService = {
 		async forUrl() { }
 	};
+	const importWmsService = {
+		async forUrl() { }
+	};
 
 	beforeAll(() => {
 		TestUtils.setupStoreAndDi();
@@ -29,7 +32,8 @@ describe('GeoResource provider', () => {
 			.registerSingleton('HttpService', httpService)
 			.registerSingleton('GeoResourceService', geoResourceService)
 			.registerSingleton('SourceTypeService', sourceTypeService)
-			.registerSingleton('ImportVectorDataService', importVectorDataService);
+			.registerSingleton('ImportVectorDataService', importVectorDataService)
+			.registerSingleton('ImportWmsService', importWmsService);
 	});
 
 	const basicAttribution = {
@@ -429,104 +433,163 @@ describe('GeoResource provider', () => {
 
 	describe('loadGeoResourceByUrlBasedId', () => {
 
-		it('loads a GEOJSON GeoResource', async () => {
-			const label = 'label';
-			const url = 'http://foo.bar';
-			const sourceType = new SourceType(SourceTypeName.GEOJSON);
-			const geoResourceId = `GEOJSON||${label}||${url}`;
-			const geoResource = new VectorGeoResource(geoResourceId, 'label', VectorSourceType.GEOJSON);
-			const sourceTypeServiceSpy = spyOn(sourceTypeService, 'forUrl').withArgs(url).and.resolveTo(new SourceTypeResult(SourceTypeResultStatus.OK, sourceType));
-			const geoResourceFuture = new GeoResourceFuture(geoResourceId, async () => geoResource);
-			const geoResourceServiceSpy = spyOn(geoResourceService, 'addOrReplace').and.callFake(gr => gr);
-			const importVectorDataServiceSpy = spyOn(importVectorDataService, 'forUrl').withArgs(url, { sourceType: sourceType, id: geoResourceId })
-				.and.returnValue(geoResourceFuture);
+		describe('Vector resources', () => {
 
-			const future = loadGeoResourceByUrlBasedId(geoResourceId);
-			const resolvedGeoResource = await future.get();
+			it('loads a GEOJSON GeoResource', async () => {
+				const label = 'label';
+				const url = 'http://foo.bar';
+				const sourceType = new SourceType(SourceTypeName.GEOJSON);
+				const geoResourceId = `GEOJSON||${label}||${url}`;
+				const geoResource = new VectorGeoResource(geoResourceId, 'label', VectorSourceType.GEOJSON);
+				const sourceTypeServiceSpy = spyOn(sourceTypeService, 'forUrl').withArgs(url).and.resolveTo(new SourceTypeResult(SourceTypeResultStatus.OK, sourceType));
+				const geoResourceFuture = new GeoResourceFuture(geoResourceId, async () => geoResource);
+				const geoResourceServiceSpy = spyOn(geoResourceService, 'addOrReplace').and.callFake(gr => gr);
+				const importVectorDataServiceSpy = spyOn(importVectorDataService, 'forUrl').withArgs(url, { sourceType: sourceType, id: geoResourceId })
+					.and.returnValue(geoResourceFuture);
 
-			expect(future.id).toBe(geoResourceId);
-			expect(future.label).toBe('');
-			expect(resolvedGeoResource).toEqual(geoResource);
-			expect(resolvedGeoResource.id).toBe(geoResourceId);
-			expect(resolvedGeoResource.label).toBe(label);
-			expect(sourceTypeServiceSpy).toHaveBeenCalled();
-			expect(importVectorDataServiceSpy).toHaveBeenCalled();
-			expect(geoResourceServiceSpy).toHaveBeenCalled();
+				const future = loadGeoResourceByUrlBasedId(geoResourceId);
+				const resolvedGeoResource = await future.get();
+
+				expect(future.id).toBe(geoResourceId);
+				expect(future.label).toBe('');
+				expect(resolvedGeoResource).toEqual(geoResource);
+				expect(resolvedGeoResource.id).toBe(geoResourceId);
+				expect(resolvedGeoResource.label).toBe(label);
+				expect(sourceTypeServiceSpy).toHaveBeenCalled();
+				expect(importVectorDataServiceSpy).toHaveBeenCalled();
+				expect(geoResourceServiceSpy).toHaveBeenCalled();
+			});
+
+			it('loads a KML GeoResource', async () => {
+				const label = 'label';
+				const url = 'http://foo.bar';
+				const sourceType = new SourceType(SourceTypeName.KML);
+				const geoResourceId = `KML||${label}||${url}`;
+				const geoResource = new VectorGeoResource(geoResourceId, 'label', VectorSourceType.GEOJSON);
+				const sourceTypeServiceSpy = spyOn(sourceTypeService, 'forUrl').withArgs(url).and.resolveTo(new SourceTypeResult(SourceTypeResultStatus.OK, sourceType));
+				const geoResourceFuture = new GeoResourceFuture(geoResourceId, async () => geoResource);
+				const geoResourceServiceSpy = spyOn(geoResourceService, 'addOrReplace').and.callFake(gr => gr);
+				const importVectorDataServiceSpy = spyOn(importVectorDataService, 'forUrl').withArgs(url, { sourceType: sourceType, id: geoResourceId })
+					.and.returnValue(geoResourceFuture);
+
+				const future = loadGeoResourceByUrlBasedId(geoResourceId);
+				const resolvedGeoResource = await future.get();
+
+				expect(future.id).toBe(geoResourceId);
+				expect(future.label).toBe('');
+				expect(resolvedGeoResource).toEqual(geoResource);
+				expect(resolvedGeoResource.id).toBe(geoResourceId);
+				expect(resolvedGeoResource.label).toBe(label);
+				expect(sourceTypeServiceSpy).toHaveBeenCalled();
+				expect(importVectorDataServiceSpy).toHaveBeenCalled();
+				expect(geoResourceServiceSpy).toHaveBeenCalled();
+			});
+
+			it('loads a GPX GeoResource', async () => {
+				const label = 'label';
+				const url = 'http://foo.bar';
+				const sourceType = new SourceType(SourceTypeName.KML);
+				const geoResourceId = `GPX||${label}||${url}`;
+				const geoResource = new VectorGeoResource(geoResourceId, 'label', VectorSourceType.GPX);
+				const sourceTypeServiceSpy = spyOn(sourceTypeService, 'forUrl').withArgs(url).and.resolveTo(new SourceTypeResult(SourceTypeResultStatus.OK, sourceType));
+				const geoResourceFuture = new GeoResourceFuture(geoResourceId, async () => geoResource);
+				const geoResourceServiceSpy = spyOn(geoResourceService, 'addOrReplace').and.callFake(gr => gr);
+				const importVectorDataServiceSpy = spyOn(importVectorDataService, 'forUrl').withArgs(url, { sourceType: sourceType, id: geoResourceId })
+					.and.returnValue(geoResourceFuture);
+
+				const future = loadGeoResourceByUrlBasedId(geoResourceId);
+				const resolvedGeoResource = await future.get();
+
+				expect(future.id).toBe(geoResourceId);
+				expect(future.label).toBe('');
+				expect(resolvedGeoResource).toEqual(geoResource);
+				expect(resolvedGeoResource.id).toBe(geoResourceId);
+				expect(resolvedGeoResource.label).toBe(label);
+				expect(sourceTypeServiceSpy).toHaveBeenCalled();
+				expect(importVectorDataServiceSpy).toHaveBeenCalled();
+				expect(geoResourceServiceSpy).toHaveBeenCalled();
+			});
+
+			it('loads a EWKT GeoResource', async () => {
+				const label = 'label';
+				const url = 'http://foo.bar';
+				const sourceType = new SourceType(SourceTypeName.KML);
+				const geoResourceId = `EWKT||${label}||${url}`;
+				const geoResource = new VectorGeoResource(geoResourceId, 'label', VectorSourceType.EWKT);
+				const sourceTypeServiceSpy = spyOn(sourceTypeService, 'forUrl').withArgs(url).and.resolveTo(new SourceTypeResult(SourceTypeResultStatus.OK, sourceType));
+				const geoResourceFuture = new GeoResourceFuture(geoResourceId, async () => geoResource);
+				const geoResourceServiceSpy = spyOn(geoResourceService, 'addOrReplace').and.callFake(gr => gr);
+				const importVectorDataServiceSpy = spyOn(importVectorDataService, 'forUrl').withArgs(url, { sourceType: sourceType, id: geoResourceId })
+					.and.returnValue(geoResourceFuture);
+
+				const future = loadGeoResourceByUrlBasedId(geoResourceId);
+				const resolvedGeoResource = await future.get();
+
+				expect(future.id).toBe(geoResourceId);
+				expect(future.label).toBe('');
+				expect(resolvedGeoResource).toEqual(geoResource);
+				expect(resolvedGeoResource.id).toBe(geoResourceId);
+				expect(resolvedGeoResource.label).toBe(label);
+				expect(sourceTypeServiceSpy).toHaveBeenCalled();
+				expect(importVectorDataServiceSpy).toHaveBeenCalled();
+				expect(geoResourceServiceSpy).toHaveBeenCalled();
+			});
 		});
 
-		it('loads a KML GeoResource', async () => {
-			const label = 'label';
-			const url = 'http://foo.bar';
-			const sourceType = new SourceType(SourceTypeName.KML);
-			const geoResourceId = `KML||${label}||${url}`;
-			const geoResource = new VectorGeoResource(geoResourceId, 'label', VectorSourceType.GEOJSON);
-			const sourceTypeServiceSpy = spyOn(sourceTypeService, 'forUrl').withArgs(url).and.resolveTo(new SourceTypeResult(SourceTypeResultStatus.OK, sourceType));
-			const geoResourceFuture = new GeoResourceFuture(geoResourceId, async () => geoResource);
-			const geoResourceServiceSpy = spyOn(geoResourceService, 'addOrReplace').and.callFake(gr => gr);
-			const importVectorDataServiceSpy = spyOn(importVectorDataService, 'forUrl').withArgs(url, { sourceType: sourceType, id: geoResourceId })
-				.and.returnValue(geoResourceFuture);
+		describe('WMS resource', () => {
 
-			const future = loadGeoResourceByUrlBasedId(geoResourceId);
-			const resolvedGeoResource = await future.get();
+			it('loads a GEOJSON GeoResource', async () => {
+				const label = 'label';
+				const layer = 'layer';
+				const url = 'http://foo.bar';
+				const sourceType = new SourceType(SourceTypeName.WMS, '1.1.1');
+				const geoResourceId = `WMS||${label}||${url}||${layer}`;
+				const geoResource = new WmsGeoResource(geoResourceId, 'label', url, layer, 'image/png');
+				const sourceTypeServiceSpy = spyOn(sourceTypeService, 'forUrl').withArgs(url).and.resolveTo(new SourceTypeResult(SourceTypeResultStatus.OK, sourceType));
+				const geoResourceServiceSpy = spyOn(geoResourceService, 'addOrReplace').and.callFake(gr => gr);
+				const importWmsServiceSpy = spyOn(importWmsService, 'forUrl').withArgs(url, { sourceType: sourceType, layers: [layer], ids: [geoResourceId] })
+					.and.returnValue([geoResource]);
 
-			expect(future.id).toBe(geoResourceId);
-			expect(future.label).toBe('');
-			expect(resolvedGeoResource).toEqual(geoResource);
-			expect(resolvedGeoResource.id).toBe(geoResourceId);
-			expect(resolvedGeoResource.label).toBe(label);
-			expect(sourceTypeServiceSpy).toHaveBeenCalled();
-			expect(importVectorDataServiceSpy).toHaveBeenCalled();
-			expect(geoResourceServiceSpy).toHaveBeenCalled();
-		});
+				const future = loadGeoResourceByUrlBasedId(geoResourceId);
+				const resolvedGeoResource = await future.get();
 
-		it('loads a GPX GeoResource', async () => {
-			const label = 'label';
-			const url = 'http://foo.bar';
-			const sourceType = new SourceType(SourceTypeName.KML);
-			const geoResourceId = `GPX||${label}||${url}`;
-			const geoResource = new VectorGeoResource(geoResourceId, 'label', VectorSourceType.GPX);
-			const sourceTypeServiceSpy = spyOn(sourceTypeService, 'forUrl').withArgs(url).and.resolveTo(new SourceTypeResult(SourceTypeResultStatus.OK, sourceType));
-			const geoResourceFuture = new GeoResourceFuture(geoResourceId, async () => geoResource);
-			const geoResourceServiceSpy = spyOn(geoResourceService, 'addOrReplace').and.callFake(gr => gr);
-			const importVectorDataServiceSpy = spyOn(importVectorDataService, 'forUrl').withArgs(url, { sourceType: sourceType, id: geoResourceId })
-				.and.returnValue(geoResourceFuture);
+				expect(future.id).toBe(geoResourceId);
+				expect(future.label).toBe('');
+				expect(resolvedGeoResource).toEqual(geoResource);
+				expect(resolvedGeoResource.id).toBe(geoResourceId);
+				expect(resolvedGeoResource.label).toBe(label);
+				expect(sourceTypeServiceSpy).toHaveBeenCalled();
+				expect(importWmsServiceSpy).toHaveBeenCalled();
+				expect(geoResourceServiceSpy).toHaveBeenCalled();
+			});
 
-			const future = loadGeoResourceByUrlBasedId(geoResourceId);
-			const resolvedGeoResource = await future.get();
+			it('throws an error when layer is missing', async () => {
+				const label = 'label';
+				const url = 'http://foo.bar';
+				const geoResourceId = `WMS||${label}||${url}`;
+				const sourceType = new SourceType(SourceTypeName.WMS, '1.1.1');
+				spyOn(sourceTypeService, 'forUrl').withArgs(url).and.resolveTo(new SourceTypeResult(SourceTypeResultStatus.OK, sourceType));
 
-			expect(future.id).toBe(geoResourceId);
-			expect(future.label).toBe('');
-			expect(resolvedGeoResource).toEqual(geoResource);
-			expect(resolvedGeoResource.id).toBe(geoResourceId);
-			expect(resolvedGeoResource.label).toBe(label);
-			expect(sourceTypeServiceSpy).toHaveBeenCalled();
-			expect(importVectorDataServiceSpy).toHaveBeenCalled();
-			expect(geoResourceServiceSpy).toHaveBeenCalled();
-		});
+				const future = loadGeoResourceByUrlBasedId(geoResourceId);
 
-		it('loads a EWKT GeoResource', async () => {
-			const label = 'label';
-			const url = 'http://foo.bar';
-			const sourceType = new SourceType(SourceTypeName.KML);
-			const geoResourceId = `EWKT||${label}||${url}`;
-			const geoResource = new VectorGeoResource(geoResourceId, 'label', VectorSourceType.EWKT);
-			const sourceTypeServiceSpy = spyOn(sourceTypeService, 'forUrl').withArgs(url).and.resolveTo(new SourceTypeResult(SourceTypeResultStatus.OK, sourceType));
-			const geoResourceFuture = new GeoResourceFuture(geoResourceId, async () => geoResource);
-			const geoResourceServiceSpy = spyOn(geoResourceService, 'addOrReplace').and.callFake(gr => gr);
-			const importVectorDataServiceSpy = spyOn(importVectorDataService, 'forUrl').withArgs(url, { sourceType: sourceType, id: geoResourceId })
-				.and.returnValue(geoResourceFuture);
+				await expectAsync(future.get()).toBeRejectedWithError('Layer parameter is missing for \'http://foo.bar\'');
+			});
 
-			const future = loadGeoResourceByUrlBasedId(geoResourceId);
-			const resolvedGeoResource = await future.get();
+			it('throws an error when no WmsGeoResouce was created', async () => {
+				const label = 'label';
+				const layer = 'layer';
+				const url = 'http://foo.bar';
+				const sourceType = new SourceType(SourceTypeName.WMS, '1.1.1');
+				const geoResourceId = `WMS||${label}||${url}||${layer}`;
+				spyOn(sourceTypeService, 'forUrl').withArgs(url).and.resolveTo(new SourceTypeResult(SourceTypeResultStatus.OK, sourceType));
+				spyOn(geoResourceService, 'addOrReplace').and.callFake(gr => gr);
+				spyOn(importWmsService, 'forUrl').withArgs(url, { sourceType: sourceType, layers: [layer], ids: [geoResourceId] })
+					.and.returnValue([]);
 
-			expect(future.id).toBe(geoResourceId);
-			expect(future.label).toBe('');
-			expect(resolvedGeoResource).toEqual(geoResource);
-			expect(resolvedGeoResource.id).toBe(geoResourceId);
-			expect(resolvedGeoResource.label).toBe(label);
-			expect(sourceTypeServiceSpy).toHaveBeenCalled();
-			expect(importVectorDataServiceSpy).toHaveBeenCalled();
-			expect(geoResourceServiceSpy).toHaveBeenCalled();
+				const future = loadGeoResourceByUrlBasedId(geoResourceId);
+
+				await expectAsync(future.get()).toBeRejectedWithError('Unsupported WMS: \'http://foo.bar\'');
+			});
 		});
 
 		it('does not overwrite label when not provided', async () => {

--- a/test/service/provider/geoResource.provider.test.js
+++ b/test/service/provider/geoResource.provider.test.js
@@ -1,19 +1,25 @@
+import { GeoResourceFuture, VectorGeoResource, VectorSourceType } from '../../../src/domain/geoResources';
+import { SourceType, SourceTypeName, SourceTypeResult, SourceTypeResultStatus } from '../../../src/domain/sourceType';
 import { $injector } from '../../../src/injection';
 import { getBvvAttribution } from '../../../src/services/provider/attribution.provider';
-import { loadBvvGeoResourceById, loadBvvGeoResources, loadExampleGeoResources, _definitionToGeoResource, _parseBvvAttributionDefinition } from '../../../src/services/provider/geoResource.provider';
+import { loadBvvGeoResourceById, loadBvvGeoResources, loadExampleGeoResources, loadGeoResourceByUrlBasedId, _definitionToGeoResource, _parseBvvAttributionDefinition } from '../../../src/services/provider/geoResource.provider';
 import { TestUtils } from '../../test-utils';
 
-describe('BVV GeoResource provider', () => {
+describe('GeoResource provider', () => {
 	const configService = {
 		getValueAsPath() { }
 	};
-
 	const httpService = {
 		async get() { }
 	};
-
 	const geoResourceService = {
 		addOrReplace() { }
+	};
+	const sourceTypeService = {
+		async forUrl() { }
+	};
+	const importVectorDataService = {
+		async forUrl() { }
 	};
 
 	beforeAll(() => {
@@ -21,7 +27,9 @@ describe('BVV GeoResource provider', () => {
 		$injector
 			.registerSingleton('ConfigService', configService)
 			.registerSingleton('HttpService', httpService)
-			.registerSingleton('GeoResourceService', geoResourceService);
+			.registerSingleton('GeoResourceService', geoResourceService)
+			.registerSingleton('SourceTypeService', sourceTypeService)
+			.registerSingleton('ImportVectorDataService', importVectorDataService);
 	});
 
 	const basicAttribution = {
@@ -417,6 +425,159 @@ describe('BVV GeoResource provider', () => {
 			}
 		});
 
+	});
+
+	describe('loadGeoResourceByUrlBasedId', () => {
+
+		it('loads a GEOJSON GeoResource', async () => {
+			const url = 'http://foo.bar';
+			const sourceType = new SourceType(SourceTypeName.GEOJSON);
+			const geoResourceId = `GEOJSON||${url}`;
+			const geoResource = new VectorGeoResource(geoResourceId, 'label', VectorSourceType.GEOJSON);
+			const sourceTypeServiceSpy = spyOn(sourceTypeService, 'forUrl').withArgs(url).and.resolveTo(new SourceTypeResult(SourceTypeResultStatus.OK, sourceType));
+			const geoResourceFuture = new GeoResourceFuture(geoResourceId, async () => geoResource);
+			const geoResourceServiceSpy = spyOn(geoResourceService, 'addOrReplace').and.callFake(gr => gr);
+			const importVectorDataServiceSpy = spyOn(importVectorDataService, 'forUrl').withArgs(url, { sourceType: sourceType, id: geoResourceId })
+				.and.returnValue(geoResourceFuture);
+
+			const future = loadGeoResourceByUrlBasedId(geoResourceId);
+			const resolvedGeoResource = await future.get();
+
+			expect(future.id).toBe(geoResourceId);
+			expect(future.label).toBe('');
+			expect(resolvedGeoResource).toEqual(geoResource);
+			expect(resolvedGeoResource.id).toBe(geoResourceId);
+			expect(sourceTypeServiceSpy).toHaveBeenCalled();
+			expect(importVectorDataServiceSpy).toHaveBeenCalled();
+			expect(geoResourceServiceSpy).toHaveBeenCalled();
+		});
+
+		it('loads a KML GeoResource', async () => {
+			const url = 'http://foo.bar';
+			const sourceType = new SourceType(SourceTypeName.KML);
+			const geoResourceId = `KML||${url}`;
+			const geoResource = new VectorGeoResource(geoResourceId, 'label', VectorSourceType.GEOJSON);
+			const sourceTypeServiceSpy = spyOn(sourceTypeService, 'forUrl').withArgs(url).and.resolveTo(new SourceTypeResult(SourceTypeResultStatus.OK, sourceType));
+			const geoResourceFuture = new GeoResourceFuture(geoResourceId, async () => geoResource);
+			const geoResourceServiceSpy = spyOn(geoResourceService, 'addOrReplace').and.callFake(gr => gr);
+			const importVectorDataServiceSpy = spyOn(importVectorDataService, 'forUrl').withArgs(url, { sourceType: sourceType, id: geoResourceId })
+				.and.returnValue(geoResourceFuture);
+
+			const future = loadGeoResourceByUrlBasedId(geoResourceId);
+			const resolvedGeoResource = await future.get();
+
+			expect(future.id).toBe(geoResourceId);
+			expect(future.label).toBe('');
+			expect(resolvedGeoResource).toEqual(geoResource);
+			expect(resolvedGeoResource.id).toBe(geoResourceId);
+			expect(sourceTypeServiceSpy).toHaveBeenCalled();
+			expect(importVectorDataServiceSpy).toHaveBeenCalled();
+			expect(geoResourceServiceSpy).toHaveBeenCalled();
+		});
+
+		it('loads a GPX GeoResource', async () => {
+			const url = 'http://foo.bar';
+			const sourceType = new SourceType(SourceTypeName.KML);
+			const geoResourceId = `GPX||${url}`;
+			const geoResource = new VectorGeoResource(geoResourceId, 'label', VectorSourceType.GPX);
+			const sourceTypeServiceSpy = spyOn(sourceTypeService, 'forUrl').withArgs(url).and.resolveTo(new SourceTypeResult(SourceTypeResultStatus.OK, sourceType));
+			const geoResourceFuture = new GeoResourceFuture(geoResourceId, async () => geoResource);
+			const geoResourceServiceSpy = spyOn(geoResourceService, 'addOrReplace').and.callFake(gr => gr);
+			const importVectorDataServiceSpy = spyOn(importVectorDataService, 'forUrl').withArgs(url, { sourceType: sourceType, id: geoResourceId })
+				.and.returnValue(geoResourceFuture);
+
+			const future = loadGeoResourceByUrlBasedId(geoResourceId);
+			const resolvedGeoResource = await future.get();
+
+			expect(future.id).toBe(geoResourceId);
+			expect(future.label).toBe('');
+			expect(resolvedGeoResource).toEqual(geoResource);
+			expect(resolvedGeoResource.id).toBe(geoResourceId);
+			expect(sourceTypeServiceSpy).toHaveBeenCalled();
+			expect(importVectorDataServiceSpy).toHaveBeenCalled();
+			expect(geoResourceServiceSpy).toHaveBeenCalled();
+		});
+
+		it('loads a EWKT GeoResource', async () => {
+			const url = 'http://foo.bar';
+			const sourceType = new SourceType(SourceTypeName.KML);
+			const geoResourceId = `EWKT||${url}`;
+			const geoResource = new VectorGeoResource(geoResourceId, 'label', VectorSourceType.EWKT);
+			const sourceTypeServiceSpy = spyOn(sourceTypeService, 'forUrl').withArgs(url).and.resolveTo(new SourceTypeResult(SourceTypeResultStatus.OK, sourceType));
+			const geoResourceFuture = new GeoResourceFuture(geoResourceId, async () => geoResource);
+			const geoResourceServiceSpy = spyOn(geoResourceService, 'addOrReplace').and.callFake(gr => gr);
+			const importVectorDataServiceSpy = spyOn(importVectorDataService, 'forUrl').withArgs(url, { sourceType: sourceType, id: geoResourceId })
+				.and.returnValue(geoResourceFuture);
+
+			const future = loadGeoResourceByUrlBasedId(geoResourceId);
+			const resolvedGeoResource = await future.get();
+
+			expect(future.id).toBe(geoResourceId);
+			expect(future.label).toBe('');
+			expect(resolvedGeoResource).toEqual(geoResource);
+			expect(resolvedGeoResource.id).toBe(geoResourceId);
+			expect(sourceTypeServiceSpy).toHaveBeenCalled();
+			expect(importVectorDataServiceSpy).toHaveBeenCalled();
+			expect(geoResourceServiceSpy).toHaveBeenCalled();
+		});
+
+		it('throws an error when source type is not supported', async () => {
+			const url = 'http://foo.bar';
+			const sourceType = new SourceType({ FOO: 'bar' });
+			const geoResourceId = `EWKT||${url}`;
+			const geoResource = new VectorGeoResource(geoResourceId, 'label', VectorSourceType.EWKT);
+			spyOn(sourceTypeService, 'forUrl').withArgs(url).and.resolveTo(new SourceTypeResult(SourceTypeResultStatus.OK, sourceType));
+			const geoResourceFuture = new GeoResourceFuture(geoResourceId, async () => geoResource);
+			spyOn(geoResourceService, 'addOrReplace').and.callFake(gr => gr);
+			spyOn(importVectorDataService, 'forUrl').withArgs(url, { sourceType: sourceType, id: geoResourceId })
+				.and.returnValue(geoResourceFuture);
+
+			const future = loadGeoResourceByUrlBasedId(geoResourceId);
+
+			await expectAsync(future.get()).toBeRejectedWithError('Unsupported source type \'FOO\'');
+		});
+
+		it('throws an error when SourceType status is not OK', async () => {
+			const url = 'http://foo.bar';
+			const sourceType = new SourceType(SourceTypeName.KML);
+			const geoResourceId = `EWKT||${url}`;
+			const geoResource = new VectorGeoResource(geoResourceId, 'label', VectorSourceType.EWKT);
+			spyOn(sourceTypeService, 'forUrl').withArgs(url).and.resolveTo(new SourceTypeResult(SourceTypeResultStatus.OTHER, sourceType));
+			const geoResourceFuture = new GeoResourceFuture(geoResourceId, async () => geoResource);
+			spyOn(geoResourceService, 'addOrReplace').and.callFake(gr => gr);
+			spyOn(importVectorDataService, 'forUrl').withArgs(url, { sourceType: sourceType, id: geoResourceId })
+				.and.returnValue(geoResourceFuture);
+
+			const future = loadGeoResourceByUrlBasedId(geoResourceId);
+
+			await expectAsync(future.get()).toBeRejectedWithError('SourceTypeService returns status=OTHER for http://foo.bar');
+		});
+
+		it('returns NULL when id does not contain a valid URL', async () => {
+			const url = 'foo.bar';
+			const geoResourceId = `EWKT||${url}`;
+
+			const future = loadGeoResourceByUrlBasedId(geoResourceId);
+
+			expect(future).toBeNull();
+		});
+
+		it('returns NULL when id does not contain a URL', async () => {
+			const geoResourceId = 'EWKT||';
+
+			const future = loadGeoResourceByUrlBasedId(geoResourceId);
+
+			expect(future).toBeNull();
+		});
+
+		it('returns NULL when id does not start with a supported Type', async () => {
+			const url = 'http://foo.bar';
+			const geoResourceId = `FOO||${url}`;
+
+			const future = loadGeoResourceByUrlBasedId(geoResourceId);
+
+			expect(future).toBeNull();
+		});
 	});
 });
 

--- a/test/service/provider/geoResource.provider.test.js
+++ b/test/service/provider/geoResource.provider.test.js
@@ -430,9 +430,10 @@ describe('GeoResource provider', () => {
 	describe('loadGeoResourceByUrlBasedId', () => {
 
 		it('loads a GEOJSON GeoResource', async () => {
+			const label = 'label';
 			const url = 'http://foo.bar';
 			const sourceType = new SourceType(SourceTypeName.GEOJSON);
-			const geoResourceId = `GEOJSON||${url}`;
+			const geoResourceId = `GEOJSON||${label}||${url}`;
 			const geoResource = new VectorGeoResource(geoResourceId, 'label', VectorSourceType.GEOJSON);
 			const sourceTypeServiceSpy = spyOn(sourceTypeService, 'forUrl').withArgs(url).and.resolveTo(new SourceTypeResult(SourceTypeResultStatus.OK, sourceType));
 			const geoResourceFuture = new GeoResourceFuture(geoResourceId, async () => geoResource);
@@ -447,15 +448,17 @@ describe('GeoResource provider', () => {
 			expect(future.label).toBe('');
 			expect(resolvedGeoResource).toEqual(geoResource);
 			expect(resolvedGeoResource.id).toBe(geoResourceId);
+			expect(resolvedGeoResource.label).toBe(label);
 			expect(sourceTypeServiceSpy).toHaveBeenCalled();
 			expect(importVectorDataServiceSpy).toHaveBeenCalled();
 			expect(geoResourceServiceSpy).toHaveBeenCalled();
 		});
 
 		it('loads a KML GeoResource', async () => {
+			const label = 'label';
 			const url = 'http://foo.bar';
 			const sourceType = new SourceType(SourceTypeName.KML);
-			const geoResourceId = `KML||${url}`;
+			const geoResourceId = `KML||${label}||${url}`;
 			const geoResource = new VectorGeoResource(geoResourceId, 'label', VectorSourceType.GEOJSON);
 			const sourceTypeServiceSpy = spyOn(sourceTypeService, 'forUrl').withArgs(url).and.resolveTo(new SourceTypeResult(SourceTypeResultStatus.OK, sourceType));
 			const geoResourceFuture = new GeoResourceFuture(geoResourceId, async () => geoResource);
@@ -470,15 +473,17 @@ describe('GeoResource provider', () => {
 			expect(future.label).toBe('');
 			expect(resolvedGeoResource).toEqual(geoResource);
 			expect(resolvedGeoResource.id).toBe(geoResourceId);
+			expect(resolvedGeoResource.label).toBe(label);
 			expect(sourceTypeServiceSpy).toHaveBeenCalled();
 			expect(importVectorDataServiceSpy).toHaveBeenCalled();
 			expect(geoResourceServiceSpy).toHaveBeenCalled();
 		});
 
 		it('loads a GPX GeoResource', async () => {
+			const label = 'label';
 			const url = 'http://foo.bar';
 			const sourceType = new SourceType(SourceTypeName.KML);
-			const geoResourceId = `GPX||${url}`;
+			const geoResourceId = `GPX||${label}||${url}`;
 			const geoResource = new VectorGeoResource(geoResourceId, 'label', VectorSourceType.GPX);
 			const sourceTypeServiceSpy = spyOn(sourceTypeService, 'forUrl').withArgs(url).and.resolveTo(new SourceTypeResult(SourceTypeResultStatus.OK, sourceType));
 			const geoResourceFuture = new GeoResourceFuture(geoResourceId, async () => geoResource);
@@ -493,15 +498,17 @@ describe('GeoResource provider', () => {
 			expect(future.label).toBe('');
 			expect(resolvedGeoResource).toEqual(geoResource);
 			expect(resolvedGeoResource.id).toBe(geoResourceId);
+			expect(resolvedGeoResource.label).toBe(label);
 			expect(sourceTypeServiceSpy).toHaveBeenCalled();
 			expect(importVectorDataServiceSpy).toHaveBeenCalled();
 			expect(geoResourceServiceSpy).toHaveBeenCalled();
 		});
 
 		it('loads a EWKT GeoResource', async () => {
+			const label = 'label';
 			const url = 'http://foo.bar';
 			const sourceType = new SourceType(SourceTypeName.KML);
-			const geoResourceId = `EWKT||${url}`;
+			const geoResourceId = `EWKT||${label}||${url}`;
 			const geoResource = new VectorGeoResource(geoResourceId, 'label', VectorSourceType.EWKT);
 			const sourceTypeServiceSpy = spyOn(sourceTypeService, 'forUrl').withArgs(url).and.resolveTo(new SourceTypeResult(SourceTypeResultStatus.OK, sourceType));
 			const geoResourceFuture = new GeoResourceFuture(geoResourceId, async () => geoResource);
@@ -516,15 +523,34 @@ describe('GeoResource provider', () => {
 			expect(future.label).toBe('');
 			expect(resolvedGeoResource).toEqual(geoResource);
 			expect(resolvedGeoResource.id).toBe(geoResourceId);
+			expect(resolvedGeoResource.label).toBe(label);
 			expect(sourceTypeServiceSpy).toHaveBeenCalled();
 			expect(importVectorDataServiceSpy).toHaveBeenCalled();
 			expect(geoResourceServiceSpy).toHaveBeenCalled();
 		});
 
+		it('does not overwrite label when not provided', async () => {
+			const originaLabel = 'originalLabel';
+			const url = 'http://foo.bar';
+			const sourceType = new SourceType(SourceTypeName.KML);
+			const geoResourceId = `EWKT||||${url}`;
+			const geoResource = new VectorGeoResource(geoResourceId, originaLabel, VectorSourceType.EWKT);
+			spyOn(sourceTypeService, 'forUrl').withArgs(url).and.resolveTo(new SourceTypeResult(SourceTypeResultStatus.OK, sourceType));
+			const geoResourceFuture = new GeoResourceFuture(geoResourceId, async () => geoResource);
+			spyOn(geoResourceService, 'addOrReplace').and.callFake(gr => gr);
+			spyOn(importVectorDataService, 'forUrl').withArgs(url, { sourceType: sourceType, id: geoResourceId })
+				.and.returnValue(geoResourceFuture);
+
+			const future = loadGeoResourceByUrlBasedId(geoResourceId);
+			const resolvedGeoResource = await future.get();
+
+			expect(resolvedGeoResource.label).toBe(originaLabel);
+		});
+
 		it('throws an error when source type is not supported', async () => {
 			const url = 'http://foo.bar';
 			const sourceType = new SourceType({ FOO: 'bar' });
-			const geoResourceId = `EWKT||${url}`;
+			const geoResourceId = `EWKT||||${url}`;
 			const geoResource = new VectorGeoResource(geoResourceId, 'label', VectorSourceType.EWKT);
 			spyOn(sourceTypeService, 'forUrl').withArgs(url).and.resolveTo(new SourceTypeResult(SourceTypeResultStatus.OK, sourceType));
 			const geoResourceFuture = new GeoResourceFuture(geoResourceId, async () => geoResource);
@@ -540,7 +566,7 @@ describe('GeoResource provider', () => {
 		it('throws an error when SourceType status is not OK', async () => {
 			const url = 'http://foo.bar';
 			const sourceType = new SourceType(SourceTypeName.KML);
-			const geoResourceId = `EWKT||${url}`;
+			const geoResourceId = `EWKT||||${url}`;
 			const geoResource = new VectorGeoResource(geoResourceId, 'label', VectorSourceType.EWKT);
 			spyOn(sourceTypeService, 'forUrl').withArgs(url).and.resolveTo(new SourceTypeResult(SourceTypeResultStatus.OTHER, sourceType));
 			const geoResourceFuture = new GeoResourceFuture(geoResourceId, async () => geoResource);
@@ -555,7 +581,7 @@ describe('GeoResource provider', () => {
 
 		it('returns NULL when id does not contain a valid URL', async () => {
 			const url = 'foo.bar';
-			const geoResourceId = `EWKT||${url}`;
+			const geoResourceId = `EWKT||||${url}`;
 
 			const future = loadGeoResourceByUrlBasedId(geoResourceId);
 
@@ -563,7 +589,7 @@ describe('GeoResource provider', () => {
 		});
 
 		it('returns NULL when id does not contain a URL', async () => {
-			const geoResourceId = 'EWKT||';
+			const geoResourceId = 'EWKT||||';
 
 			const future = loadGeoResourceByUrlBasedId(geoResourceId);
 
@@ -572,7 +598,7 @@ describe('GeoResource provider', () => {
 
 		it('returns NULL when id does not start with a supported Type', async () => {
 			const url = 'http://foo.bar';
-			const geoResourceId = `FOO||${url}`;
+			const geoResourceId = `FOO||||${url}`;
 
 			const future = loadGeoResourceByUrlBasedId(geoResourceId);
 

--- a/test/service/provider/geoResource.provider.test.js
+++ b/test/service/provider/geoResource.provider.test.js
@@ -418,7 +418,6 @@ describe('GeoResource provider', () => {
 				new Response(null, { status: 404 })
 			));
 
-
 			try {
 				const future = loadBvvGeoResourceById(id);
 				await future.get();
@@ -433,13 +432,13 @@ describe('GeoResource provider', () => {
 
 	describe('loadGeoResourceByUrlBasedId', () => {
 
-		describe('Vector resources', () => {
+		describe('Vector Url', () => {
 
 			it('loads a GEOJSON GeoResource', async () => {
 				const label = 'label';
 				const url = 'http://foo.bar';
 				const sourceType = new SourceType(SourceTypeName.GEOJSON);
-				const geoResourceId = `GEOJSON||${label}||${url}`;
+				const geoResourceId = `${url}`;
 				const geoResource = new VectorGeoResource(geoResourceId, 'label', VectorSourceType.GEOJSON);
 				const sourceTypeServiceSpy = spyOn(sourceTypeService, 'forUrl').withArgs(url).and.resolveTo(new SourceTypeResult(SourceTypeResultStatus.OK, sourceType));
 				const geoResourceFuture = new GeoResourceFuture(geoResourceId, async () => geoResource);
@@ -464,8 +463,8 @@ describe('GeoResource provider', () => {
 				const label = 'label';
 				const url = 'http://foo.bar';
 				const sourceType = new SourceType(SourceTypeName.KML);
-				const geoResourceId = `KML||${label}||${url}`;
-				const geoResource = new VectorGeoResource(geoResourceId, 'label', VectorSourceType.GEOJSON);
+				const geoResourceId = `${url}`;
+				const geoResource = new VectorGeoResource(geoResourceId, label, VectorSourceType.GEOJSON);
 				const sourceTypeServiceSpy = spyOn(sourceTypeService, 'forUrl').withArgs(url).and.resolveTo(new SourceTypeResult(SourceTypeResultStatus.OK, sourceType));
 				const geoResourceFuture = new GeoResourceFuture(geoResourceId, async () => geoResource);
 				const geoResourceServiceSpy = spyOn(geoResourceService, 'addOrReplace').and.callFake(gr => gr);
@@ -489,8 +488,8 @@ describe('GeoResource provider', () => {
 				const label = 'label';
 				const url = 'http://foo.bar';
 				const sourceType = new SourceType(SourceTypeName.KML);
-				const geoResourceId = `GPX||${label}||${url}`;
-				const geoResource = new VectorGeoResource(geoResourceId, 'label', VectorSourceType.GPX);
+				const geoResourceId = `${url}`;
+				const geoResource = new VectorGeoResource(geoResourceId, label, VectorSourceType.GPX);
 				const sourceTypeServiceSpy = spyOn(sourceTypeService, 'forUrl').withArgs(url).and.resolveTo(new SourceTypeResult(SourceTypeResultStatus.OK, sourceType));
 				const geoResourceFuture = new GeoResourceFuture(geoResourceId, async () => geoResource);
 				const geoResourceServiceSpy = spyOn(geoResourceService, 'addOrReplace').and.callFake(gr => gr);
@@ -514,8 +513,8 @@ describe('GeoResource provider', () => {
 				const label = 'label';
 				const url = 'http://foo.bar';
 				const sourceType = new SourceType(SourceTypeName.KML);
-				const geoResourceId = `EWKT||${label}||${url}`;
-				const geoResource = new VectorGeoResource(geoResourceId, 'label', VectorSourceType.EWKT);
+				const geoResourceId = `${url}`;
+				const geoResource = new VectorGeoResource(geoResourceId, label, VectorSourceType.EWKT);
 				const sourceTypeServiceSpy = spyOn(sourceTypeService, 'forUrl').withArgs(url).and.resolveTo(new SourceTypeResult(SourceTypeResultStatus.OK, sourceType));
 				const geoResourceFuture = new GeoResourceFuture(geoResourceId, async () => geoResource);
 				const geoResourceServiceSpy = spyOn(geoResourceService, 'addOrReplace').and.callFake(gr => gr);
@@ -534,17 +533,40 @@ describe('GeoResource provider', () => {
 				expect(importVectorDataServiceSpy).toHaveBeenCalled();
 				expect(geoResourceServiceSpy).toHaveBeenCalled();
 			});
+
+			it('sets the GeoResource label when provided', async () => {
+				const label = 'label';
+				const url = 'http://foo.bar';
+				const sourceType = new SourceType(SourceTypeName.KML);
+				const geoResourceId = `${url}||${label}`;
+				const geoResource = new VectorGeoResource(geoResourceId, 'some label', VectorSourceType.EWKT);
+				spyOn(sourceTypeService, 'forUrl').withArgs(url).and.resolveTo(new SourceTypeResult(SourceTypeResultStatus.OK, sourceType));
+				const geoResourceFuture = new GeoResourceFuture(geoResourceId, async () => geoResource);
+				spyOn(geoResourceService, 'addOrReplace').and.callFake(gr => gr);
+				spyOn(importVectorDataService, 'forUrl').withArgs(url, { sourceType: sourceType, id: geoResourceId })
+					.and.returnValue(geoResourceFuture);
+
+				const future = loadGeoResourceByUrlBasedId(geoResourceId);
+				const resolvedGeoResource = await future.get();
+
+				expect(future.id).toBe(geoResourceId);
+				expect(future.label).toBe('');
+				expect(resolvedGeoResource).toEqual(geoResource);
+				expect(resolvedGeoResource.id).toBe(geoResourceId);
+				expect(resolvedGeoResource.label).toBe(label);
+
+			});
 		});
 
-		describe('WMS resource', () => {
+		describe('WMS Url', () => {
 
-			it('loads a GEOJSON GeoResource', async () => {
+			it('loads a WMS GeoResource', async () => {
 				const label = 'label';
 				const layer = 'layer';
 				const url = 'http://foo.bar';
 				const sourceType = new SourceType(SourceTypeName.WMS, '1.1.1');
-				const geoResourceId = `WMS||${label}||${url}||${layer}`;
-				const geoResource = new WmsGeoResource(geoResourceId, 'label', url, layer, 'image/png');
+				const geoResourceId = `${url}||${layer}`;
+				const geoResource = new WmsGeoResource(geoResourceId, label, url, layer, 'image/png');
 				const sourceTypeServiceSpy = spyOn(sourceTypeService, 'forUrl').withArgs(url).and.resolveTo(new SourceTypeResult(SourceTypeResultStatus.OK, sourceType));
 				const geoResourceServiceSpy = spyOn(geoResourceService, 'addOrReplace').and.callFake(gr => gr);
 				const importWmsServiceSpy = spyOn(importWmsService, 'forUrl').withArgs(url, { sourceType: sourceType, layers: [layer], ids: [geoResourceId] })
@@ -563,24 +585,59 @@ describe('GeoResource provider', () => {
 				expect(geoResourceServiceSpy).toHaveBeenCalled();
 			});
 
-			it('throws an error when layer is missing', async () => {
-				const label = 'label';
-				const url = 'http://foo.bar';
-				const geoResourceId = `WMS||${label}||${url}`;
-				const sourceType = new SourceType(SourceTypeName.WMS, '1.1.1');
-				spyOn(sourceTypeService, 'forUrl').withArgs(url).and.resolveTo(new SourceTypeResult(SourceTypeResultStatus.OK, sourceType));
-
-				const future = loadGeoResourceByUrlBasedId(geoResourceId);
-
-				await expectAsync(future.get()).toBeRejectedWithError('Layer parameter is missing for \'http://foo.bar\'');
-			});
-
-			it('throws an error when no WmsGeoResouce was created', async () => {
+			it('returns the first GeoResource provided by the ImportService when no layer is available', async () => {
 				const label = 'label';
 				const layer = 'layer';
 				const url = 'http://foo.bar';
 				const sourceType = new SourceType(SourceTypeName.WMS, '1.1.1');
-				const geoResourceId = `WMS||${label}||${url}||${layer}`;
+				const geoResourceId = `${url}`;
+				const geoResource0 = new WmsGeoResource(geoResourceId, label, url, layer, 'image/png');
+				const geoResource1 = new WmsGeoResource('otherGeoResourceId', label, url, 'otherLayer', 'image/png');
+				const sourceTypeServiceSpy = spyOn(sourceTypeService, 'forUrl').withArgs(url).and.resolveTo(new SourceTypeResult(SourceTypeResultStatus.OK, sourceType));
+				const geoResourceServiceSpy = spyOn(geoResourceService, 'addOrReplace').and.callFake(gr => gr);
+				const importWmsServiceSpy = spyOn(importWmsService, 'forUrl').withArgs(url, { sourceType: sourceType, layers: [], ids: [geoResourceId] })
+					.and.returnValue([geoResource0, geoResource1]);
+
+				const future = loadGeoResourceByUrlBasedId(geoResourceId);
+				const resolvedGeoResource = await future.get();
+
+				expect(future.id).toBe(geoResourceId);
+				expect(future.label).toBe('');
+				expect(resolvedGeoResource).toEqual(geoResource0);
+				expect(resolvedGeoResource.id).toBe(geoResourceId);
+				expect(resolvedGeoResource.label).toBe(label);
+				expect(sourceTypeServiceSpy).toHaveBeenCalled();
+				expect(importWmsServiceSpy).toHaveBeenCalled();
+				expect(geoResourceServiceSpy).toHaveBeenCalled();
+			});
+
+			it('sets the GeoResource label when provided', async () => {
+				const label = 'label';
+				const layer = 'layer';
+				const url = 'http://foo.bar';
+				const sourceType = new SourceType(SourceTypeName.WMS, '1.1.1');
+				const geoResourceId = `${url}||${layer}||${label}`;
+				const geoResource = new WmsGeoResource(geoResourceId, 'some label', url, layer, 'image/png');
+				spyOn(sourceTypeService, 'forUrl').withArgs(url).and.resolveTo(new SourceTypeResult(SourceTypeResultStatus.OK, sourceType));
+				spyOn(geoResourceService, 'addOrReplace').and.callFake(gr => gr);
+				spyOn(importWmsService, 'forUrl').withArgs(url, { sourceType: sourceType, layers: [layer], ids: [geoResourceId] })
+					.and.returnValue([geoResource]);
+
+				const future = loadGeoResourceByUrlBasedId(geoResourceId);
+				const resolvedGeoResource = await future.get();
+
+				expect(future.id).toBe(geoResourceId);
+				expect(future.label).toBe('');
+				expect(resolvedGeoResource).toEqual(geoResource);
+				expect(resolvedGeoResource.id).toBe(geoResourceId);
+				expect(resolvedGeoResource.label).toBe(label);
+			});
+
+			it('throws an error when no WmsGeoResource was created', async () => {
+				const layer = 'layer';
+				const url = 'http://foo.bar';
+				const sourceType = new SourceType(SourceTypeName.WMS, '1.1.1');
+				const geoResourceId = `${url}||${layer}`;
 				spyOn(sourceTypeService, 'forUrl').withArgs(url).and.resolveTo(new SourceTypeResult(SourceTypeResultStatus.OK, sourceType));
 				spyOn(geoResourceService, 'addOrReplace').and.callFake(gr => gr);
 				spyOn(importWmsService, 'forUrl').withArgs(url, { sourceType: sourceType, layers: [layer], ids: [geoResourceId] })
@@ -592,28 +649,10 @@ describe('GeoResource provider', () => {
 			});
 		});
 
-		it('does not overwrite label when not provided', async () => {
-			const originaLabel = 'originalLabel';
-			const url = 'http://foo.bar';
-			const sourceType = new SourceType(SourceTypeName.KML);
-			const geoResourceId = `EWKT||||${url}`;
-			const geoResource = new VectorGeoResource(geoResourceId, originaLabel, VectorSourceType.EWKT);
-			spyOn(sourceTypeService, 'forUrl').withArgs(url).and.resolveTo(new SourceTypeResult(SourceTypeResultStatus.OK, sourceType));
-			const geoResourceFuture = new GeoResourceFuture(geoResourceId, async () => geoResource);
-			spyOn(geoResourceService, 'addOrReplace').and.callFake(gr => gr);
-			spyOn(importVectorDataService, 'forUrl').withArgs(url, { sourceType: sourceType, id: geoResourceId })
-				.and.returnValue(geoResourceFuture);
-
-			const future = loadGeoResourceByUrlBasedId(geoResourceId);
-			const resolvedGeoResource = await future.get();
-
-			expect(resolvedGeoResource.label).toBe(originaLabel);
-		});
-
 		it('throws an error when source type is not supported', async () => {
 			const url = 'http://foo.bar';
 			const sourceType = new SourceType({ FOO: 'bar' });
-			const geoResourceId = `EWKT||||${url}`;
+			const geoResourceId = `${url}`;
 			const geoResource = new VectorGeoResource(geoResourceId, 'label', VectorSourceType.EWKT);
 			spyOn(sourceTypeService, 'forUrl').withArgs(url).and.resolveTo(new SourceTypeResult(SourceTypeResultStatus.OK, sourceType));
 			const geoResourceFuture = new GeoResourceFuture(geoResourceId, async () => geoResource);
@@ -629,7 +668,7 @@ describe('GeoResource provider', () => {
 		it('throws an error when SourceType status is not OK', async () => {
 			const url = 'http://foo.bar';
 			const sourceType = new SourceType(SourceTypeName.KML);
-			const geoResourceId = `EWKT||||${url}`;
+			const geoResourceId = `${url}`;
 			const geoResource = new VectorGeoResource(geoResourceId, 'label', VectorSourceType.EWKT);
 			spyOn(sourceTypeService, 'forUrl').withArgs(url).and.resolveTo(new SourceTypeResult(SourceTypeResultStatus.OTHER, sourceType));
 			const geoResourceFuture = new GeoResourceFuture(geoResourceId, async () => geoResource);
@@ -644,7 +683,7 @@ describe('GeoResource provider', () => {
 
 		it('returns NULL when id does not contain a valid URL', async () => {
 			const url = 'foo.bar';
-			const geoResourceId = `EWKT||||${url}`;
+			const geoResourceId = `${url}`;
 
 			const future = loadGeoResourceByUrlBasedId(geoResourceId);
 
@@ -652,16 +691,7 @@ describe('GeoResource provider', () => {
 		});
 
 		it('returns NULL when id does not contain a URL', async () => {
-			const geoResourceId = 'EWKT||||';
-
-			const future = loadGeoResourceByUrlBasedId(geoResourceId);
-
-			expect(future).toBeNull();
-		});
-
-		it('returns NULL when id does not start with a supported Type', async () => {
-			const url = 'http://foo.bar';
-			const geoResourceId = `FOO||||${url}`;
+			const geoResourceId = 'some';
 
 			const future = loadGeoResourceByUrlBasedId(geoResourceId);
 

--- a/test/service/provider/wmsCapabilities.provider.test.js
+++ b/test/service/provider/wmsCapabilities.provider.test.js
@@ -261,6 +261,69 @@ describe('bvvCapabilitiesProvider', () => {
 		}));
 	});
 
+	it('returns just a subset of all available WmsGeoResources filtered by layer name', async () => {
+		const layerName = 'layer0';
+		const url = 'https://some.url/wms';
+		const sourceType = new SourceType(SourceTypeName.WMS, '42');
+		const responseMock = {
+			ok: true, status: 200, json: () => {
+				return Default_Capabilities_Result;
+			}
+		};
+		spyOn(configService, 'getValueAsPath').withArgs('BACKEND_URL').and.returnValue('BACKEND_URL/');
+		spyOn(httpService, 'post').withArgs('BACKEND_URL/wms/getCapabilities', JSON.stringify({ url: url }), MediaType.JSON).and.resolveTo(responseMock);
+
+
+		const wmsGeoResources = await bvvCapabilitiesProvider(url, { sourceType: sourceType, isAuthenticated: false, ids: [], layers: [layerName] });
+
+		expect(wmsGeoResources).toHaveSize(1);
+		expect(wmsGeoResources[0]).toEqual(jasmine.objectContaining({
+			id: jasmine.stringMatching(/^\d*$/),
+			label: 'Layer 0',
+			url: 'https://online.resource/GetMap?',
+			format: 'image/png',
+			queryable: true,
+			authenticationType: null,
+			layers: layerName
+		}));
+
+	});
+
+	it('returns WmsGeoResource with custom ids', async () => {
+		const layerId0 = 'myLayerId0';
+		const layerId1 = 'myLayerId1';
+		const url = 'https://some.url/wms';
+		const sourceType = new SourceType(SourceTypeName.WMS, '42');
+		const responseMock = {
+			ok: true, status: 200, json: () => {
+				return Default_Capabilities_Result;
+			}
+		};
+		spyOn(configService, 'getValueAsPath').withArgs('BACKEND_URL').and.returnValue('BACKEND_URL/');
+		spyOn(httpService, 'post').withArgs('BACKEND_URL/wms/getCapabilities', JSON.stringify({ url: url }), MediaType.JSON).and.resolveTo(responseMock);
+
+
+		const wmsGeoResources = await bvvCapabilitiesProvider(url, { sourceType: sourceType, isAuthenticated: false, ids: [layerId0, layerId1], layers: [] });
+
+		expect(wmsGeoResources).toHaveSize(2);
+		expect(wmsGeoResources[0]).toEqual(jasmine.objectContaining({
+			id: layerId0,
+			label: 'Layer 0',
+			url: 'https://online.resource/GetMap?',
+			format: 'image/png',
+			queryable: true,
+			authenticationType: null
+		}));
+		expect(wmsGeoResources[1]).toEqual(jasmine.objectContaining({
+			id: layerId1,
+			label: 'Layer 1',
+			url: 'https://online.resource/GetMap?',
+			format: 'image/png',
+			queryable: false,
+			authenticationType: null
+		}));
+	});
+
 	it('recognize extraParams from layers', async () => {
 		const url = 'https://some.url/wms';
 		const username = 'foo';

--- a/test/service/provider/wmsCapabilities.provider.test.js
+++ b/test/service/provider/wmsCapabilities.provider.test.js
@@ -262,7 +262,7 @@ describe('bvvCapabilitiesProvider', () => {
 	});
 
 	it('returns just a subset of all available WmsGeoResources filtered by layer name', async () => {
-		const layerName = 'layer0';
+		const layerName = 'layer1';
 		const url = 'https://some.url/wms';
 		const sourceType = new SourceType(SourceTypeName.WMS, '42');
 		const responseMock = {
@@ -279,10 +279,10 @@ describe('bvvCapabilitiesProvider', () => {
 		expect(wmsGeoResources).toHaveSize(1);
 		expect(wmsGeoResources[0]).toEqual(jasmine.objectContaining({
 			id: jasmine.stringMatching(/^\d*$/),
-			label: 'Layer 0',
+			label: 'Layer 1',
 			url: 'https://online.resource/GetMap?',
 			format: 'image/png',
-			queryable: true,
+			queryable: false,
 			authenticationType: null,
 			layers: layerName
 		}));

--- a/test/service/provider/wmsCapabilities.provider.test.js
+++ b/test/service/provider/wmsCapabilities.provider.test.js
@@ -179,7 +179,7 @@ describe('bvvCapabilitiesProvider', () => {
 		const configSpy = spyOn(configService, 'getValueAsPath').withArgs('BACKEND_URL').and.returnValue('BACKEND_URL/');
 		const httpSpy = spyOn(httpService, 'post').withArgs('BACKEND_URL/wms/getCapabilities', JSON.stringify({ url: url }), MediaType.JSON).and.resolveTo(responseMock);
 
-		bvvCapabilitiesProvider(url, sourceType, false);
+		bvvCapabilitiesProvider(url, { sourceType: sourceType, isAuthenticated: false });
 
 		expect(configSpy).toHaveBeenCalled();
 		expect(httpSpy).toHaveBeenCalled();
@@ -200,7 +200,7 @@ describe('bvvCapabilitiesProvider', () => {
 		const httpSpy = spyOn(httpService, 'post').withArgs('BACKEND_URL/wms/getCapabilities', JSON.stringify({ url: url, username: username, password: password }), MediaType.JSON).and.resolveTo(responseMock);
 		const baaCredentialSpy = spyOn(baaCredentialService, 'get').withArgs(url).and.returnValue({ username: username, password: password });
 
-		bvvCapabilitiesProvider(url, sourceType, true);
+		bvvCapabilitiesProvider(url, { sourceType: sourceType, isAuthenticated: true });
 
 		expect(configSpy).toHaveBeenCalled();
 		expect(httpSpy).toHaveBeenCalled();
@@ -221,7 +221,7 @@ describe('bvvCapabilitiesProvider', () => {
 		spyOn(httpService, 'post').withArgs('BACKEND_URL/wms/getCapabilities', JSON.stringify({ url: url, username: username, password: password }), MediaType.JSON).and.resolveTo(responseMock);
 		spyOn(baaCredentialService, 'get').withArgs(url).and.returnValue({ username: username, password: password });
 
-		const wmsGeoResources = await bvvCapabilitiesProvider(url, sourceType, true);
+		const wmsGeoResources = await bvvCapabilitiesProvider(url, { sourceType: sourceType, isAuthenticated: true });
 
 		expect(wmsGeoResources).toHaveSize(2);
 		expect(wmsGeoResources).toEqual(jasmine.arrayWithExactContents([jasmine.any(WmsGeoResource), jasmine.any(WmsGeoResource)]));
@@ -230,6 +230,7 @@ describe('bvvCapabilitiesProvider', () => {
 
 	it('maps wmsGeoResource with valid properties from layer ', async () => {
 		const url = 'https://some.url/wms';
+		const sourceType = new SourceType(SourceTypeName.WMS, '42');
 		const responseMock = {
 			ok: true, status: 200, json: () => {
 				return Default_Capabilities_Result;
@@ -239,7 +240,7 @@ describe('bvvCapabilitiesProvider', () => {
 		spyOn(httpService, 'post').withArgs('BACKEND_URL/wms/getCapabilities', JSON.stringify({ url: url }), MediaType.JSON).and.resolveTo(responseMock);
 
 
-		const wmsGeoResources = await bvvCapabilitiesProvider(url);
+		const wmsGeoResources = await bvvCapabilitiesProvider(url, { sourceType: sourceType, isAuthenticated: false });
 
 		expect(wmsGeoResources).toHaveSize(2);
 		expect(wmsGeoResources[0]).toEqual(jasmine.objectContaining({
@@ -269,7 +270,7 @@ describe('bvvCapabilitiesProvider', () => {
 		spyOn(configService, 'getValueAsPath').withArgs('BACKEND_URL').and.returnValue('BACKEND_URL/');
 		spyOn(httpService, 'post').withArgs('BACKEND_URL/wms/getCapabilities', JSON.stringify({ url: url }), MediaType.JSON).and.resolveTo(responseMock);
 
-		const wmsGeoResources = await bvvCapabilitiesProvider(url, sourceType);
+		const wmsGeoResources = await bvvCapabilitiesProvider(url, { sourceType: sourceType, isAuthenticated: false });
 
 		expect(wmsGeoResources).toHaveSize(2);
 		expect(wmsGeoResources).toEqual(jasmine.arrayWithExactContents([jasmine.any(WmsGeoResource), jasmine.any(WmsGeoResource)]));
@@ -290,7 +291,7 @@ describe('bvvCapabilitiesProvider', () => {
 		spyOn(httpService, 'post').withArgs('BACKEND_URL/wms/getCapabilities', JSON.stringify({ url: url, username: username, password: password }), MediaType.JSON).and.resolveTo(responseMock);
 		spyOn(baaCredentialService, 'get').withArgs(url).and.returnValue({ username: username, password: password });
 
-		const wmsGeoResources = await bvvCapabilitiesProvider(url, sourceType, true);
+		const wmsGeoResources = await bvvCapabilitiesProvider(url, { sourceType: sourceType, isAuthenticated: true });
 
 		expect(wmsGeoResources).toHaveSize(2);
 		expect(wmsGeoResources).toEqual(jasmine.arrayWithExactContents([
@@ -309,7 +310,7 @@ describe('bvvCapabilitiesProvider', () => {
 		spyOn(httpService, 'post').withArgs('BACKEND_URL/wms/getCapabilities', JSON.stringify({ url: url, username: username, password: password }), MediaType.JSON).and.resolveTo(failedResponseMock);
 		spyOn(baaCredentialService, 'get').withArgs(url).and.returnValue(null);
 
-		await expectAsync(bvvCapabilitiesProvider(url, sourceType, true)).toBeRejectedWithError('Import of WMS failed. Credential for \'https://some.url/wms\' not found.');
+		await expectAsync(bvvCapabilitiesProvider(url, { sourceType: sourceType, isAuthenticated: true })).toBeRejectedWithError('Import of WMS failed. Credential for \'https://some.url/wms\' not found.');
 	});
 
 	it('throws an error on failed request', async () => {
@@ -322,7 +323,7 @@ describe('bvvCapabilitiesProvider', () => {
 		spyOn(httpService, 'post').withArgs('BACKEND_URL/wms/getCapabilities', JSON.stringify({ url: url, username: username, password: password }), MediaType.JSON).and.resolveTo(failedResponseMock);
 		spyOn(baaCredentialService, 'get').withArgs(url).and.returnValue({ username: username, password: password });
 
-		await expectAsync(bvvCapabilitiesProvider(url, sourceType, true)).toBeRejectedWithError('GeoResource for \'https://some.url/wms\' could not be loaded: Http-Status 420');
+		await expectAsync(bvvCapabilitiesProvider(url, { sourceType: sourceType, isAuthenticated: true })).toBeRejectedWithError('GeoResource for \'https://some.url/wms\' could not be loaded: Http-Status 420');
 	});
 
 	it('returns empty list for 404-response', async () => {
@@ -335,7 +336,7 @@ describe('bvvCapabilitiesProvider', () => {
 		spyOn(httpService, 'post').withArgs('BACKEND_URL/wms/getCapabilities', JSON.stringify({ url: url, username: username, password: password }), MediaType.JSON).and.resolveTo(emptyResponseMock);
 		spyOn(baaCredentialService, 'get').withArgs(url).and.returnValue({ username: username, password: password });
 
-		const wmsGeoResources = await bvvCapabilitiesProvider(url, sourceType, true);
+		const wmsGeoResources = await bvvCapabilitiesProvider(url, { sourceType: sourceType, isAuthenticated: true });
 
 		expect(wmsGeoResources).toEqual([]);
 	});
@@ -352,7 +353,7 @@ describe('bvvCapabilitiesProvider', () => {
 		spyOn(configService, 'getValueAsPath').withArgs('BACKEND_URL').and.returnValue('BACKEND_URL/');
 		spyOn(httpService, 'post').withArgs('BACKEND_URL/wms/getCapabilities', JSON.stringify({ url: url }), MediaType.JSON).and.resolveTo(responseMock);
 
-		const wmsGeoResources = await bvvCapabilitiesProvider(url, sourceType);
+		const wmsGeoResources = await bvvCapabilitiesProvider(url, { sourceType: sourceType, isAuthenticated: false });
 
 		expect(wmsGeoResources).toEqual([]);
 	});
@@ -368,7 +369,7 @@ describe('bvvCapabilitiesProvider', () => {
 		spyOn(configService, 'getValueAsPath').withArgs('BACKEND_URL').and.returnValue('BACKEND_URL/');
 		spyOn(httpService, 'post').withArgs('BACKEND_URL/wms/getCapabilities', JSON.stringify({ url: url }), MediaType.JSON).and.resolveTo(responseMock);
 
-		const wmsGeoResources = await bvvCapabilitiesProvider(url, sourceType);
+		const wmsGeoResources = await bvvCapabilitiesProvider(url, { sourceType: sourceType, isAuthenticated: false });
 
 		expect(wmsGeoResources).toEqual([]);
 	});


### PR DESCRIPTION
An URL-based ID for GeoResource must match the following pattern:

KML,GPX,GEOJSON,EWKT:
 `{url}`||`[{label}]`

WMS:
 `{url}`||`{layer}`||`[{label}]`

e.g. `?l=https://foo.bar||wmsLayer0,MyWms,https://foo.bar/kml`
