### PR TITLE
SourceTypeService: extend GeoJSON type list with 'Feature' and 'GeometryCollection'

### DIFF
--- a/src/services/provider/sourceType.provider.js
+++ b/src/services/provider/sourceType.provider.js
@@ -167,7 +167,17 @@ export const defaultDataSourceTypeProvider = (data) => {
 	}
 	try {
 		// According to the GeoJSON specification (RFC 7946)
-		const validGeoJsonTypes = ['FeatureCollection', 'Point', 'LineString', 'Polygon', 'MultiPoint', 'MultiLineString', 'MultiPolygon'];
+		const validGeoJsonTypes = [
+			'FeatureCollection',
+			'Feature',
+			'Point',
+			'LineString',
+			'Polygon',
+			'MultiPoint',
+			'MultiLineString',
+			'MultiPolygon',
+			'GeometryCollection'
+		];
 		const { type } = JSON.parse(data);
 		if (validGeoJsonTypes.includes(type)) {
 			return new SourceTypeResult(SourceTypeResultStatus.OK, new SourceType(SourceTypeName.GEOJSON, null, 4326));

--- a/test/service/provider/sourceType.provider.test.js
+++ b/test/service/provider/sourceType.provider.test.js
@@ -453,7 +453,17 @@ describe('sourceType provider', () => {
 		it('tries to detect the source type for GeoJSON sources', () => {
 			expect(defaultDataSourceTypeProvider(JSON.stringify(42))).toEqual(new SourceTypeResult(SourceTypeResultStatus.UNSUPPORTED_TYPE));
 			expect(defaultDataSourceTypeProvider(JSON.stringify({ type: 'foo' }))).toEqual(new SourceTypeResult(SourceTypeResultStatus.UNSUPPORTED_TYPE));
-			['FeatureCollection', 'Point', 'LineString', 'Polygon', 'MultiPoint', 'MultiLineString', 'MultiPolygon'].forEach((type) => {
+			[
+				'FeatureCollection',
+				'Feature',
+				'Point',
+				'LineString',
+				'Polygon',
+				'MultiPoint',
+				'MultiLineString',
+				'MultiPolygon',
+				'GeometryCollection'
+			].forEach((type) => {
 				expect(defaultDataSourceTypeProvider(JSON.stringify({ type }))).toEqual(
 					new SourceTypeResult(SourceTypeResultStatus.OK, new SourceType(SourceTypeName.GEOJSON, null, 4326))
 				);


### PR DESCRIPTION
As defined in [rfc7946](https://datatracker.ietf.org/doc/html/rfc7946#section-7) 'Feature' and 'GeometryCollection' are valid GeoJSON types