### PR TITLE
OlStyleService: cache & reuse anchor values

### DIFF
--- a/src/modules/olMap/services/OlStyleService.js
+++ b/src/modules/olMap/services/OlStyleService.js
@@ -412,12 +412,27 @@ export class OlStyleService {
 				const size = style.getImage()?.getSize();
 				const pixelAnchor = style.getImage()?.getAnchor();
 				const text = displayFeatureLabel ? (style.getText()?.getText() ?? feature.get('name')) : null;
+
+				/*
+				 * We interpret the existing anchor values such that the icon was already rendered and
+				 * its save to use them for the new style. Otherwise we check the internal feature property 'normalized_anchor' as a fallback, if
+				 * other changes on the marker style are applied but could not take effect, due to a missing rendering-phase.
+				 */
+				const normalizedAnchor =
+					size && pixelAnchor ? [pixelAnchor[0] / size[0], pixelAnchor[1] / size[1]] : (feature.get(asInternalProperty('normalized_anchor')) ?? null);
+
+				/*
+				 * If we have size & anchor values from the last rendering, we save them as internal feature property for the next (not applied by rendering) style change
+				 */
+				if (size && pixelAnchor) {
+					feature.set(asInternalProperty('normalized_anchor'), [pixelAnchor[0] / size[0], pixelAnchor[1] / size[1]]);
+				}
 				return {
 					symbolSrc: symbolSrc,
 					color: rgbToHex(color ? color : style.getText()?.getFill()?.getColor()),
 					scale: scale,
 					text: text,
-					anchor: size && pixelAnchor ? [pixelAnchor[0] / size[0], pixelAnchor[1] / size[1]] : null
+					anchor: normalizedAnchor
 				};
 			};
 

--- a/test/modules/olMap/services/OlStyleService.test.js
+++ b/test/modules/olMap/services/OlStyleService.test.js
@@ -387,6 +387,8 @@ describe('OlStyleService', () => {
 				anchorYUnits: 'fraction'
 			});
 
+			const featureAnchorSpy = vi.spyOn(featureWithStyleFunction, 'get');
+
 			const anchorSpy = vi.spyOn(icon, 'getAnchor').mockImplementation(() => {
 				return [24, 48];
 			});
@@ -433,8 +435,75 @@ describe('OlStyleService', () => {
 			expect(anchorSpy).toHaveBeenCalled();
 			expect(sizeSpy).toHaveBeenCalled();
 
+			expect(featureAnchorSpy).not.toHaveBeenCalledWith(asInternalProperty('normalized_anchor'));
+
 			// ..the normalized-anchor value should be saved as internal property for usages where anchor and size of the icon are not calculated.
 			expect(featureWithStyleFunction.get(asInternalProperty('normalized_anchor'))).toEqual([0.5, 1]);
+		});
+
+		it('adds marker-style with color from existing label-style but anchor as feature-property', () => {
+			const featureWithStyleFunction = new Feature({ geometry: new Point([0, 0]) });
+			featureWithStyleFunction.set(asInternalProperty('normalized_anchor'), [42, 21]);
+			const icon = new Icon({
+				src: 'http://foo.bar/icon.png',
+				anchor: [0.5, 1],
+				anchorXUnits: 'fraction',
+				anchorYUnits: 'fraction'
+			});
+
+			const featureAnchorSpy = vi.spyOn(featureWithStyleFunction, 'get');
+
+			const anchorSpy = vi.spyOn(icon, 'getAnchor').mockImplementation(() => {
+				return null;
+			});
+
+			const sizeSpy = vi.spyOn(icon, 'getSize').mockImplementation(() => {
+				return null;
+			});
+			const style = new Style({
+				image: icon,
+				text: new TextStyle({
+					text: 'foo',
+					fill: new Fill({
+						color: [42, 21, 0, 1]
+					})
+				})
+			});
+			featureWithStyleFunction.setId('draw_marker_9876543');
+			featureWithStyleFunction.setStyle(() => [style]);
+
+			const viewMock = {
+				getResolution() {
+					return 50;
+				},
+				once() {}
+			};
+
+			const mapMock = {
+				getView: () => viewMock,
+				getInteractions() {
+					return { getArray: () => [] };
+				}
+			};
+			vi.spyOn(iconServiceMock, 'decodeColor').mockReturnValue(null); //we simulate a local IconResult, which have no url property
+			const displayFeatureLabel = true;
+
+			let markerStyle = null;
+			const styleSetterFunctionSpy = vi.spyOn(featureWithStyleFunction, 'setStyle').mockImplementation((f) => (markerStyle = f()));
+			instanceUnderTest.addInternalFeatureStyle(featureWithStyleFunction, mapMock, displayFeatureLabel);
+			expect(styleSetterFunctionSpy).toHaveBeenCalledWith(expect.any(Function));
+			expect(markerStyle).toContainEqual(expect.any(Style));
+			// uses the existing color
+			expect(markerStyle[0].getText().getFill().getColor()).toEqual([42, 21, 0, 1]);
+
+			//...and the existing anchor/size
+			expect(anchorSpy).toHaveBeenCalled();
+			expect(sizeSpy).toHaveBeenCalled();
+
+			expect(featureAnchorSpy).toHaveBeenCalledWith(asInternalProperty('normalized_anchor'));
+
+			// ..the normalized-anchor value should be saved as internal property for usages where anchor and size of the icon are not calculated.
+			expect(featureWithStyleFunction.get(asInternalProperty('normalized_anchor'))).toEqual([42, 21]);
 		});
 
 		it('adds marker-style with color, anchor and size from existing label-style to feature and hide the label', () => {

--- a/test/modules/olMap/services/OlStyleService.test.js
+++ b/test/modules/olMap/services/OlStyleService.test.js
@@ -15,6 +15,7 @@ import VectorSource, { VectorSourceEvent } from 'ol/source/Vector';
 import { createDefaultLayer, layersReducer } from '@src/store/layers/layers.reducer';
 import { CollectionEvent } from 'ol/Collection';
 import { asInternalProperty } from '@src/utils/propertyUtils';
+import { expect } from 'vitest';
 
 describe('OlFeatureStyleTypes', () => {
 	it('provides an enum of all valid OlFeatureStyleTypes', () => {
@@ -431,6 +432,9 @@ describe('OlStyleService', () => {
 			//...and the existing anchor/size
 			expect(anchorSpy).toHaveBeenCalled();
 			expect(sizeSpy).toHaveBeenCalled();
+
+			// ..the normalized-anchor value should be saved as internal property for usages where anchor and size of the icon are not calculated.
+			expect(featureWithStyleFunction.get(asInternalProperty('normalized_anchor'))).toEqual([0.5, 1]);
 		});
 
 		it('adds marker-style with color, anchor and size from existing label-style to feature and hide the label', () => {
@@ -488,6 +492,9 @@ describe('OlStyleService', () => {
 			//...and uses the existing anchor/size
 			expect(anchorSpy).toHaveBeenCalled();
 			expect(sizeSpy).toHaveBeenCalled();
+
+			// ..the normalized-anchor value should be saved as internal property for usages where anchor and size of the icon are not calculated.
+			expect(featureWithStyleFunction.get(asInternalProperty('normalized_anchor'))).toEqual([0.5, 1]);
 		});
 
 		it('adds marker-style to feature without style but attribute', () => {


### PR DESCRIPTION
To prevent losing information about anchor-values of an OpenLayers IconStyle, we save them as internal property.

#45120762