### PR TITLE
ClusterStyle: use contrastColor consequent

### DIFF
--- a/src/modules/olMap/utils/olStyleUtils.js
+++ b/src/modules/olMap/utils/olStyleUtils.js
@@ -274,7 +274,7 @@ export const defaultClusterStyleFunction = (rgbaColor, displayLabel = true) => {
 						image: new CircleStyle({
 							radius: 15,
 							stroke: new Stroke({
-								color: White_Color
+								color: getContrastColorFrom(colorRGB)
 							}),
 							fill: new Fill({
 								color: colorRGB

--- a/test/modules/olMap/util/olStyleUtils.test.js
+++ b/test/modules/olMap/util/olStyleUtils.test.js
@@ -1384,7 +1384,7 @@ describe('defaultClusterStyleFunction', () => {
 		image: new CircleStyle({
 			radius: 15,
 			stroke: new Stroke({
-				color: [14, 0, 38]
+				color: getContrastColorFrom([9, 157, 218, 1] /** this is the Default_Feature_Color as defined in olStyleUtils.js */)
 			}),
 			fill: new Fill({
 				color: [9, 157, 218]

--- a/test/modules/olMap/util/olStyleUtils.test.js
+++ b/test/modules/olMap/util/olStyleUtils.test.js
@@ -1384,7 +1384,7 @@ describe('defaultClusterStyleFunction', () => {
 		image: new CircleStyle({
 			radius: 15,
 			stroke: new Stroke({
-				color: [255, 255, 255]
+				color: [14, 0, 38]
 			}),
 			fill: new Fill({
 				color: [9, 157, 218]


### PR DESCRIPTION
Using contrastColor not only for the number, but the border.

<img width="173" height="157" alt="image" src="https://github.com/user-attachments/assets/e1ff15fe-cbc1-41c6-95dc-6a59a2cc390d" />
