### PR TITLE
add "collaborativeData" flag to fileStorage s-o-s

### DIFF
--- a/src/store/fileStorage/fileStorage.action.js
+++ b/src/store/fileStorage/fileStorage.action.js
@@ -6,7 +6,7 @@ import { $injector } from '../../injection';
 import { isString } from '../../utils/checks';
 import { EventLike } from '../../utils/storeUtils';
 import {
-	ADMIN_ID_CHANGED,
+	ADMIN_ID_INITIALLY_SET,
 	DATA_CHANGED,
 	CLEARED,
 	LATEST_AND_ADMIN_AND_FILE_ID_CHANGED,
@@ -30,7 +30,8 @@ const getStore = () => {
 };
 
 /**
- * Sets the admin and its corresponding file ID.
+ * Initially sets an existing admin ID and its corresponding file ID.
+ * Further calls of this action will be ignored.
  * @param {string} adminId
  * @param {string} fileId
  * @function
@@ -38,7 +39,7 @@ const getStore = () => {
 export const setAdminAndFileId = (adminId, fileId) => {
 	if (isString(adminId) && isString(fileId)) {
 		getStore().dispatch({
-			type: ADMIN_ID_CHANGED,
+			type: ADMIN_ID_INITIALLY_SET,
 			payload: { adminId, fileId }
 		});
 	}

--- a/src/store/fileStorage/fileStorage.reducer.js
+++ b/src/store/fileStorage/fileStorage.reducer.js
@@ -1,6 +1,6 @@
 import { EventLike } from '../../utils/storeUtils';
 
-export const ADMIN_ID_CHANGED = 'fileStorage/adminId';
+export const ADMIN_ID_INITIALLY_SET = 'fileStorage/adminId';
 export const ADMIN_AND_FILE_ID_CHANGED = 'fileStorage/adminAndFileId';
 export const CLEARED = 'fileStorage/clear';
 export const DATA_CHANGED = 'fileStorage/data';
@@ -51,19 +51,29 @@ export const initialState = {
 	/**
 	 * @property {FileStorageState}
 	 */
-	state: FileStorageState.DEFAULT
+	state: FileStorageState.DEFAULT,
+
+	/**
+	 * Flag if we have collaborative data
+	 *  @property {boolean}
+	 */
+	collaborativeData: false
 };
 
 export const fileStorageReducer = (state = initialState, action) => {
 	const { type, payload } = action;
 	switch (type) {
-		case ADMIN_ID_CHANGED: {
+		case ADMIN_ID_INITIALLY_SET: {
 			const { adminId, fileId } = payload;
-			return {
-				...state,
-				adminId,
-				fileId
-			};
+			if (!state.adminId && !state.fileId) {
+				return {
+					...state,
+					adminId,
+					fileId,
+					collaborativeData: true
+				};
+			}
+			return state;
 		}
 		case DATA_CHANGED: {
 			return {

--- a/test/store/fileStorage/fileStorage.reducer.test.js
+++ b/test/store/fileStorage/fileStorage.reducer.test.js
@@ -31,9 +31,10 @@ describe('fileStorageReducer', () => {
 		expect(store.getState().fileStorage.data).toBeNull();
 		expect(store.getState().fileStorage.latest.payload).toEqual({ success: false, created: null, lastSaved: null });
 		expect(store.getState().fileStorage.state).toBe(FileStorageState.DEFAULT);
+		expect(store.getState().fileStorage.collaborativeData).toBeFalse();
 	});
 
-	it('updates the `adminId` and `fileId` property', () => {
+	it('initially sets the `adminId` and `fileId` property', () => {
 		const store = setup();
 
 		setAdminAndFileId('adminId');
@@ -47,6 +48,12 @@ describe('fileStorageReducer', () => {
 		expect(store.getState().fileStorage.fileId).toBeNull();
 
 		setAdminAndFileId('adminId', 'fileId');
+
+		expect(store.getState().fileStorage.adminId).toBe('adminId');
+		expect(store.getState().fileStorage.fileId).toBe('fileId');
+		expect(store.getState().fileStorage.collaborativeData).toBeTrue();
+
+		setAdminAndFileId('adminId_2', 'fileId_2');
 
 		expect(store.getState().fileStorage.adminId).toBe('adminId');
 		expect(store.getState().fileStorage.fileId).toBe('fileId');
@@ -73,6 +80,7 @@ describe('fileStorageReducer', () => {
 		expect(store.getState().fileStorage.adminId).toBeNull();
 		expect(store.getState().fileStorage.latest.payload).toEqual({ success: false, created: null, lastSaved: null });
 		expect(store.getState().fileStorage.state).toBe(FileStorageState.DEFAULT);
+		expect(store.getState().fileStorage.collaborativeData).toBeFalse();
 	});
 
 	it('updates the `data` property and the `state` property', () => {


### PR DESCRIPTION
This PR adds the "missing link" to preserve the knowledge of whether we have collaborative data or not. 
The `OlDrawHandler` and `OlMeasurementHandler` then just have to mark the GeoResource
in the following manner:

<img width="1340" height="919" alt="grafik" src="https://github.com/user-attachments/assets/376fe551-8219-4c6c-83eb-dc26b89a756f" />
