### PR TITLE
prevent unnecessary calls of History API

### DIFF
--- a/src/plugins/HistoryStatePlugin.js
+++ b/src/plugins/HistoryStatePlugin.js
@@ -38,7 +38,7 @@ export class HistoryStatePlugin extends BaPlugin {
 	_updateHistory() {
 		const encodedState = this._shareService.encodeState();
 		if (this._currentEncodedState !== encodedState) {
-			this._environmentService.getWindow().history.replaceState(null, '', this._shareService.encodeState());
+			this._environmentService.getWindow().history.replaceState(null, '', encodedState);
 			this._currentEncodedState = encodedState;
 		}
 	}

--- a/src/plugins/HistoryStatePlugin.js
+++ b/src/plugins/HistoryStatePlugin.js
@@ -13,6 +13,7 @@ export class HistoryStatePlugin extends BaPlugin {
 		const { EnvironmentService: environmentService, ShareService: shareService } = $injector.inject('EnvironmentService', 'ShareService');
 		this._environmentService = environmentService;
 		this._shareService = shareService;
+		this._currentEncodedState = null;
 	}
 
 	/**
@@ -35,6 +36,10 @@ export class HistoryStatePlugin extends BaPlugin {
 	}
 
 	_updateHistory() {
-		this._environmentService.getWindow().history.replaceState(null, '', this._shareService.encodeState());
+		const encodedState = this._shareService.encodeState();
+		if (this._currentEncodedState !== encodedState) {
+			this._environmentService.getWindow().history.replaceState(null, '', this._shareService.encodeState());
+			this._currentEncodedState = encodedState;
+		}
 	}
 }

--- a/test/plugins/HistoryStatePlugin.test.js
+++ b/test/plugins/HistoryStatePlugin.test.js
@@ -130,6 +130,30 @@ describe('HistoryState', () => {
 		expect(historySpy).toHaveBeenCalledWith(null, '', expectedEncodedState);
 	});
 
+	it('does nothing when encoded state has\'nt changed', async () => {
+		const expectedEncodedState = 'foo';
+		const mockHistory = { replaceState: () => { } };
+		const historySpy = spyOn(mockHistory, 'replaceState');
+		const mockWindow = { history: mockHistory };
+		spyOn(environmentService, 'getWindow').and.returnValue(mockWindow);
+		spyOn(environmentService, 'isEmbedded').and.returnValue(false);
+		spyOn(shareService, 'encodeState').and.returnValue(expectedEncodedState);
+		const store = setup();
+		const instanceUnderTest = new HistoryStatePlugin();
+		await instanceUnderTest.register(store);
+		await TestUtils.timeout(0);
+
+		// Let's trigger one observer multiple times
+		changeCenter([1, 1]);
+		changeCenter([1, 2]);
+		changeCenter([1, 3]);
+		changeCenter([1, 4]);
+
+		// But as we always return the same encoded state from the ShareService
+		// the history API should be called only once
+		expect(historySpy).toHaveBeenCalledOnceWith(null, '', expectedEncodedState);
+	});
+
 	it('does nothing when we are in \'embed\' mode', async () => {
 		spyOn(environmentService, 'isEmbedded').and.returnValue(true);
 		const store = setup();

--- a/test/plugins/HistoryStatePlugin.test.js
+++ b/test/plugins/HistoryStatePlugin.test.js
@@ -149,8 +149,8 @@ describe('HistoryState', () => {
 		changeCenter([1, 3]);
 		changeCenter([1, 4]);
 
-		// But as we always return the same encoded state from the ShareService
-		// the history API should be called only once
+		// We always return the same encoded state from the ShareService,
+		// so the history API should be called only once
 		expect(historySpy).toHaveBeenCalledOnceWith(null, '', expectedEncodedState);
 	});
 


### PR DESCRIPTION
Avoid throwing an exception due to too many calls to History API within a short timeframe.