### PR TITLE
Map-Button Adjustments

### DIFF
--- a/src/modules/map/components/rotationButton/RotationButton.js
+++ b/src/modules/map/components/rotationButton/RotationButton.js
@@ -90,9 +90,11 @@ export class RotationButton extends MvuElement {
 					${css}
 				</style>
 				<div>
-					<button class="rotation-button" style="${styleMap(styles)}" @click=${onClick} title=${translate('map_rotationButton_title')}>
-						<i class="icon rotation-icon"></i>
-					</button>
+					<div id="rotation-target" style="${styleMap(styles)}">
+						<button class="rotation-button" @click=${onClick} title=${translate('map_rotationButton_title')}>
+							<i class="icon rotation-icon"></i>
+						</button>
+					</div>
 				</div>
 			`;
 		}

--- a/src/modules/map/components/rotationButton/rotationButton.css
+++ b/src/modules/map/components/rotationButton/rotationButton.css
@@ -9,8 +9,8 @@
 	-webkit-mask-size: cover;
 	cursor: pointer;
 	display: inline-block;
-	height: 2em;
-	width: 2em;
+	height: 2.05em;
+	width: 2.05em;
 	border-top: 0.5em solid var(--error-color);
 }
 

--- a/src/modules/map/components/zoomButtons/ZoomButtons.js
+++ b/src/modules/map/components/zoomButtons/ZoomButtons.js
@@ -26,10 +26,16 @@ export class ZoomButtons extends MvuElement {
 		const translate = (key) => this._translationService.translate(key);
 
 		return html`
-			<style>${css}</style>
+			<style>
+				${css}
+			</style>
 			<div class="zoom-buttons">
-				<button class="button" aria-label="${translate('map_zoomButtons_in')}" title="${translate('map_zoomButtons_in')}" @click="${increaseZoom}"><span class="icon zoom-in"></button>
-				<button class="button" aria-label="${translate('map_zoomButtons_out')}" title="${translate('map_zoomButtons_out')}"  @click="${decreaseZoom}"><span class="icon zoom-out"></button>
+				<button class="button" aria-label="${translate('map_zoomButtons_in')}" title="${translate('map_zoomButtons_in')}" @click="${increaseZoom}">
+					<span class="icon zoom-in"></span><span class="zoom-icon-fill"></span>
+				</button>
+				<button class="button" aria-label="${translate('map_zoomButtons_out')}" title="${translate('map_zoomButtons_out')}" @click="${decreaseZoom}">
+					<span class="icon zoom-out"></span><span class="zoom-icon-fill"></span>
+				</button>
 			</div>
 		`;
 	}

--- a/src/modules/map/components/zoomButtons/zoomButtons.css
+++ b/src/modules/map/components/zoomButtons/zoomButtons.css
@@ -50,10 +50,25 @@
 }
 
 .zoom-buttons .button {
-	background-color: var(--text3);
+	position: relative;
 	display: inline-block;
 	height: 2.5em;
 	width: 2.5em;
 	border-radius: 50%;
 	border: 0;
+
+	.icon {
+		position: relative;
+		z-index: 2;
+	}
+
+	.zoom-icon-fill {
+		background-color: var(--text3);
+		position: absolute;
+		height: 1.5em;
+		width: 1.5em;
+		top: 0.5em;
+		left: 0.5em;
+		z-index: 1;
+	}
 }

--- a/test/modules/map/components/rotationButton/RotationButton.test.js
+++ b/test/modules/map/components/rotationButton/RotationButton.test.js
@@ -56,7 +56,7 @@ describe('RotationButton', () => {
 				expect(element.shadowRoot.querySelectorAll('button')).toHaveSize(1);
 				expect(element.shadowRoot.querySelector('button').classList.contains('rotation-button')).toBeTrue();
 				expect(element.shadowRoot.querySelector('button').title).toBe('map_rotationButton_title');
-				expect(element.shadowRoot.querySelector('button').style.transform).toBe(`rotate(${liveRotationValue}rad)`);
+				expect(element.shadowRoot.querySelector('#rotation-target').style.transform).toBe(`rotate(${liveRotationValue}rad)`);
 				expect(element.shadowRoot.querySelectorAll('.icon')).toHaveSize(1);
 			});
 		});
@@ -78,12 +78,12 @@ describe('RotationButton', () => {
 			const element = await setup({ liveRotation: liveRotationValue });
 
 			jasmine.clock().tick(RotationButton.THROTTLE_DELAY_MS + 100);
-			expect(element.shadowRoot.querySelector('button').style.transform).toBe(`rotate(${liveRotationValue}rad)`);
+			expect(element.shadowRoot.querySelector('#rotation-target').style.transform).toBe(`rotate(${liveRotationValue}rad)`);
 
 			changeLiveRotation((liveRotationValue = 1));
 			jasmine.clock().tick(RotationButton.THROTTLE_DELAY_MS) + 100;
 
-			expect(element.shadowRoot.querySelector('button').style.transform).toBe(`rotate(${liveRotationValue}rad)`);
+			expect(element.shadowRoot.querySelector('#rotation-target').style.transform).toBe(`rotate(${liveRotationValue}rad)`);
 		});
 
 		it('hides the button when rotation < threshold', async () => {


### PR DESCRIPTION
Fixes #3234 

Also removes undesired outlines on zoom-button, see screenshot:

<img width="161" height="386" alt="borders" src="https://github.com/user-attachments/assets/544bd2f9-3eb3-406f-9393-228cda734392" />

<img width="94" height="362" alt="borderremoved" src="https://github.com/user-attachments/assets/52720df4-e544-4ca2-8cb8-ab3b2b121d1f" />
