### PR TITLE
OlStyleService: cache & reuse anchor values (v4.5) 

### DIFF
--- a/src/modules/olMap/services/OlStyleService.js
+++ b/src/modules/olMap/services/OlStyleService.js
@@ -394,12 +394,27 @@ export class OlStyleService {
 				const size = style.getImage()?.getSize();
 				const pixelAnchor = style.getImage()?.getAnchor();
 				const text = displayFeatureLabel ? (style.getText()?.getText() ?? feature.get('name')) : null;
+
+				/*
+				 * We interpret the existing anchor values such that the icon was already rendered and
+				 * its save to use them for the new style. Otherwise we check the internal feature property 'normalized_anchor' as a fallback, if
+				 * other changes on the marker style are applied but could not take effect, due to a missing rendering-phase.
+				 */
+				const normalizedAnchor =
+					size && pixelAnchor ? [pixelAnchor[0] / size[0], pixelAnchor[1] / size[1]] : (feature.get(asInternalProperty('normalized_anchor')) ?? null);
+
+				/*
+				 * If we have size & anchor values from the last rendering, we save them as internal feature property for the next (not applied by rendering) style change
+				 */
+				if (size && pixelAnchor) {
+					feature.set(asInternalProperty('normalized_anchor'), [pixelAnchor[0] / size[0], pixelAnchor[1] / size[1]]);
+				}
 				return {
 					symbolSrc: symbolSrc,
 					color: rgbToHex(color ? color : style.getText()?.getFill()?.getColor()),
 					scale: scale,
 					text: text,
-					anchor: size && pixelAnchor ? [pixelAnchor[0] / size[0], pixelAnchor[1] / size[1]] : null
+					anchor: normalizedAnchor
 				};
 			};
 

--- a/test/modules/olMap/services/OlStyleService.test.js
+++ b/test/modules/olMap/services/OlStyleService.test.js
@@ -387,6 +387,8 @@ describe('OlStyleService', () => {
 				anchorYUnits: 'fraction'
 			});
 
+			const featureAnchorSpy = spyOn(featureWithStyleFunction, 'get').and.callThrough();
+
 			const anchorSpy = spyOn(icon, 'getAnchor').and.callFake(() => {
 				return [24, 48];
 			});
@@ -432,6 +434,72 @@ describe('OlStyleService', () => {
 			//...and the existing anchor/size
 			expect(anchorSpy).toHaveBeenCalled();
 			expect(sizeSpy).toHaveBeenCalled();
+
+			expect(featureAnchorSpy).not.toHaveBeenCalledWith(asInternalProperty('normalized_anchor'));
+
+			// ..the normalized-anchor value should be saved as internal property for usages where anchor and size of the icon are not calculated.
+			expect(featureWithStyleFunction.get(asInternalProperty('normalized_anchor'))).toEqual([0.5, 1]);
+		});
+
+		it('adds marker-style with color from existing label-style but anchor as feature-property', () => {
+			const featureWithStyleFunction = new Feature({ geometry: new Point([0, 0]) });
+			featureWithStyleFunction.set(asInternalProperty('normalized_anchor'), [42, 21]);
+			const icon = new Icon({
+				src: 'http://foo.bar/icon.png',
+				anchor: [0.5, 1],
+				anchorXUnits: 'fraction',
+				anchorYUnits: 'fraction'
+			});
+
+			const featureAnchorSpy = spyOn(featureWithStyleFunction, 'get').and.callThrough();
+
+			const anchorSpy = spyOn(icon, 'getAnchor').and.callFake(() => {});
+			const sizeSpy = spyOn(icon, 'getSize').and.callFake(() => {});
+
+			const style = new Style({
+				image: icon,
+				text: new TextStyle({
+					text: 'foo',
+					fill: new Fill({
+						color: [42, 21, 0, 1]
+					})
+				})
+			});
+			featureWithStyleFunction.setId('draw_marker_9876543');
+			featureWithStyleFunction.setStyle(() => [style]);
+
+			const viewMock = {
+				getResolution() {
+					return 50;
+				},
+				once() {}
+			};
+
+			const mapMock = {
+				getView: () => viewMock,
+				getInteractions() {
+					return { getArray: () => [] };
+				}
+			};
+			spyOn(iconServiceMock, 'decodeColor').and.returnValue(null); //we simulate a local IconResult, which have no url property
+			const displayFeatureLabel = true;
+
+			let markerStyle = null;
+			const styleSetterFunctionSpy = spyOn(featureWithStyleFunction, 'setStyle').and.callFake((f) => (markerStyle = f()));
+			instanceUnderTest.addInternalFeatureStyle(featureWithStyleFunction, mapMock, displayFeatureLabel);
+			expect(styleSetterFunctionSpy).toHaveBeenCalledWith(jasmine.any(Function));
+			expect(markerStyle).toContain(jasmine.any(Style));
+			// uses the existing color
+			expect(markerStyle[0].getText().getFill().getColor()).toEqual([42, 21, 0, 1]);
+
+			//...and the existing anchor/size
+			expect(anchorSpy).toHaveBeenCalled();
+			expect(sizeSpy).toHaveBeenCalled();
+
+			expect(featureAnchorSpy).toHaveBeenCalledWith(asInternalProperty('normalized_anchor'));
+
+			// ..the normalized-anchor value should be saved as internal property for usages where anchor and size of the icon are not calculated.
+			expect(featureWithStyleFunction.get(asInternalProperty('normalized_anchor'))).toEqual([42, 21]);
 		});
 
 		it('adds marker-style with color, anchor and size from existing label-style to feature and hide the label', () => {


### PR DESCRIPTION
cache the anchor property  as internal  feature property (#3860)