### PR TITLE
bvvFeatureInfoProvider (v4.5): handle non-string values correctly in the feature info display

### DIFF
--- a/src/modules/featureInfo/components/featureInfoIframePanel/featureInfoIframePanel.css
+++ b/src/modules/featureInfo/components/featureInfoIframePanel/featureInfoIframePanel.css
@@ -256,7 +256,7 @@ a[href^='https://geodaten.bayern.de/odd/'] {
 	opacity: 0.8;
 	display: block;
 	text-align: center;
-	word-wrap: break-word;
+	overflow-wrap: break-word;
 }
 a[href^='https://geodaten.bayern.de/odd/']:has(> img) {
 	background-color: transparent;

--- a/src/modules/featureInfo/components/featureInfoPanel/featureInfoPanel.css
+++ b/src/modules/featureInfo/components/featureInfoPanel/featureInfoPanel.css
@@ -237,7 +237,7 @@ a[href^='https://geodaten.bayern.de/odd/'] {
 	opacity: 0.8;
 	display: block;
 	text-align: center;
-	word-wrap: break-word;
+	overflow-wrap: break-word;
 }
 a[href^='https://geodaten.bayern.de/odd/']:has(> img) {
 	background-color: transparent;

--- a/src/modules/olMap/handler/featureInfo/featureInfoItem.provider.js
+++ b/src/modules/olMap/handler/featureInfo/featureInfoItem.provider.js
@@ -92,7 +92,9 @@ export const bvvFeatureInfoProvider = (olFeature, olLayer, layerProperties) => {
 								const values = Array.isArray(value) ? value : [value];
 								return html`<tr>
 									<td>${replaceOafQueryableIdByTitle(key)}</td>
-									<td>${values.map((v) => html`<div>${unsafeHTML(securityService.sanitizeHtml(isObject(v) ? JSON.stringify(v) : v))}</div>`)}</td>
+									<td>
+										${values.map((v) => html`<div>${unsafeHTML(securityService.sanitizeHtml(isObject(v) ? JSON.stringify(v) : v.toString()))}</div>`)}
+									</td>
 								</tr>`;
 							})}
 						</tbody>

--- a/test/modules/olMap/handler/featureInfo/featureInfoItem.provider.test.js
+++ b/test/modules/olMap/handler/featureInfo/featureInfoItem.provider.test.js
@@ -482,7 +482,7 @@ describe('FeatureInfo provider', () => {
 					const olFeature = new Feature({ geometry: geometry });
 					olFeature.setId('id');
 					olFeature.set('foo', 'bar');
-					olFeature.set('some', 'thing');
+					olFeature.set('some', 0 /** non-string value */);
 
 					const featureInfo = bvvFeatureInfoProvider(olFeature, olLayer, layer);
 					const wrapperElement = TestUtils.renderTemplateResult(featureInfo.content);
@@ -494,10 +494,10 @@ describe('FeatureInfo provider', () => {
 					expect(wrapperElement.querySelector('.props-table tbody tr:nth-child(1) td:nth-child(1)').innerText).toContain('foo');
 					expect(wrapperElement.querySelector('.props-table tbody tr:nth-child(1) td:nth-child(2)').innerText).toContain('bar');
 					expect(wrapperElement.querySelector('.props-table tbody tr:nth-child(2) td:nth-child(1)').innerText).toContain('Real Some');
-					expect(wrapperElement.querySelector('.props-table tbody tr:nth-child(2) td:nth-child(2)').innerText).toContain('thing');
+					expect(wrapperElement.querySelector('.props-table tbody tr:nth-child(2) td:nth-child(2)').innerText).toContain('0');
 					expect(sanitizeSpy).toHaveBeenCalledTimes(2);
 					expect(sanitizeSpy.calls.all()[0].args[0]).toBe('bar');
-					expect(sanitizeSpy.calls.all()[1].args[0]).toBe('thing');
+					expect(sanitizeSpy.calls.all()[1].args[0]).toBe('0');
 				});
 
 				it('displays nothing when no valid properties are available', () => {


### PR DESCRIPTION
<img width="634" height="354" alt="image" src="https://github.com/user-attachments/assets/3fc33eb3-0852-4c7e-a556-14ef8d867afc" />
