### PR TITLE
 #bugfix #drawing no drawing of symbol possible after style color is changed

### DIFF
--- a/test/service/IconService.test.js
+++ b/test/service/IconService.test.js
@@ -158,7 +158,7 @@ describe('IconsService', () => {
 
 			expect(defaultIcon).toBeInstanceOf(IconResult);
 			expect(defaultIcon.id).toBe('marker');
-			expect(defaultIcon.getUrl([1, 2, 3])).toBe('http://some.url/icons/1,2,3/marker');
+			expect(defaultIcon.getUrl([1, 2, 3])).toBe('http://some.url/icons/1,2,3/marker.png');
 		});
 
 		it('provides a default icon, without url', async () => {


### PR DESCRIPTION
bug workflow:
- open draw dialog
- select "symbol"
- open "style" area
- choose another color

result:
- no drawing of symbol is possible any more
- there is no icon selected inside "style" area

This pull requests changes the inital value of the marker to "marker.png" as the matcher function of the IconResult class only matches if the URL ends with "/${id}.png"