### PR TITLE
rework GeoResourceInfo handling for imported GeoResources

### DIFF
--- a/src/domain/geoResources.js
+++ b/src/domain/geoResources.js
@@ -189,9 +189,10 @@ export class GeoResource {
 	}
 
 	/**
-	 * Checks if this GeoResource denotes an imported resource.
+	 * Checks if this GeoResource has an HTTP based id
+	 * which means it denotes an (imported) external resource.
 	 */
-	isImported() {
+	isExternal() {
 		return isHttpUrl(this.id.split('||')[0]);
 	}
 

--- a/src/domain/geoResources.js
+++ b/src/domain/geoResources.js
@@ -1,5 +1,6 @@
 import { $injector } from '../injection';
 import { getDefaultAttribution } from '../services/provider/attribution.provider';
+import { isHttpUrl } from '../utils/checks';
 
 /**
  * Attribution data of a GeoResource.
@@ -185,6 +186,13 @@ export class GeoResource {
 	 */
 	hasLabel() {
 		return !!this._label;
+	}
+
+	/**
+	 * Checks if this GeoResource denotes an imported resource.
+	 */
+	isImported() {
+		return isHttpUrl(this.id.split('||')[0]);
 	}
 
 	/**

--- a/src/domain/geoResources.js
+++ b/src/domain/geoResources.js
@@ -64,7 +64,6 @@ export class GeoResource {
 		this._attribution = null;
 		this._attributionProvider = getDefaultAttribution;
 		this._authenticationType = null;
-		this._importedByUser = false;
 		this._queryable = true;
 		this._exportable = true;
 	}
@@ -110,10 +109,6 @@ export class GeoResource {
 
 	get authenticationType() {
 		return this._authenticationType;
-	}
-
-	get importedByUser() {
-		return this._importedByUser;
 	}
 
 	get queryable() {
@@ -171,11 +166,6 @@ export class GeoResource {
 
 	setAuthenticationType(type) {
 		this._authenticationType = type;
-		return this;
-	}
-
-	setImportedByUser(userImported) {
-		this._importedByUser = userImported;
 		return this;
 	}
 

--- a/src/modules/geoResourceInfo/services/GeoResourceInfoService.js
+++ b/src/modules/geoResourceInfo/services/GeoResourceInfoService.js
@@ -3,10 +3,17 @@ import { $injector } from '../../../injection';
 import { FALLBACK_GEORESOURCE_ID_0, FALLBACK_GEORESOURCE_ID_1 } from '../../../services/GeoResourceService';
 
 /**
+ * An async function that returns a {@link GeoResourceInfoResult}.
+ * @async
+ * @param {string} id Id of the requested GeoResource
+ * @typedef {function(id) : (GeoResourceInfoResult|null)} geoResourceInfoProvider
+ */
+
+/**
  * Service for managing {@link GeoResourceInfoResult}s.
- *
  * @class
  * @author costa_gi
+ * @author taulinger
  */
 export class GeoResourceInfoService {
 

--- a/src/modules/geoResourceInfo/services/GeoResourceInfoService.js
+++ b/src/modules/geoResourceInfo/services/GeoResourceInfoService.js
@@ -17,10 +17,10 @@ import { $injector } from '../../../injection';
 export class GeoResourceInfoService {
 
 	/**
-	 * @param {provider} [provider=loadBvvGeoResources]
+	 * @param {provider} [providers=loadBvvGeoResources]
 	 */
-	constructor(provider = [loadBvvGeoResourceInfo]) {
-		this._provider = provider;
+	constructor(providers = [loadBvvGeoResourceInfo]) {
+		this._providers = providers;
 		this._geoResourceInfoResults = new Map();
 		const { EnvironmentService: environmentService } = $injector.inject('EnvironmentService');
 		this._environmentService = environmentService;
@@ -41,7 +41,7 @@ export class GeoResourceInfoService {
 
 		if (!this._geoResourceInfoResults.get(geoResourceId)) {
 			try {
-				for (const provider of this._provider) {
+				for (const provider of this._providers) {
 					const geoResourceInfoResult = await provider(geoResourceId);
 					if (geoResourceInfoResult) {
 						this._geoResourceInfoResults.set(geoResourceId, this._geoResourceInfoResult);

--- a/src/modules/geoResourceInfo/services/GeoResourceInfoService.js
+++ b/src/modules/geoResourceInfo/services/GeoResourceInfoService.js
@@ -1,6 +1,5 @@
 import { loadBvvGeoResourceInfo } from './provider/geoResourceInfoResult.provider';
 import { $injector } from '../../../injection';
-import { FALLBACK_GEORESOURCE_ID_0, FALLBACK_GEORESOURCE_ID_1 } from '../../../services/GeoResourceService';
 
 /**
  * An async function that returns a {@link GeoResourceInfoResult}.
@@ -35,6 +34,11 @@ export class GeoResourceInfoService {
 	* @throws Will throw an error if the provider result is wrong and pass it to the view.
 	*/
 	async byId(geoResourceId) {
+		if (this._environmentService.isStandalone()) {
+			console.warn('GeoResourceInfo could not be fetched from backend. Using a fallback GeoResourceInfo.');
+			return this._newFallbackGeoResourceInfo(geoResourceId);
+		}
+
 		if (!this._geoResourceInfoResults.get(geoResourceId)) {
 			try {
 				for (const provider of this._provider) {
@@ -46,32 +50,15 @@ export class GeoResourceInfoService {
 				}
 			}
 			catch (e) {
-				if (this._environmentService.isStandalone()) {
-					console.warn('georesourceinfo could not be fetched from backend. Using fallback georesourceinfo');
-					this._geoResourceInfoResult = this._newFallbackGeoResourceInfo(geoResourceId);
-					this._geoResourceInfoResults.set(geoResourceId, this._geoResourceInfoResult);
-				}
-				else {
-					throw new Error('Could not load geoResourceInfoResult from provider: ' + e.message);
-				}
+				throw new Error('Could not load a GeoResourceInfoResult from provider: ' + e.message);
 			}
 		}
 		return this._geoResourceInfoResults.get(geoResourceId) ?? null;
 	}
 
-	/**
-	 * @private
-	 */
 	_newFallbackGeoResourceInfo(geoResourceId) {
 		//see fallback georesources in GeoResourceService
-		switch (geoResourceId) {
-			case FALLBACK_GEORESOURCE_ID_0: {
-				return new GeoResourceInfoResult('This is a fallback georesourceinfo', FALLBACK_GEORESOURCE_ID_0);
-			}
-			case FALLBACK_GEORESOURCE_ID_1: {
-				return new GeoResourceInfoResult('This is a fallback georesourceinfo', FALLBACK_GEORESOURCE_ID_1);
-			}
-		}
+		return new GeoResourceInfoResult(`This is a fallback GeoResourceInfoResult for '${geoResourceId}'`, geoResourceId);
 	}
 }
 

--- a/src/modules/geoResourceInfo/services/provider/geoResourceInfoResult.provider.js
+++ b/src/modules/geoResourceInfo/services/provider/geoResourceInfoResult.provider.js
@@ -48,11 +48,11 @@ export const loadBvvGeoResourceInfo = async (geoResourceId) => {
 	};
 
 	const geoResource = geoResourceService.byId(geoResourceId);
-	// only WmsGeoResources are currenly supported as imported GeoResources
-	if (geoResource.isImported() && !(geoResource instanceof WmsGeoResource)) {
+	// only WmsGeoResources are currenly supported as external GeoResources
+	if (geoResource.isExternal() && !(geoResource instanceof WmsGeoResource)) {
 		return null;
 	}
-	const loadGeoResourceInfo = geoResource.isImported() ? loadExternal : loadInternal;
+	const loadGeoResourceInfo = geoResource.isExternal() ? loadExternal : loadInternal;
 
 	const result = await loadGeoResourceInfo(geoResource);
 	switch (result.status) {

--- a/src/modules/geoResourceInfo/services/provider/geoResourceInfoResult.provider.js
+++ b/src/modules/geoResourceInfo/services/provider/geoResourceInfoResult.provider.js
@@ -1,7 +1,7 @@
 import { $injector } from '../../../../injection';
 import { GeoResourceInfoResult } from '../GeoResourceInfoService';
 import { MediaType } from '../../../../services/HttpService';
-import { GeoResourceAuthenticationType } from '../../../../domain/geoResources';
+import { GeoResourceAuthenticationType, WmsGeoResource } from '../../../../domain/geoResources';
 
 /**
  * Uses the BVV endpoint to load GeoResourceInfoResult.
@@ -22,6 +22,7 @@ export const loadBvvGeoResourceInfo = async (geoResourceId) => {
 	};
 
 	const loadExternal = async (geoResource) => {
+
 		const url = `${configService.getValueAsPath('BACKEND_URL')}georesource/info/external/wms`;
 
 		const getPayload = geoResource => {
@@ -47,7 +48,11 @@ export const loadBvvGeoResourceInfo = async (geoResourceId) => {
 	};
 
 	const geoResource = geoResourceService.byId(geoResourceId);
-	const loadGeoResourceInfo = geoResource.importedByUser ? loadExternal : loadInternal;
+	// only WmsGeoResources are currenly supported as imported GeoResources
+	if (geoResource.isImported() && !(geoResource instanceof WmsGeoResource)) {
+		return null;
+	}
+	const loadGeoResourceInfo = geoResource.isImported() ? loadExternal : loadInternal;
 
 	const result = await loadGeoResourceInfo(geoResource);
 	switch (result.status) {

--- a/src/modules/geoResourceInfo/services/provider/geoResourceInfoResult.provider.js
+++ b/src/modules/geoResourceInfo/services/provider/geoResourceInfoResult.provider.js
@@ -5,6 +5,8 @@ import { GeoResourceAuthenticationType } from '../../../../domain/geoResources';
 
 /**
  * Uses the BVV endpoint to load GeoResourceInfoResult.
+ * @implements geoResourceInfoProvider
+ * @async
  * @function
  * @returns {Promise<GeoResourceInfoResult>}
  */

--- a/src/services/ImportWmsService.js
+++ b/src/services/ImportWmsService.js
@@ -62,7 +62,6 @@ export class ImportWmsService {
 		const completeOptions = { ...this._newDefaultImportWmsOptions(), ...options };
 		const geoResources = await this._wmsCapabilitiesProvider(this._urlService.originAndPathname(url), completeOptions);
 		return geoResources
-			.map(gr => gr.setImportedByUser(true))
 			.map(gr => gr.setAttributionProvider(getAttributionProviderForGeoResourceImportedByUrl(url)))
 			.map(gr => this._geoResourceService.addOrReplace(gr));
 	}

--- a/src/services/provider/featureInfo.provider.js
+++ b/src/services/provider/featureInfo.provider.js
@@ -40,17 +40,6 @@ export const loadBvvFeatureInfo = async (geoResourceId, coordinate3857, mapResol
 
 	if (geoResource) {
 
-		const determineId = geoResource => {
-			if (geoResource.importedByUser) {
-
-				switch (geoResource.getType()) {
-					case GeoResourceTypes.WMS:
-						return `${geoResource.url}||${geoResource.layers}`;
-				}
-			}
-			return geoResource.id;
-		};
-
 		const determineCredential = geoResource => {
 			return geoResource.authenticationType === GeoResourceAuthenticationType.BAA
 				? baaCredentialService.get(geoResource.url) ?? throwError()
@@ -58,7 +47,7 @@ export const loadBvvFeatureInfo = async (geoResourceId, coordinate3857, mapResol
 		};
 
 		const requestPayload = { ...{
-			id: determineId(geoResource),
+			id: geoResource.id,
 			easting: coordinate3857[0], northing: coordinate3857[1],
 			srid: 3857,
 			resolution: mapResolution

--- a/src/services/provider/featureInfo.provider.js
+++ b/src/services/provider/featureInfo.provider.js
@@ -2,7 +2,7 @@
  * @module service/provider
  */
 import { $injector } from '../../injection';
-import { GeoResourceAuthenticationType, GeoResourceTypes } from '../../domain/geoResources';
+import { GeoResourceAuthenticationType } from '../../domain/geoResources';
 import { FeatureInfoResult } from '../FeatureInfoService';
 import { MediaType } from '../HttpService';
 

--- a/test/domain/geoResources.test.js
+++ b/test/domain/geoResources.test.js
@@ -167,7 +167,6 @@ describe('GeoResource', () => {
 				expect(georesource.hidden).toBeFalse();
 				expect(georesource.attribution).toBeNull();
 				expect(georesource.authenticationType).toBeNull();
-				expect(georesource.importedByUser).toBeFalse();
 				expect(georesource._attributionProvider).toBe(getDefaultAttribution);
 				expect(georesource._queryable).toBeTrue();
 				expect(georesource._exportable).toBeTrue();
@@ -185,7 +184,6 @@ describe('GeoResource', () => {
 					.setLabel('some label')
 					.setAttribution('some attribution')
 					.setAuthenticationType(GeoResourceAuthenticationType.BAA)
-					.setImportedByUser(true)
 					.setQueryable(false)
 					.setExportable(false);
 
@@ -197,7 +195,6 @@ describe('GeoResource', () => {
 				expect(georesource.label).toBe('some label');
 				expect(georesource.attribution).toBe('some attribution');
 				expect(georesource.authenticationType).toEqual(GeoResourceAuthenticationType.BAA);
-				expect(georesource.importedByUser).toBeTrue();
 				expect(georesource.queryable).toBeFalse();
 				expect(georesource.exportable).toBeFalse();
 			});

--- a/test/domain/geoResources.test.js
+++ b/test/domain/geoResources.test.js
@@ -85,6 +85,13 @@ describe('GeoResource', () => {
 				expect(new GeoResourceImpl('id', 'foo').hasLabel()).toBeTrue();
 			});
 
+			it('provides a check for detecting an imported GeoResource ', () => {
+
+				expect(new GeoResourceImpl('id').isImported()).toBeFalse();
+				expect(new GeoResourceImpl('https://foo.bar', null).isImported()).toBeTrue();
+				expect(new GeoResourceImpl('https://foo.bar||some ||thing', null).isImported()).toBeTrue();
+			});
+
 			it('sets the attribution provider', () => {
 
 				const provider = jasmine.createSpy();

--- a/test/domain/geoResources.test.js
+++ b/test/domain/geoResources.test.js
@@ -87,9 +87,9 @@ describe('GeoResource', () => {
 
 			it('provides a check for detecting an imported GeoResource ', () => {
 
-				expect(new GeoResourceImpl('id').isImported()).toBeFalse();
-				expect(new GeoResourceImpl('https://foo.bar', null).isImported()).toBeTrue();
-				expect(new GeoResourceImpl('https://foo.bar||some ||thing', null).isImported()).toBeTrue();
+				expect(new GeoResourceImpl('id').isExternal()).toBeFalse();
+				expect(new GeoResourceImpl('https://foo.bar', null).isExternal()).toBeTrue();
+				expect(new GeoResourceImpl('https://foo.bar||some||thing', null).isExternal()).toBeTrue();
 			});
 
 			it('sets the attribution provider', () => {

--- a/test/modules/geoResourceInfo/services/GeoResourceInfoService.test.js
+++ b/test/modules/geoResourceInfo/services/GeoResourceInfoService.test.js
@@ -20,23 +20,22 @@ describe('GeoResourceInfoService', () => {
 
 		const geoResourceInfoService = new GeoResourceInfoService();
 
-		expect(geoResourceInfoService._provider).toEqual(loadBvvGeoResourceInfo);
+		expect(geoResourceInfoService._provider).toEqual([loadBvvGeoResourceInfo]);
 	});
 
 	it('initializes the service with custom provider', async () => {
 		const customProvider = async () => { };
-		const instanceUnderTest = new GeoResourceInfoService(customProvider);
+		const instanceUnderTest = new GeoResourceInfoService([customProvider]);
 		expect(instanceUnderTest._provider).toBeDefined();
-		expect(instanceUnderTest._provider).toEqual(customProvider);
+		expect(instanceUnderTest._provider).toEqual([customProvider]);
 	});
-
 
 	it('should return a GeoResourceInfoResult with html content', async () => {
 
 		const loadMockBvvGeoResourceInfo = async () => {
 			return new GeoResourceInfoResult('<b>content</b>');
 		};
-		const geoResourceInfoSerice = new GeoResourceInfoService(loadMockBvvGeoResourceInfo);
+		const geoResourceInfoSerice = new GeoResourceInfoService([loadMockBvvGeoResourceInfo]);
 
 		const geoResourceInfoResult = await geoResourceInfoSerice.byId(geoResourceId);
 
@@ -49,7 +48,7 @@ describe('GeoResourceInfoService', () => {
 		const loadMockBvvGeoResourceInfo = async () => {
 			return null;
 		};
-		const geoResourceInfoSerice = new GeoResourceInfoService(loadMockBvvGeoResourceInfo);
+		const geoResourceInfoSerice = new GeoResourceInfoService([loadMockBvvGeoResourceInfo]);
 
 		const result = await geoResourceInfoSerice.byId(geoResourceId);
 		expect(result).toBeNull();
@@ -61,7 +60,7 @@ describe('GeoResourceInfoService', () => {
 		const loadMockBvvGeoResourceInfo = async () => {
 			return Promise.reject(new Error(providerErrMsg));
 		};
-		const geoResourceInfoSerice = new GeoResourceInfoService(loadMockBvvGeoResourceInfo);
+		const geoResourceInfoSerice = new GeoResourceInfoService([loadMockBvvGeoResourceInfo]);
 
 		try {
 			await geoResourceInfoSerice.byId(geoResourceId);
@@ -99,7 +98,7 @@ describe('GeoResourceInfoService', () => {
 				return Promise.reject(new Error(providerErrMsg));
 			};
 			const warnSpy = spyOn(console, 'warn');
-			const geoResourceInfoSerice = new GeoResourceInfoService(loadMockBvvGeoResourceInfo);
+			const geoResourceInfoSerice = new GeoResourceInfoService([loadMockBvvGeoResourceInfo]);
 			const geoResourceInfoResult = await geoResourceInfoSerice.byId(FALLBACK_GEORESOURCE_ID_0);
 
 
@@ -116,7 +115,7 @@ describe('GeoResourceInfoService', () => {
 				return Promise.reject(new Error(providerErrMsg));
 			};
 			const warnSpy = spyOn(console, 'warn');
-			const geoResourceInfoSerice = new GeoResourceInfoService(loadMockBvvGeoResourceInfo);
+			const geoResourceInfoSerice = new GeoResourceInfoService([loadMockBvvGeoResourceInfo]);
 			const geoResourceInfoResult = await geoResourceInfoSerice.byId(FALLBACK_GEORESOURCE_ID_1);
 
 
@@ -131,7 +130,7 @@ describe('GeoResourceInfoService', () => {
 			const loadMockBvvGeoResourceInfo = async () => {
 				return Promise.reject(new Error(providerErrMsg));
 			};
-			const geoResourceInfoSerice = new GeoResourceInfoService(loadMockBvvGeoResourceInfo);
+			const geoResourceInfoSerice = new GeoResourceInfoService([loadMockBvvGeoResourceInfo]);
 
 			try {
 				await geoResourceInfoSerice.byId(geoResourceId);
@@ -158,7 +157,7 @@ describe('GeoResourceInfoService', () => {
 			const loadMockBvvGeoResourceInfo = async () => {
 				return new GeoResourceInfoResult('<div><content/div>');
 			};
-			const geoResourceInfoSerice = new GeoResourceInfoService(loadMockBvvGeoResourceInfo);
+			const geoResourceInfoSerice = new GeoResourceInfoService([loadMockBvvGeoResourceInfo]);
 			geoResourceInfoSerice._geoResourceInfoResults.set(FALLBACK_GEORESOURCE_ID_1, null);
 
 			const geoResourceInfoResult = await geoResourceInfoSerice.byId(FALLBACK_GEORESOURCE_ID_0);

--- a/test/modules/geoResourceInfo/services/GeoResourceInfoService.test.js
+++ b/test/modules/geoResourceInfo/services/GeoResourceInfoService.test.js
@@ -20,14 +20,14 @@ describe('GeoResourceInfoService', () => {
 
 		const geoResourceInfoService = new GeoResourceInfoService();
 
-		expect(geoResourceInfoService._provider).toEqual([loadBvvGeoResourceInfo]);
+		expect(geoResourceInfoService._providers).toEqual([loadBvvGeoResourceInfo]);
 	});
 
 	it('initializes the service with custom provider', async () => {
 		const customProvider = async () => { };
 		const instanceUnderTest = new GeoResourceInfoService([customProvider]);
-		expect(instanceUnderTest._provider).toBeDefined();
-		expect(instanceUnderTest._provider).toEqual([customProvider]);
+		expect(instanceUnderTest._providers).toBeDefined();
+		expect(instanceUnderTest._providers).toEqual([customProvider]);
 	});
 
 	it('should return a GeoResourceInfoResult with html content', async () => {

--- a/test/modules/geoResourceInfo/services/GeoResourceInfoService.test.js
+++ b/test/modules/geoResourceInfo/services/GeoResourceInfoService.test.js
@@ -54,7 +54,7 @@ describe('GeoResourceInfoService', () => {
 		expect(result).toBeNull();
 	});
 
-	it('should throw error when backend provides unknown respone', async () => {
+	it('should throw an error when backend provides unknown response', async () => {
 
 		const providerErrMsg = 'GeoResourceInfo for \'914c9263-5312-453e-b3eb-5104db1bf788\' could not be loaded';
 		const loadMockBvvGeoResourceInfo = async () => {
@@ -62,13 +62,7 @@ describe('GeoResourceInfoService', () => {
 		};
 		const geoResourceInfoSerice = new GeoResourceInfoService([loadMockBvvGeoResourceInfo]);
 
-		try {
-			await geoResourceInfoSerice.byId(geoResourceId);
-			throw new Error('Promise should not be resolved');
-		}
-		catch (err) {
-			expect(err.message).toBe('Could not load geoResourceInfoResult from provider: ' + providerErrMsg);
-		}
+		await expectAsync(geoResourceInfoSerice.byId(geoResourceId)).toBeRejectedWithError('Could not load a GeoResourceInfoResult from provider: ' + providerErrMsg);
 	});
 
 	describe('GeoResourceInfoResult', () => {
@@ -90,7 +84,7 @@ describe('GeoResourceInfoService', () => {
 
 	describe('provider cannot fulfill', () => {
 
-		it('loads fallback atkis when we are in standalone mode', async () => {
+		it('loads fallback when we are in standalone mode', async () => {
 			spyOn(environmentService, 'isStandalone').and.returnValue(true);
 
 			const providerErrMsg = 'GeoResourceInfo for \'914c9263-5312-453e-b3eb-5104db1bf788\' could not be loaded';
@@ -102,26 +96,9 @@ describe('GeoResourceInfoService', () => {
 			const geoResourceInfoResult = await geoResourceInfoSerice.byId(FALLBACK_GEORESOURCE_ID_0);
 
 
-			expect(geoResourceInfoResult.content).toBe('This is a fallback georesourceinfo');
+			expect(geoResourceInfoResult.content).toBe(`This is a fallback GeoResourceInfoResult for '${FALLBACK_GEORESOURCE_ID_0}'`);
 			expect(geoResourceInfoResult.title).toBe(FALLBACK_GEORESOURCE_ID_0);
-			expect(warnSpy).toHaveBeenCalledWith('georesourceinfo could not be fetched from backend. Using fallback georesourceinfo');
-		});
-
-		it('loads fallback atkis_sw when we are in standalone mode', async () => {
-			spyOn(environmentService, 'isStandalone').and.returnValue(true);
-
-			const providerErrMsg = 'GeoResourceInfo for \'914c9263-5312-453e-b3eb-5104db1bf788\' could not be loaded';
-			const loadMockBvvGeoResourceInfo = async () => {
-				return Promise.reject(new Error(providerErrMsg));
-			};
-			const warnSpy = spyOn(console, 'warn');
-			const geoResourceInfoSerice = new GeoResourceInfoService([loadMockBvvGeoResourceInfo]);
-			const geoResourceInfoResult = await geoResourceInfoSerice.byId(FALLBACK_GEORESOURCE_ID_1);
-
-
-			expect(geoResourceInfoResult.content).toBe('This is a fallback georesourceinfo');
-			expect(geoResourceInfoResult.title).toBe(FALLBACK_GEORESOURCE_ID_1);
-			expect(warnSpy).toHaveBeenCalledWith('georesourceinfo could not be fetched from backend. Using fallback georesourceinfo');
+			expect(warnSpy).toHaveBeenCalledWith('GeoResourceInfo could not be fetched from backend. Using a fallback GeoResourceInfo.');
 		});
 
 		it('logs an error when we are NOT in standalone mode', async () => {
@@ -132,13 +109,7 @@ describe('GeoResourceInfoService', () => {
 			};
 			const geoResourceInfoSerice = new GeoResourceInfoService([loadMockBvvGeoResourceInfo]);
 
-			try {
-				await geoResourceInfoSerice.byId(geoResourceId);
-				throw new Error('Promise should not be resolved');
-			}
-			catch (err) {
-				expect(err.message).toBe('Could not load geoResourceInfoResult from provider: ' + providerErrMsg);
-			}
+			await expectAsync(geoResourceInfoSerice.byId(geoResourceId)).toBeRejectedWithError('Could not load a GeoResourceInfoResult from provider: ' + providerErrMsg);
 		});
 
 		it('just provides geoResourceInfoResult when geoResourceId already available in locale cache', async () => {

--- a/test/service/ImportWmsService.test.js
+++ b/test/service/ImportWmsService.test.js
@@ -77,7 +77,6 @@ describe('ImportWmsService', () => {
 
 			expect(result).toHaveSize(3);
 			result.forEach(gr => {
-				expect(gr.importedByUser).toBeTrue();
 				expect(gr.getAttribution()).toEqual([getAttributionProviderForGeoResourceImportedByUrl(url)(gr)]);
 				expect(gr.marker).toBe(handledByGeoResourceServiceMarker);
 			});

--- a/test/service/provider/featureInfo.provider.test.js
+++ b/test/service/provider/featureInfo.provider.test.js
@@ -67,45 +67,6 @@ describe('FeatureInfoResult provider', () => {
 			expect(featureInfoResult.title).toBe(title);
 		});
 
-		it('loads a FeatureInfoResult for a user imported WmsGeoResource', async () => {
-
-			const backendUrl = 'https://backend.url/';
-			const geoResourceId = 'geoResourceId';
-			const geoResourceUrl = 'url';
-			const geoResourceLayer = 'layer';
-			const wmsGeoResource = new WmsGeoResource(geoResourceId, '', geoResourceUrl, geoResourceLayer, '').setImportedByUser(true);
-			const coordinate3857 = [38, 57];
-			const mapResolution = 5;
-			const content = 'content';
-			const title = 'title';
-			const configServiceSpy = spyOn(configService, 'getValueAsPath').withArgs('BACKEND_URL').and.returnValue(backendUrl);
-			spyOn(geoResourceService, 'byId').withArgs(geoResourceId).and.returnValue(wmsGeoResource);
-			spyOn(baaCredentialService, 'get').withArgs(geoResourceUrl).and.returnValue(null);
-			const expectedRequestPayload = JSON.stringify({
-				id: `${geoResourceUrl}||${geoResourceLayer}`,
-				easting: coordinate3857[0], northing: coordinate3857[1],
-				srid: 3857,
-				resolution: mapResolution
-			});
-			const featureInfoResultPayload = { title: title, content: 'content' };
-			const httpServiceSpy = spyOn(httpService, 'post')
-				.withArgs(`${backendUrl}getFeature`, expectedRequestPayload, MediaType.JSON, { timeout: 5000 })
-				.and.resolveTo(
-					new Response(
-						JSON.stringify(
-							featureInfoResultPayload
-						)
-					)
-				);
-
-			const featureInfoResult = await loadBvvFeatureInfo(geoResourceId, coordinate3857, mapResolution);
-
-			expect(configServiceSpy).toHaveBeenCalled();
-			expect(httpServiceSpy).toHaveBeenCalled();
-			expect(featureInfoResult.content).toBe(content);
-			expect(featureInfoResult.title).toBe(title);
-		});
-
 		it('loads a FeatureInfoResult for a user imported BAA restricted WmsGeoResource', async () => {
 
 			const backendUrl = 'https://backend.url/';
@@ -117,7 +78,6 @@ describe('FeatureInfoResult provider', () => {
 				password: 'p'
 			};
 			const wmsGeoResource = new WmsGeoResource(geoResourceId, '', geoResourceUrl, geoResourceLayer, '')
-				.setImportedByUser(true)
 				.setAuthenticationType(GeoResourceAuthenticationType.BAA);
 			const coordinate3857 = [38, 57];
 			const mapResolution = 5;
@@ -127,7 +87,7 @@ describe('FeatureInfoResult provider', () => {
 			spyOn(geoResourceService, 'byId').withArgs(geoResourceId).and.returnValue(wmsGeoResource);
 			spyOn(baaCredentialService, 'get').withArgs(geoResourceUrl).and.returnValue(credential);
 			const expectedRequestPayload = JSON.stringify({
-				id: `${geoResourceUrl}||${geoResourceLayer}`,
+				id: geoResourceId,
 				easting: coordinate3857[0], northing: coordinate3857[1],
 				srid: 3857,
 				resolution: mapResolution,
@@ -152,6 +112,92 @@ describe('FeatureInfoResult provider', () => {
 			expect(featureInfoResult.content).toBe(content);
 			expect(featureInfoResult.title).toBe(title);
 		});
+
+		// it('loads a FeatureInfoResult for a user imported WmsGeoResource', async () => {
+
+		// 	const backendUrl = 'https://backend.url/';
+		// 	const geoResourceId = 'geoResourceId';
+		// 	const geoResourceUrl = 'url';
+		// 	const geoResourceLayer = 'layer';
+		// 	const wmsGeoResource = new WmsGeoResource(geoResourceId, '', geoResourceUrl, geoResourceLayer, '').setImportedByUser(true);
+		// 	const coordinate3857 = [38, 57];
+		// 	const mapResolution = 5;
+		// 	const content = 'content';
+		// 	const title = 'title';
+		// 	const configServiceSpy = spyOn(configService, 'getValueAsPath').withArgs('BACKEND_URL').and.returnValue(backendUrl);
+		// 	spyOn(geoResourceService, 'byId').withArgs(geoResourceId).and.returnValue(wmsGeoResource);
+		// 	spyOn(baaCredentialService, 'get').withArgs(geoResourceUrl).and.returnValue(null);
+		// 	const expectedRequestPayload = JSON.stringify({
+		// 		id: `${geoResourceUrl}||${geoResourceLayer}`,
+		// 		easting: coordinate3857[0], northing: coordinate3857[1],
+		// 		srid: 3857,
+		// 		resolution: mapResolution
+		// 	});
+		// 	const featureInfoResultPayload = { title: title, content: 'content' };
+		// 	const httpServiceSpy = spyOn(httpService, 'post')
+		// 		.withArgs(`${backendUrl}getFeature`, expectedRequestPayload, MediaType.JSON, { timeout: 5000 })
+		// 		.and.resolveTo(
+		// 			new Response(
+		// 				JSON.stringify(
+		// 					featureInfoResultPayload
+		// 				)
+		// 			)
+		// 		);
+
+		// 	const featureInfoResult = await loadBvvFeatureInfo(geoResourceId, coordinate3857, mapResolution);
+
+		// 	expect(configServiceSpy).toHaveBeenCalled();
+		// 	expect(httpServiceSpy).toHaveBeenCalled();
+		// 	expect(featureInfoResult.content).toBe(content);
+		// 	expect(featureInfoResult.title).toBe(title);
+		// });
+
+		// it('loads a FeatureInfoResult for a user imported BAA restricted WmsGeoResource', async () => {
+
+		// 	const backendUrl = 'https://backend.url/';
+		// 	const geoResourceId = 'geoResourceId';
+		// 	const geoResourceUrl = 'url';
+		// 	const geoResourceLayer = 'layer';
+		// 	const credential = {
+		// 		username: 'u',
+		// 		password: 'p'
+		// 	};
+		// 	const wmsGeoResource = new WmsGeoResource(geoResourceId, '', geoResourceUrl, geoResourceLayer, '')
+		// 		.setImportedByUser(true)
+		// 		.setAuthenticationType(GeoResourceAuthenticationType.BAA);
+		// 	const coordinate3857 = [38, 57];
+		// 	const mapResolution = 5;
+		// 	const content = 'content';
+		// 	const title = 'title';
+		// 	const configServiceSpy = spyOn(configService, 'getValueAsPath').withArgs('BACKEND_URL').and.returnValue(backendUrl);
+		// 	spyOn(geoResourceService, 'byId').withArgs(geoResourceId).and.returnValue(wmsGeoResource);
+		// 	spyOn(baaCredentialService, 'get').withArgs(geoResourceUrl).and.returnValue(credential);
+		// 	const expectedRequestPayload = JSON.stringify({
+		// 		id: `${geoResourceUrl}||${geoResourceLayer}`,
+		// 		easting: coordinate3857[0], northing: coordinate3857[1],
+		// 		srid: 3857,
+		// 		resolution: mapResolution,
+		// 		username: credential.username,
+		// 		password: credential.password
+		// 	});
+		// 	const featureInfoResultPayload = { title: title, content: 'content' };
+		// 	const httpServiceSpy = spyOn(httpService, 'post')
+		// 		.withArgs(`${backendUrl}getFeature`, expectedRequestPayload, MediaType.JSON, { timeout: 5000 })
+		// 		.and.resolveTo(
+		// 			new Response(
+		// 				JSON.stringify(
+		// 					featureInfoResultPayload
+		// 				)
+		// 			)
+		// 		);
+
+		// 	const featureInfoResult = await loadBvvFeatureInfo(geoResourceId, coordinate3857, mapResolution);
+
+		// 	expect(configServiceSpy).toHaveBeenCalled();
+		// 	expect(httpServiceSpy).toHaveBeenCalled();
+		// 	expect(featureInfoResult.content).toBe(content);
+		// 	expect(featureInfoResult.title).toBe(title);
+		// });
 
 		it('throws an error when BaaCredentialService cannot fulfill', async () => {
 

--- a/test/service/provider/featureInfo.provider.test.js
+++ b/test/service/provider/featureInfo.provider.test.js
@@ -126,13 +126,7 @@ describe('FeatureInfoResult provider', () => {
 			spyOn(geoResourceService, 'byId').withArgs(geoResourceId).and.returnValue(wmsGeoResource);
 			spyOn(baaCredentialService, 'get').withArgs(geoResourceUrl).and.returnValue(null);
 
-			try {
-				await loadBvvFeatureInfo(geoResourceId, coordinate3857, mapResolution);
-				throw new Error('Promise should not be resolved');
-			}
-			catch (ex) {
-				expect(ex.message).toBe('FeatureInfoResult could not be retrieved');
-			}
+			await expectAsync(loadBvvFeatureInfo(geoResourceId, coordinate3857, mapResolution)).toBeRejectedWithError('FeatureInfoResult could not be retrieved');
 		});
 
 		it('returns Null when no content is available', async () => {
@@ -184,15 +178,9 @@ describe('FeatureInfoResult provider', () => {
 					new Response(null, { status: 500 })
 				);
 
-			try {
-				await loadBvvFeatureInfo(geoResourceId, coordinate3857, mapResolution);
-				throw new Error('Promise should not be resolved');
-			}
-			catch (ex) {
-				expect(configServiceSpy).toHaveBeenCalled();
-				expect(httpServiceSpy).toHaveBeenCalled();
-				expect(ex.message).toBe('FeatureInfoResult could not be retrieved');
-			}
+			await expectAsync(loadBvvFeatureInfo(geoResourceId, coordinate3857, mapResolution)).toBeRejectedWithError('FeatureInfoResult could not be retrieved');
+			expect(configServiceSpy).toHaveBeenCalled();
+			expect(httpServiceSpy).toHaveBeenCalled();
 		});
 
 		it('throws an exception when GeoResourceService cannot fulfill', async () => {
@@ -202,13 +190,7 @@ describe('FeatureInfoResult provider', () => {
 			const mapResolution = 5;
 			spyOn(geoResourceService, 'byId').withArgs(geoResourceId).and.returnValue(null);
 
-			try {
-				await loadBvvFeatureInfo(geoResourceId, coordinate3857, mapResolution);
-				throw new Error('Promise should not be resolved');
-			}
-			catch (ex) {
-				expect(ex.message).toBe('FeatureInfoResult could not be retrieved');
-			}
+			await expectAsync(loadBvvFeatureInfo(geoResourceId, coordinate3857, mapResolution)).toBeRejectedWithError('FeatureInfoResult could not be retrieved');
 		});
 	});
 });

--- a/test/service/provider/featureInfo.provider.test.js
+++ b/test/service/provider/featureInfo.provider.test.js
@@ -67,7 +67,7 @@ describe('FeatureInfoResult provider', () => {
 			expect(featureInfoResult.title).toBe(title);
 		});
 
-		it('loads a FeatureInfoResult for a user imported BAA restricted WmsGeoResource', async () => {
+		it('loads a FeatureInfoResult for a imported and BAA restricted WmsGeoResource', async () => {
 
 			const backendUrl = 'https://backend.url/';
 			const geoResourceId = 'geoResourceId';
@@ -113,92 +113,6 @@ describe('FeatureInfoResult provider', () => {
 			expect(featureInfoResult.title).toBe(title);
 		});
 
-		// it('loads a FeatureInfoResult for a user imported WmsGeoResource', async () => {
-
-		// 	const backendUrl = 'https://backend.url/';
-		// 	const geoResourceId = 'geoResourceId';
-		// 	const geoResourceUrl = 'url';
-		// 	const geoResourceLayer = 'layer';
-		// 	const wmsGeoResource = new WmsGeoResource(geoResourceId, '', geoResourceUrl, geoResourceLayer, '').setImportedByUser(true);
-		// 	const coordinate3857 = [38, 57];
-		// 	const mapResolution = 5;
-		// 	const content = 'content';
-		// 	const title = 'title';
-		// 	const configServiceSpy = spyOn(configService, 'getValueAsPath').withArgs('BACKEND_URL').and.returnValue(backendUrl);
-		// 	spyOn(geoResourceService, 'byId').withArgs(geoResourceId).and.returnValue(wmsGeoResource);
-		// 	spyOn(baaCredentialService, 'get').withArgs(geoResourceUrl).and.returnValue(null);
-		// 	const expectedRequestPayload = JSON.stringify({
-		// 		id: `${geoResourceUrl}||${geoResourceLayer}`,
-		// 		easting: coordinate3857[0], northing: coordinate3857[1],
-		// 		srid: 3857,
-		// 		resolution: mapResolution
-		// 	});
-		// 	const featureInfoResultPayload = { title: title, content: 'content' };
-		// 	const httpServiceSpy = spyOn(httpService, 'post')
-		// 		.withArgs(`${backendUrl}getFeature`, expectedRequestPayload, MediaType.JSON, { timeout: 5000 })
-		// 		.and.resolveTo(
-		// 			new Response(
-		// 				JSON.stringify(
-		// 					featureInfoResultPayload
-		// 				)
-		// 			)
-		// 		);
-
-		// 	const featureInfoResult = await loadBvvFeatureInfo(geoResourceId, coordinate3857, mapResolution);
-
-		// 	expect(configServiceSpy).toHaveBeenCalled();
-		// 	expect(httpServiceSpy).toHaveBeenCalled();
-		// 	expect(featureInfoResult.content).toBe(content);
-		// 	expect(featureInfoResult.title).toBe(title);
-		// });
-
-		// it('loads a FeatureInfoResult for a user imported BAA restricted WmsGeoResource', async () => {
-
-		// 	const backendUrl = 'https://backend.url/';
-		// 	const geoResourceId = 'geoResourceId';
-		// 	const geoResourceUrl = 'url';
-		// 	const geoResourceLayer = 'layer';
-		// 	const credential = {
-		// 		username: 'u',
-		// 		password: 'p'
-		// 	};
-		// 	const wmsGeoResource = new WmsGeoResource(geoResourceId, '', geoResourceUrl, geoResourceLayer, '')
-		// 		.setImportedByUser(true)
-		// 		.setAuthenticationType(GeoResourceAuthenticationType.BAA);
-		// 	const coordinate3857 = [38, 57];
-		// 	const mapResolution = 5;
-		// 	const content = 'content';
-		// 	const title = 'title';
-		// 	const configServiceSpy = spyOn(configService, 'getValueAsPath').withArgs('BACKEND_URL').and.returnValue(backendUrl);
-		// 	spyOn(geoResourceService, 'byId').withArgs(geoResourceId).and.returnValue(wmsGeoResource);
-		// 	spyOn(baaCredentialService, 'get').withArgs(geoResourceUrl).and.returnValue(credential);
-		// 	const expectedRequestPayload = JSON.stringify({
-		// 		id: `${geoResourceUrl}||${geoResourceLayer}`,
-		// 		easting: coordinate3857[0], northing: coordinate3857[1],
-		// 		srid: 3857,
-		// 		resolution: mapResolution,
-		// 		username: credential.username,
-		// 		password: credential.password
-		// 	});
-		// 	const featureInfoResultPayload = { title: title, content: 'content' };
-		// 	const httpServiceSpy = spyOn(httpService, 'post')
-		// 		.withArgs(`${backendUrl}getFeature`, expectedRequestPayload, MediaType.JSON, { timeout: 5000 })
-		// 		.and.resolveTo(
-		// 			new Response(
-		// 				JSON.stringify(
-		// 					featureInfoResultPayload
-		// 				)
-		// 			)
-		// 		);
-
-		// 	const featureInfoResult = await loadBvvFeatureInfo(geoResourceId, coordinate3857, mapResolution);
-
-		// 	expect(configServiceSpy).toHaveBeenCalled();
-		// 	expect(httpServiceSpy).toHaveBeenCalled();
-		// 	expect(featureInfoResult.content).toBe(content);
-		// 	expect(featureInfoResult.title).toBe(title);
-		// });
-
 		it('throws an error when BaaCredentialService cannot fulfill', async () => {
 
 			const geoResourceId = 'geoResourceId';
@@ -206,7 +120,6 @@ describe('FeatureInfoResult provider', () => {
 			const geoResourceLayer = 'layer';
 
 			const wmsGeoResource = new WmsGeoResource(geoResourceId, '', geoResourceUrl, geoResourceLayer, '')
-				.setImportedByUser(true)
 				.setAuthenticationType(GeoResourceAuthenticationType.BAA);
 			const coordinate3857 = [38, 57];
 			const mapResolution = 5;


### PR DESCRIPTION
- [x] Add additional GeoResourceInfo providers (e.g. for VectorGeoResources)
- [x] Remove obsolete GeoResource property `importedByUser` 
- [x] Add method `#isExternal` to GeoResource 