### PR TITLE
CoordinateUtils: normalize multiworld coordinates

### DIFF
--- a/src/services/provider/stringifyCoords.provider.js
+++ b/src/services/provider/stringifyCoords.provider.js
@@ -14,9 +14,11 @@ import { normalize } from '../../utils/coordinateUtils';
 export const bvvStringifyFunction = (coordinate, coordinateRepresentation, transformFn, options = {}) => {
 	const { global, code, digits, id } = coordinateRepresentation;
 
-	// The coordinates could be from any of openlayers multiworlds, if the user pans off the edge.
-	// For this case we have to normalize the coordinates to the primary world.
-	const normalizedCoordinate = normalize(coordinate, 3857);
+	/*
+	 * The coordinates could be from any of openlayers multiworlds, if the user pans off the edge.
+	 * For this case we have to normalize the coordinates to the primary world.
+	 */
+	const normalizedCoordinate = normalize(coordinate);
 
 	// all global coordinate representations
 	if (global) {

--- a/src/utils/coordinateUtils.js
+++ b/src/utils/coordinateUtils.js
@@ -21,29 +21,23 @@ export const fromString = (coordinatesAsString, separator = ',') => {
 };
 
 /**
- * Normalizes a coordinate in a given spatial reference system.
+ * Normalizes a coordinate in map projection (EPSG:3857).
  *
- * Currently, normalization is only implemented for the WebMercator projection (EPSG:3857).
- * In this projection, the x-coordinate is wrapped around the boundary value of 20037508.34 meters.
- * This means that if the x-coordinate exceeds this boundary, it is adjusted to fall within the valid range.
+ * In this projection, the x-coordinate is wrapped around the boundary value @see {@link https://epsg.io/3857|3857}
+ * of 20037508.34 meters.This means that if the x-coordinate exceeds this boundary, it is adjusted to fall within the valid range.
  *
  * @param {module:domain/coordinateTypeDef~Coordinate} coordinate - The coordinate to be normalized.
- * @param {number} srid - The spatial reference system identifier (e.g., 3857 for WebMercator).
  * @returns {module:domain/coordinateTypeDef~Coordinate} The normalized coordinate.
  */
-export const normalize = (coordinate, srid) => {
+export const normalize = (coordinate) => {
 	const normalizeByBoundary = (value, boundary) => {
 		const worldOffset = boundary * 2;
 		return ((value + worldOffset) % worldOffset) - Math.trunc(((value + worldOffset) % worldOffset) / boundary) * worldOffset;
 	};
 
-	if (srid === 3857) {
-		// boundary for WebMercator coordinate values @see {@link https://epsg.io/3857|3857}
-		const boundaryValue = 20037508.34;
+	// boundary for WebMercator coordinate values
+	const boundaryValue = 20037508.34;
 
-		// only the x-coordinate must be normalized in WebMercator projection
-		return [normalizeByBoundary(coordinate[0], boundaryValue), coordinate[1]];
-	}
-
-	return coordinate;
+	// only the x-coordinate must be normalized in WebMercator projection
+	return [normalizeByBoundary(coordinate[0], boundaryValue), coordinate[1]];
 };

--- a/test/service/provider/stringifyCoords.provider.test.js
+++ b/test/service/provider/stringifyCoords.provider.test.js
@@ -155,5 +155,18 @@ describe('StringifyCoord provider', () => {
 				expect(bvvStringifyFunction(coord3857, BvvCoordinateRepresentations.GK4, transformFn, { digits: 3 })).toBe('4467647.000 5405041.000');
 			});
 		});
+
+		describe('with multiworld coordinates', () => {
+			it('uses normalized coordinates to stringify', () => {
+				const sphericalMercatorBoundary = 20037508.34;
+				const coord3857 = [-2 * sphericalMercatorBoundary + 10000, 20000];
+				const normalizedCoord3857 = [10000, 20000];
+				const coord4326 = [11.572457, 48.140212, 0];
+				const transformFn = jasmine.createSpy().and.returnValue(coord4326);
+
+				expect(bvvStringifyFunction(coord3857, GlobalCoordinateRepresentations.SphericalMercator, transformFn)).toBe('10000.000000 20000.000000');
+				expect(transformFn).toHaveBeenCalledWith(normalizedCoord3857, 3857, 4326);
+			});
+		});
 	});
 });

