### PR TITLE
ShareApi:  use fallback dialog

### DIFF
--- a/src/modules/chips/components/assistChips/ShareChip.js
+++ b/src/modules/chips/components/assistChips/ShareChip.js
@@ -112,9 +112,10 @@ export class ShareChip extends AbstractAssistChip {
 			};
 			await this._environmentService.getWindow().navigator.share(content);
 		} catch (error) {
-			// In some rare cases we need a fallback. This happens when the webbrowser can basically
-			// use the share-API but enterprise policies on operating system level rejects the calls,
-			// due to missing user privileges.
+			/**
+			 * In some rare cases, we need a fallback. This occurs when the web browser can use the Share-API,
+			 * but enterprise policies at the operating system level reject the call due to a lack of user privileges.
+			 */
 			if (!(error instanceof DOMException && error.name === 'AbortError')) {
 				this._shareUrlDialog(url, title);
 			}

--- a/src/modules/toolbox/components/shareToolContent/ShareToolContent.js
+++ b/src/modules/toolbox/components/shareToolContent/ShareToolContent.js
@@ -129,9 +129,10 @@ export class ShareToolContent extends AbstractToolContent {
 
 						await this._window.navigator.share(shareData);
 					} catch (e) {
-						// In some rare cases we need a fallback. This happens when the webbrowser can basically
-						// use the share-API but enterprise policies on operating system level rejects the calls,
-						// due to missing user privileges.
+						/**
+						 * In some rare cases, we need a fallback. This occurs when the web browser can use the Share-API,
+						 * but enterprise policies at the operating system level reject the call due to a lack of user privileges.
+						 */
 						if (!(e instanceof DOMException && e.name === 'AbortError')) {
 							shareUrlWithDialog();
 						}

--- a/test/modules/chips/components/ShareChip.test.js
+++ b/test/modules/chips/components/ShareChip.test.js
@@ -136,7 +136,7 @@ describe('ShareChip', () => {
 				expect(shareSpy).toHaveBeenCalledWith({ url: 'http://shorten.foo' });
 			});
 
-			it('uses dialog on share api reject as fallback', async () => {
+			it('uses a dialog as fallback on share api reject', async () => {
 				const element = await setup({ share: () => Promise.resolve(true) }, { center: [42, 21] });
 				const shareServiceSpy = spyOn(shareServiceMock, 'encodeStateForPosition').and.callThrough();
 
@@ -159,7 +159,7 @@ describe('ShareChip', () => {
 				expect(shareDialogContentElement.shadowRoot.querySelector('input').value).toBe('http://shorten.foo');
 			});
 
-			it('does NOT opens fallback dialog on share api canceled', async () => {
+			it('does NOT open the fallback dialog on share api canceled', async () => {
 				const element = await setup({ share: () => Promise.resolve(true) }, { center: [42, 21] });
 				const shareServiceSpy = spyOn(shareServiceMock, 'encodeStateForPosition').and.callThrough();
 

--- a/test/modules/toolbox/components/shareToolContent/ShareToolContent.test.js
+++ b/test/modules/toolbox/components/shareToolContent/ShareToolContent.test.js
@@ -113,7 +113,7 @@ describe('ShareToolContent', () => {
 					expect(windowShareSpy).toHaveBeenCalledWith(mockShareData);
 				});
 
-				it('uses dialog on share api reject as fallback', async () => {
+				it('uses a dialog as fallback on share api reject', async () => {
 					const mockShortUrl = 'https://short/url';
 					const mockErrorMsg = 'something got wrong';
 					const windowMock = {
@@ -137,7 +137,7 @@ describe('ShareToolContent', () => {
 					expect(shareDialogContentElement.shadowRoot.querySelector('input').value).toBe('https://short/url');
 				});
 
-				it('does NOT opens fallback dialog on share api canceled', async () => {
+				it('does NOT open the fallback dialog on share api canceled', async () => {
 					const mockShortUrl = 'https://short/url';
 					const windowMock = {
 						navigator: {


### PR DESCRIPTION
refactor share-api usage to use fallback dialog instead of warning notification