--- a/test/utils/coordinateUtils.test.js
+++ b/test/utils/coordinateUtils.test.js
@@ -15,36 +15,23 @@ describe('Unit test functions from coordinateUtils.js', () => {
 
 	describe('normalize', () => {
 		it('normalizes coordinates in map projection', () => {
-			const mapProjectionSrid = 3857;
-			const invalidProjectionSrid = 42;
 			const boundary = 20037508.34;
 
 			// going east multiple worlds
-			expect(normalize([boundary + 500, 0], mapProjectionSrid)[0]).toBeCloseTo((boundary - 500) * -1, 0.01);
-			expect(normalize([boundary + 1000, 0], mapProjectionSrid)[0]).toBeCloseTo((boundary - 1000) * -1, 0.01);
-			expect(normalize([boundary * 2 + 1000, 0], mapProjectionSrid)[0]).toBeCloseTo(1000, 0.01);
-			expect(normalize([boundary * 3 + 1000, 0], mapProjectionSrid)[0]).toBeCloseTo((boundary - 1000) * -1, 0.01);
+			expect(normalize([boundary + 500, 0])[0]).toBeCloseTo((boundary - 500) * -1, 0.01);
+			expect(normalize([boundary + 1000, 0])[0]).toBeCloseTo((boundary - 1000) * -1, 0.01);
+			expect(normalize([boundary * 2 + 1000, 0])[0]).toBeCloseTo(1000, 0.01);
+			expect(normalize([boundary * 3 + 1000, 0])[0]).toBeCloseTo((boundary - 1000) * -1, 0.01);
 
 			// going west multiple worlds
-			expect(normalize([boundary * -1 - 500, 0], mapProjectionSrid)[0]).toBeCloseTo(boundary - 500, 0.01);
-			expect(normalize([boundary * -2 - 1000, 0], mapProjectionSrid)[0]).toBeCloseTo(-1000, 0.01);
-			expect(normalize([boundary * -3 - 2000, 0], mapProjectionSrid)[0]).toBeCloseTo(boundary - 2000, 0.01);
+			expect(normalize([boundary * -1 - 500, 0])[0]).toBeCloseTo(boundary - 500, 0.01);
+			expect(normalize([boundary * -2 - 1000, 0])[0]).toBeCloseTo(-1000, 0.01);
+			expect(normalize([boundary * -3 - 2000, 0])[0]).toBeCloseTo(boundary - 2000, 0.01);
 
 			// primary world coordinates stay the same
-			expect(normalize([0, 0], mapProjectionSrid)[0]).toBeCloseTo(0, 0.01);
-			expect(normalize([1000, 0], mapProjectionSrid)[0]).toBeCloseTo(1000, 0.01);
-			expect(normalize([-1000, 0], mapProjectionSrid)[0]).toBeCloseTo(-1000, 0.01);
-
-			// coordinates in invalid projection stay the same
-			expect(normalize([0, 0], invalidProjectionSrid)).toEqual([0, 0]);
-			expect(normalize([42, 42], invalidProjectionSrid)).toEqual([42, 42]);
-			expect(normalize([boundary + 500, 0], invalidProjectionSrid)).toEqual([boundary + 500, 0]);
-			expect(normalize([boundary + 1000, 0], invalidProjectionSrid)).toEqual([boundary + 1000, 0]);
-			expect(normalize([boundary * 2 + 1000, 0], invalidProjectionSrid)).toEqual([boundary * 2 + 1000, 0]);
-			expect(normalize([boundary * 3 + 1000, 0], invalidProjectionSrid)).toEqual([boundary * 3 + 1000, 0]);
-			expect(normalize([boundary * -1 - 500, 0], invalidProjectionSrid)).toEqual([boundary * -1 - 500, 0]);
-			expect(normalize([boundary * -2 - 1000, 0], invalidProjectionSrid)).toEqual([boundary * -2 - 1000, 0]);
-			expect(normalize([boundary * -3 - 2000, 0], invalidProjectionSrid)).toEqual([boundary * -3 - 2000, 0]);
+			expect(normalize([0, 0])[0]).toBeCloseTo(0, 0.01);
+			expect(normalize([1000, 0])[0]).toBeCloseTo(1000, 0.01);
+			expect(normalize([-1000, 0])[0]).toBeCloseTo(-1000, 0.01);
 		});
 	});
 });


### PR DESCRIPTION
implement coordinate normalization for multiworld coordinates in WebMercator projection and add tests